### PR TITLE
S0004 not default

### DIFF
--- a/DbC.Net.Examples/NotDefaultExamples.cs
+++ b/DbC.Net.Examples/NotDefaultExamples.cs
@@ -1,38 +1,39 @@
 ﻿namespace DbC.Net.Examples;
-public sealed class NotNullExamples
+
+public sealed class NotDefaultExamples
 {
    public void Examples()
    {
-      var customMessageTemplate = "{ValueExpression} can not be null";
+      var customMessageTemplate = "{ValueExpression} can not be default";
       var customExceptionFactory = new CustomExceptionFactory();
 
-      String lastName = null!;
+      Int64 id = default;
 
-      List<Guid> identifiers = null!;
+      List<Guid> identifiers = default!;
 
       // Precondition with default message template/default exception factory.
-      lastName.RequiresNotNull();
+      id.RequiresNotDefault();
 
       // Precondition with custom message template/default exception factory.
-      lastName.RequiresNotNull(customMessageTemplate);
+      id.RequiresNotDefault(customMessageTemplate);
 
       // Precondition with default message template/custom exception factory.
-      lastName.RequiresNotNull(exceptionFactory: customExceptionFactory);
+      id.RequiresNotDefault(exceptionFactory: customExceptionFactory);
 
       // Precondition with custom message template/custom exception factory.
-      lastName.RequiresNotNull(customMessageTemplate, customExceptionFactory);
+      id.RequiresNotDefault(customMessageTemplate, customExceptionFactory);
 
 
       // Postcondition with default message template/default exception factory.
-      identifiers.EnsuresNotNull();
+      identifiers.EnsuresNotDefault();
 
       // Postcondition with custom message template/default exception factory.
-      identifiers.EnsuresNotNull(customMessageTemplate);
+      identifiers.EnsuresNotDefault(customMessageTemplate);
 
       // Postcondition with default message template/custom exception factory.
-      identifiers.EnsuresNotNull(exceptionFactory: customExceptionFactory);
+      identifiers.EnsuresNotDefault(exceptionFactory: customExceptionFactory);
 
       // Postcondition with custom message template/custom exception factory.
-      identifiers.EnsuresNotNull(customMessageTemplate, customExceptionFactory);
+      identifiers.EnsuresNotDefault(customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Tests.Benchmarks/NotDefaultBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/NotDefaultBenchmarks.cs
@@ -1,0 +1,161 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class NotDefaultBenchmarks
+{
+   private const Int32 _intValue = 1;
+   private const String _stringValue = "This is a test";
+   private static readonly List<Double> _listValue = new() { Double.MinValue, Double.MaxValue };
+   private const String _messageTemplate = "Requires{RequirementName} failed: {ValueExpression} may not be default";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresNotDefault();
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_Int32_P00()
+   {
+      var result = _intValue.RequiresNotDefault();
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_Int32_P10()
+   {
+      var result = _intValue.RequiresNotDefault(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_Int32_P01()
+   {
+      var result = _intValue.RequiresNotDefault(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_Int32_P11()
+   {
+      var result = _intValue.RequiresNotDefault(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_String_P00()
+   {
+      var result = _stringValue.RequiresNotDefault();
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_String_P10()
+   {
+      var result = _stringValue.RequiresNotDefault(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_String_P01()
+   {
+      var result = _stringValue.RequiresNotDefault(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_String_P11()
+   {
+      var result = _stringValue.RequiresNotDefault(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_List_P00()
+   {
+      var result = _listValue.RequiresNotDefault();
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_List_P10()
+   {
+      var result = _listValue.RequiresNotDefault(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_List_P01()
+   {
+      var result = _listValue.RequiresNotDefault(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotDefault_List_P11()
+   {
+      var result = _listValue.RequiresNotDefault(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_Int32_P00()
+   {
+      var result = _intValue.EnsuresNotDefault();
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_Int32_P10()
+   {
+      var result = _intValue.EnsuresNotDefault(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_Int32_P01()
+   {
+      var result = _intValue.EnsuresNotDefault(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_Int32_P11()
+   {
+      var result = _intValue.EnsuresNotDefault(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_String_P00()
+   {
+      var result = _stringValue.EnsuresNotDefault();
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_String_P10()
+   {
+      var result = _stringValue.EnsuresNotDefault(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_String_P01()
+   {
+      var result = _stringValue.EnsuresNotDefault(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_String_P11()
+   {
+      var result = _stringValue.EnsuresNotDefault(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_List_P00()
+   {
+      var result = _listValue.EnsuresNotDefault();
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_List_P10()
+   {
+      var result = _listValue.EnsuresNotDefault(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_List_P01()
+   {
+      var result = _listValue.EnsuresNotDefault(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void EnsuresNotDefault_List_P11()
+   {
+      var result = _listValue.EnsuresNotDefault(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -1,5 +1,2 @@
-﻿// Console.WriteLine("Write some benchmarks!");
-
-using DbC.Net.Tests.Benchmarks;
-
-BenchmarkRunner.Run<NotNullBenchmarks>();
+﻿BenchmarkRunner.Run<NotNullBenchmarks>(); 
+BenchmarkRunner.Run<NotDefaultBenchmarks>();

--- a/DbC.Net.Tests.Unit/NotDefaultTests.cs
+++ b/DbC.Net.Tests.Unit/NotDefaultTests.cs
@@ -1,0 +1,180 @@
+﻿using DbC.Net.Tests.Unit.TestData;
+
+namespace DbC.Net.Tests.Unit;
+
+public class NotDefaultTests
+{
+   #region RequiresNotDefault Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldReturnOriginalValue_WhenValueIsValueTypeAndNotDefault()
+   {
+      // Arrange.
+      var value = Single.Pi;
+
+      // Act.
+      var result = value.RequiresNotDefault();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldReturnOriginalValue_WhenValueIsReferenceTypeAndIsNotDefault()
+   {
+      // Arrange.
+      var value = new List<Int32> { 1, 2, 3 };
+
+      // Act.
+      var result = value.RequiresNotDefault();
+
+      // Assert.
+      result.Should().BeSameAs(value);
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrow_WhenValueIsValueTypeAndIsDefault()
+   {
+      // Arrange.
+      var value = default(SByte);
+      var act = () => _ = value.RequiresNotDefault();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrow_WhenValueIsReferenceTypeAndIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresNotDefault();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrow_WhenValueIsReferenceTypeAndIsDefault()
+   {
+      // Arrange.
+      var value = default(List<Double>);
+      var act = () => _ = value.RequiresNotDefault();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowExceptionWithExpectedDataDictionary_WhenValueIsValueTypeAndIsDefault()
+   {
+      // Arrange.
+      Char value = default;
+      var act = () => _ = value.RequiresNotDefault();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(4);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(nameof(NotDefault));
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.ValueDatatype].Should().Be(nameof(Char));
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowExceptionWithExpectedDataDictionary_WhenValueIsReferenceTypeAndIsNull()
+   {
+      // Arrange.
+      ICollection<DateTime> value = null!;
+      var act = () => _ = value.RequiresNotDefault();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(4);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(nameof(NotDefault));
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.ValueDatatype].Should().Be("ICollection`1");
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowExceptionWithExpectedDataDictionary_WhenValueIsReferenceTypeAndIsDefault()
+   {
+      // Arrange.
+      String value = default!;
+      var act = () => _ = value.RequiresNotDefault();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(4);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(nameof(NotDefault));
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.ValueDatatype].Should().Be(nameof(String));
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowArgumentExceptionWithExpectedMessage_WhenAllDefaultsUsed()
+   {
+      // Arrange.
+      String value = default!;
+      var act = () => _ = value.RequiresNotDefault();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = "Precondition NotDefault failed: value may not be default(String)";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotDefault(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = "Requirement NotDefault failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      Single value = default;
+      var act = () => _ = value.RequiresNotDefault(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = "Precondition NotDefault failed: value may not be default(Single)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotDefault_RequiresNotDefault_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      PointStruct value = default;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotDefault(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = "Requirement NotDefault failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/NotDefaultTests.cs
+++ b/DbC.Net.Tests.Unit/NotDefaultTests.cs
@@ -4,6 +4,177 @@ namespace DbC.Net.Tests.Unit;
 
 public class NotDefaultTests
 {
+   #region EnsuresNotDefault Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldReturnOriginalValue_WhenValueIsValueTypeAndNotDefault()
+   {
+      // Arrange.
+      var value = Single.Pi;
+
+      // Act.
+      var result = value.EnsuresNotDefault();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldReturnOriginalValue_WhenValueIsReferenceTypeAndIsNotDefault()
+   {
+      // Arrange.
+      var value = new List<Int32> { 1, 2, 3 };
+
+      // Act.
+      var result = value.EnsuresNotDefault();
+
+      // Assert.
+      result.Should().BeSameAs(value);
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrow_WhenValueIsValueTypeAndIsDefault()
+   {
+      // Arrange.
+      var value = default(SByte);
+      var act = () => _ = value.EnsuresNotDefault();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrow_WhenValueIsReferenceTypeAndIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresNotDefault();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrow_WhenValueIsReferenceTypeAndIsDefault()
+   {
+      // Arrange.
+      var value = default(List<Double>);
+      var act = () => _ = value.EnsuresNotDefault();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowExceptionWithExpectedDataDictionary_WhenValueIsValueTypeAndIsDefault()
+   {
+      // Arrange.
+      Char value = default;
+      var act = () => _ = value.EnsuresNotDefault();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(4);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(nameof(NotDefault));
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.ValueDatatype].Should().Be(nameof(Char));
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowExceptionWithExpectedDataDictionary_WhenValueIsReferenceTypeAndIsNull()
+   {
+      // Arrange.
+      ICollection<DateTime> value = null!;
+      var act = () => _ = value.EnsuresNotDefault();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(4);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(nameof(NotDefault));
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.ValueDatatype].Should().Be("ICollection`1");
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowExceptionWithExpectedDataDictionary_WhenValueIsReferenceTypeAndIsDefault()
+   {
+      // Arrange.
+      String value = default!;
+      var act = () => _ = value.EnsuresNotDefault();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(4);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(nameof(NotDefault));
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.ValueDatatype].Should().Be(nameof(String));
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenAllDefaultsUsed()
+   {
+      // Arrange.
+      String value = default!;
+      var act = () => _ = value.EnsuresNotDefault();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = "Postcondition NotDefault failed: value may not be default(String)";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotDefault(messageTemplate);
+      var expectedMessage = "Requirement NotDefault failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      Single value = default;
+      var act = () => _ = value.EnsuresNotDefault(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = "Postcondition NotDefault failed: value may not be default(Single)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotDefault_EnsuresNotDefault_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      PointStruct value = default;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotDefault(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = "Requirement NotDefault failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
    #region RequiresNotDefault Tests
    // ==========================================================================
    // ==========================================================================
@@ -134,7 +305,7 @@ public class NotDefaultTests
    }
 
    [Fact]
-   public void NotDefault_RequiresNotDefault_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   public void NotDefault_RequiresNotDefault_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
       String value = null!;

--- a/DbC.Net.Tests.Unit/TestData/PointStruct.cs
+++ b/DbC.Net.Tests.Unit/TestData/PointStruct.cs
@@ -1,0 +1,8 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public struct PointStruct
+{
+   public Int32 X { get; set; }
+
+   public Int32 Y { get; set; }
+}

--- a/DbC.Net/DataNames.cs
+++ b/DbC.Net/DataNames.cs
@@ -8,6 +8,7 @@ public static class DataNames
    // The value being checked.
    public const String Value = "Value";
    public const String ValueExpression = "ValueExpression";
+   public const String ValueDatatype = "ValueDatatype";
 
    // The target for equality checks.
    public const String Target = "Target";

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -61,6 +61,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype}).
+        /// </summary>
+        internal static string NotDefaultTemplate {
+            get {
+                return ResourceManager.GetString("NotDefaultTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be null.
         /// </summary>
         internal static string NotNullTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="NotDefaultTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
+  </data>
   <data name="NotNullTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be null</value>
   </data>

--- a/DbC.Net/NotDefault.cs
+++ b/DbC.Net/NotDefault.cs
@@ -1,0 +1,74 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement NotDefault requirement.
+/// </summary>
+public static class NotDefault
+{
+   /// <summary>
+   ///   NotDefault precondition. Confirm that <paramref name="value"/> is not 
+   ///   the default for type {T} and throw an exception if it is default for 
+   ///   type {T}.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresNotDefault<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!)
+   {
+      CheckNotDefault(
+         value!,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   private static void CheckNotDefault<T>(
+      T value,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression)
+   {
+      if (EqualityComparer<T>.Default.Equals(value, default))
+      {
+         messageTemplate ??= MessageTemplates.NotDefaultTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = new Dictionary<String, Object>()
+         {
+            {  DataNames.RequirementType, requirementType },
+            {  DataNames.RequirementName, nameof(NotDefault) },
+            {  DataNames.ValueExpression, valueExpression },
+            {  DataNames.ValueDatatype, typeof(T).Name },
+         };
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/NotDefault.cs
+++ b/DbC.Net/NotDefault.cs
@@ -6,6 +6,48 @@
 public static class NotDefault
 {
    /// <summary>
+   ///   NotDefault postcondition. Confirm that <paramref name="value"/> is not 
+   ///   the default for type {T} and throw an exception if it is default for 
+   ///   type {T}.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresNotDefault<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!)
+   {
+      CheckNotDefault(
+         value!,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   NotDefault precondition. Confirm that <paramref name="value"/> is not 
    ///   the default for type {T} and throw an exception if it is default for 
    ///   type {T}.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@
 
 - **[Performance Data](#performance-data)**
 
+  - [NotNull Benchmarks](#notnull-benchmarks)
+  - [NotDefault Benchmarks](#notdefault-benchmarks)
+
 # Introduction
 
 DbC.Net is inspired by the concept of Design by Contract, first introduced by 
@@ -368,48 +371,83 @@ identifiers.EnsuresNotDefault(customMessageTemplate, customExceptionFactory);
 
 # Performance Data
 
+Benchmark details
+
+``` ini
+
+BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1105)
+Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK=7.0.100
+  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+
+
+```
+
+### NotNull Benchmarks
+
 X indicates that the optional parameter was supplied; blank indicates that the 
 parameter was omitted.
 
-| Method          | Value Type  | Message Template | Exception Factory |      Mean |    Median | Allocated |
-|:--------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|
-| RequiresNotNull | Int32       |                  |                   | 0.0010 ns | 0.0000 ns |         - |
-| RequiresNotNull | Int32       | X                |                   | 0.0106 ns | 0.0000 ns |         - |
-| RequiresNotNull | Int32       |                  | X                 | 0.0031 ns | 0.0000 ns |         - |
-| RequiresNotNull | Int32       | X                | X                 | 0.0172 ns | 0.0085 ns |         - |
-| RequiresNotNull | String      |                  |                   | 0.0101 ns | 0.0031 ns |         - |
-| RequiresNotNull | String      | X                |                   | 0.0277 ns | 0.0167 ns |         - |
-| RequiresNotNull | String      |                  | X                 | 0.0040 ns | 0.0000 ns |         - |
-| RequiresNotNull | String      | X                | X                 | 0.0101 ns | 0.0045 ns |         - |
-| RequiresNotNull | List<T>     |                  |                   | 0.0044 ns | 0.0000 ns |         - |
-| RequiresNotNull | List<T>     | X                |                   | 0.0069 ns | 0.0000 ns |         - |
-| RequiresNotNull | List<T>     |                  | X                 | 0.0118 ns | 0.0053 ns |         - |
-| RequiresNotNull | List<T>     | X                | X                 | 0.0053 ns | 0.0050 ns |         - |
-
 | Method          | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev |    Median | Allocated |
 |:--------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|----------:|
-| RequiresNotNull | Int32       |                  |                   | 0.0091 ns | 0.0139 ns | 0.0130 ns | 0.0004 ns |         - |
-| RequiresNotNull | Int32       | X                |                   | 0.0116 ns | 0.0134 ns | 0.0126 ns | 0.0096 ns |         - |
-| RequiresNotNull | Int32       |                  | X                 | 1.1947 ns | 0.0255 ns | 0.0226 ns | 1.1873 ns |         - |
-| RequiresNotNull | Int32       | X                | X                 | 1.1980 ns | 0.0537 ns | 0.0502 ns | 1.1830 ns |         - |
-| RequiresNotNull | String      |                  |                   | 0.0124 ns | 0.0191 ns | 0.0178 ns | 0.0023 ns |         - |
-| RequiresNotNull | String      | X                |                   | 0.0001 ns | 0.0003 ns | 0.0003 ns | 0.0000 ns |         - |
-| RequiresNotNull | String      |                  | X                 | 1.7804 ns | 0.0594 ns | 0.0526 ns | 1.7720 ns |         - |
-| RequiresNotNull | String      | X                | X                 | 2.2868 ns | 0.0694 ns | 0.0682 ns | 2.2851 ns |         - |
-| RequiresNotNull | List<T>     |                  |                   | 0.0077 ns | 0.0103 ns | 0.0096 ns | 0.0019 ns |         - |
-| RequiresNotNull | List<T>     | X                |                   | 0.0282 ns | 0.0264 ns | 0.0294 ns | 0.0197 ns |         - |
-| RequiresNotNull | List<T>     |                  | X                 | 2.7550 ns | 0.0593 ns | 0.0554 ns | 2.7352 ns |         - |
-| RequiresNotNull | List<T>     | X                | X                 | 2.5334 ns | 0.0797 ns | 0.0917 ns | 2.5312 ns |         - |
+| RequiresNotNull | Int32       |                  |                   | 0.0127 ns | 0.0168 ns | 0.0157 ns | 0.0056 ns |         - |
+| RequiresNotNull | Int32       | X                |                   | 0.0040 ns | 0.0062 ns | 0.0058 ns | 0.0000 ns |         - |
+| RequiresNotNull | Int32       |                  | X                 | 1.1554 ns | 0.0261 ns | 0.0244 ns | 1.1442 ns |         - |
+| RequiresNotNull | Int32       | X                | X                 | 1.1624 ns | 0.0248 ns | 0.0207 ns | 1.1623 ns |         - |
+| RequiresNotNull | String      |                  |                   | 0.0033 ns | 0.0049 ns | 0.0043 ns | 0.0008 ns |         - |
+| RequiresNotNull | String      | X                |                   | 0.0008 ns | 0.0023 ns | 0.0019 ns | 0.0000 ns |         - |
+| RequiresNotNull | String      |                  | X                 | 1.7635 ns | 0.0201 ns | 0.0168 ns | 1.7626 ns |         - |
+| RequiresNotNull | String      | X                | X                 | 2.2459 ns | 0.0288 ns | 0.0269 ns | 2.2467 ns |         - |
+| RequiresNotNull | List<T>     |                  |                   | 0.0064 ns | 0.0074 ns | 0.0070 ns | 0.0054 ns |         - |
+| RequiresNotNull | List<T>     | X                |                   | 0.0012 ns | 0.0025 ns | 0.0023 ns | 0.0000 ns |         - |
+| RequiresNotNull | List<T>     |                  | X                 | 1.7117 ns | 0.0305 ns | 0.0285 ns | 1.7042 ns |         - |
+| RequiresNotNull | List<T>     | X                | X                 | 2.4327 ns | 0.0197 ns | 0.0175 ns | 2.4263 ns |         - |
 | *************** | *********** | **************** | ***************** | ********* | ********* | ********* | ********* | ********* |
-| EnsuresNotNull  | Int32       |                  |                   | 0.0109 ns | 0.0172 ns | 0.0161 ns | 0.0000 ns |         - |
-| EnsuresNotNull  | Int32       | X                |                   | 0.0043 ns | 0.0096 ns | 0.0090 ns | 0.0000 ns |         - |
-| EnsuresNotNull  | Int32       |                  | X                 | 1.2186 ns | 0.0531 ns | 0.0522 ns | 1.2043 ns |         - |
-| EnsuresNotNull  | Int32       | X                | X                 | 1.1917 ns | 0.0481 ns | 0.0450 ns | 1.1839 ns |         - |
-| EnsuresNotNull  | String      |                  |                   | 0.0090 ns | 0.0137 ns | 0.0122 ns | 0.0017 ns |         - |
-| EnsuresNotNull  | String      | X                |                   | 0.0004 ns | 0.0011 ns | 0.0010 ns | 0.0000 ns |         - |
-| EnsuresNotNull  | String      |                  | X                 | 1.8940 ns | 0.0524 ns | 0.0465 ns | 1.8797 ns |         - |
-| EnsuresNotNull  | String      | X                | X                 | 2.1058 ns | 0.0439 ns | 0.0366 ns | 2.1191 ns |         - |
-| EnsuresNotNull  | List<T>     |                  |                   | 0.0436 ns | 0.0287 ns | 0.0307 ns | 0.0430 ns |         - |
-| EnsuresNotNull  | List<T>     | X                |                   | 0.0135 ns | 0.0154 ns | 0.0144 ns | 0.0149 ns |         - |
-| EnsuresNotNull  | List<T>     |                  | X                 | 1.9349 ns | 0.0571 ns | 0.0534 ns | 1.9332 ns |         - |
-| EnsuresNotNull  | List<T>     | X                | X                 | 1.6444 ns | 0.0490 ns | 0.0458 ns | 1.6400 ns |         - |
+| EnsuresNotNull  | Int32       |                  |                   | 0.0013 ns | 0.0030 ns | 0.0025 ns | 0.0000 ns |         - |
+| EnsuresNotNull  | Int32       | X                |                   | 0.0038 ns | 0.0059 ns | 0.0055 ns | 0.0015 ns |         - |
+| EnsuresNotNull  | Int32       |                  | X                 | 1.1545 ns | 0.0096 ns | 0.0090 ns | 1.1547 ns |         - |
+| EnsuresNotNull  | Int32       | X                | X                 | 1.1586 ns | 0.0111 ns | 0.0104 ns | 1.1562 ns |         - |
+| EnsuresNotNull  | String      |                  |                   | 0.0040 ns | 0.0057 ns | 0.0053 ns | 0.0023 ns |         - |
+| EnsuresNotNull  | String      | X                |                   | 0.0042 ns | 0.0073 ns | 0.0065 ns | 0.0009 ns |         - |
+| EnsuresNotNull  | String      |                  | X                 | 1.8425 ns | 0.0131 ns | 0.0116 ns | 1.8397 ns |         - |
+| EnsuresNotNull  | String      | X                | X                 | 2.0406 ns | 0.0271 ns | 0.0253 ns | 2.0303 ns |         - |
+| EnsuresNotNull  | List<T>     |                  |                   | 0.0030 ns | 0.0061 ns | 0.0051 ns | 0.0000 ns |         - |
+| EnsuresNotNull  | List<T>     | X                |                   | 0.0005 ns | 0.0014 ns | 0.0013 ns | 0.0000 ns |         - |
+| EnsuresNotNull  | List<T>     |                  | X                 | 1.8339 ns | 0.0122 ns | 0.0102 ns | 1.8344 ns |         - |
+| EnsuresNotNull  | List<T>     | X                | X                 | 1.5898 ns | 0.0128 ns | 0.0107 ns | 1.5866 ns |         - |
+
+### NotDefault Benchmarks
+
+RequiresNotDefault and EnsuresNotDefault use EqualityComparer<T>.Default.Equals to test if a value is default.
+
+X indicates that the optional parameter was supplied; blank indicates that the 
+parameter was omitted.
+
+|  Method            | Value Type  | Message Template | Exception Factory |     Mean |     Error |    StdDev | Allocated |
+|:------------------ |:------------|:----------------:|:-----------------:|---------:|----------:|----------:|----------:|
+| RequiresNotDefault | Int32       |                  |                   | 1.460 ns | 0.0184 ns | 0.0154 ns |         - |
+| RequiresNotDefault | Int32       | X                |                   | 1.515 ns | 0.0259 ns | 0.0242 ns |         - |
+| RequiresNotDefault | Int32       |                  | X                 | 1.581 ns | 0.0229 ns | 0.0215 ns |         - |
+| RequiresNotDefault | Int32       | X                | X                 | 1.370 ns | 0.0248 ns | 0.0194 ns |         - |
+| RequiresNotDefault | String      |                  |                   | 7.902 ns | 0.1122 ns | 0.1049 ns |         - |
+| RequiresNotDefault | String      | X                |                   | 7.632 ns | 0.0346 ns | 0.0307 ns |         - |
+| RequiresNotDefault | String      |                  | X                 | 7.598 ns | 0.0387 ns | 0.0323 ns |         - |
+| RequiresNotDefault | String      | X                | X                 | 7.563 ns | 0.0460 ns | 0.0384 ns |         - |
+| RequiresNotDefault | List<T>     |                  |                   | 7.564 ns | 0.0678 ns | 0.0634 ns |         - |
+| RequiresNotDefault | List<T>     | X                |                   | 7.372 ns | 0.0254 ns | 0.0199 ns |         - |
+| RequiresNotDefault | List<T>     |                  | X                 | 6.882 ns | 0.0588 ns | 0.0550 ns |         - |
+| RequiresNotDefault | List<T>     | X                | X                 | 7.361 ns | 0.0356 ns | 0.0297 ns |         - |
+| ****************** | *********** | **************** | ***************** | ******** | ********* | ********* | ********* |
+| EnsuresNotDefault  | Int32       |                  |                   | 1.389 ns | 0.0150 ns | 0.0133 ns |         - |
+| EnsuresNotDefault  | Int32       | X                |                   | 1.512 ns | 0.0239 ns | 0.0224 ns |         - |
+| EnsuresNotDefault  | Int32       |                  | X                 | 1.462 ns | 0.0161 ns | 0.0143 ns |         - |
+| EnsuresNotDefault  | Int32       | X                | X                 | 1.557 ns | 0.0313 ns | 0.0293 ns |         - |
+| EnsuresNotDefault  | String      |                  |                   | 7.184 ns | 0.0619 ns | 0.0517 ns |         - |
+| EnsuresNotDefault  | String      | X                |                   | 8.361 ns | 0.0642 ns | 0.0570 ns |         - |
+| EnsuresNotDefault  | String      |                  | X                 | 7.085 ns | 0.0355 ns | 0.0315 ns |         - |
+| EnsuresNotDefault  | String      | X                | X                 | 7.314 ns | 0.0751 ns | 0.0666 ns |         - |
+| EnsuresNotDefault  | List<T>     |                  |                   | 7.529 ns | 0.0445 ns | 0.0347 ns |         - |
+| EnsuresNotDefault  | List<T>     | X                |                   | 6.994 ns | 0.0691 ns | 0.0612 ns |         - |
+| EnsuresNotDefault  | List<T>     |                  | X                 | 6.906 ns | 0.0354 ns | 0.0295 ns |         - |
+| EnsuresNotDefault  | List<T>     | X                | X                 | 6.999 ns | 0.0480 ns | 0.0449 ns |         - |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [Initialization Requirements](#initialization-requirements)
 
     - [NotNull](#notnull)
+    - [NotDefault](#notdefault)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 
@@ -270,8 +271,9 @@ NotNull requires that the value being checked not be null. Use RequiresNotNull
 for preconditions and EnsuresNotNull for postconditions.
 
 The default message template for NotNull is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null".
-The default exception factory for RequiresNotNull is StandardExceptionFactories.ArgumentNullExceptionFactory and
-StandardExceptionFactories.PostconditionFailedExceptionFactory for EnsuresNotNull.
+The default exception factory for RequiresNotNull is StandardExceptionFactories.ArgumentNullExceptionFactory 
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresNotNull.
 
 The data dictionary for exceptions thrown will contain entries for RequirementType,
 RequirementName and ValueExpression.
@@ -309,6 +311,56 @@ identifiers.EnsuresNotNull(exceptionFactory: customExceptionFactory);
 
 // Postcondition with custom message template/custom exception factory.
 identifiers.EnsuresNotNull(customMessageTemplate, customExceptionFactory);
+```
+
+### NotDefault
+
+NotDefault requires that the value being checked not be the default for the 
+datatype of the value being checked (zero for value types, null for reference
+types). Use RequiresNotDefault for preconditions and EnsuresNotDefault for 
+postconditions.
+
+The default message template for NotDefault is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})".
+The default exception factory for RequiresNotDefault is StandardExceptionFactories.ArgumentExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresNotDefault.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, ValueExpression and ValueDatatype.
+
+Examples:
+```C#
+var customMessageTemplate = "{ValueExpression} can not be default";
+var customExceptionFactory = new CustomExceptionFactory();
+
+Int64 id = default;
+
+List<Guid> identifiers = default!;
+
+// Precondition with default message template/default exception factory.
+id.RequiresNotDefault();
+
+// Precondition with custom message template/default exception factory.
+id.RequiresNotDefault(customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+id.RequiresNotDefault(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+id.RequiresNotDefault(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+identifiers.EnsuresNotDefault();
+
+// Postcondition with custom message template/default exception factory.
+identifiers.EnsuresNotDefault(customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+identifiers.EnsuresNotDefault(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+identifiers.EnsuresNotDefault(customMessageTemplate, customExceptionFactory);
 ```
 
 # Release History/Release Notes


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a value is not default (both null for reference types and 0 for value types).

Requirements:

  RequiresNotDefault (precondition), default ArgumentException
  EnsuresNotDefault (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresNotDefault
2. Implement EnsuresNotDefault
3. Unit tests for Requires/Ensures NotDefault
4. Performance tests
5. Readme updates
6. Examples