### PR TITLE
S0006 not equal

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -10,11 +10,12 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
   DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
-
 ```
 
   - [NotNull Benchmarks](#notnull-benchmarks)
   - [NotDefault Benchmarks](#notdefault-benchmarks)
+  - [Equal Benchmarks](#equal-benchmarks)
+  - [NotEqual Benchmarks](#notequal-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -78,41 +79,82 @@ parameter was omitted.
 
 ### Equal Benchmarks
 
-|  Method            | Value Type  | Comparer             | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
-|:------------------ |:------------|:--------------------:|:----------------:|:-----------------:|-----------:|----------:|----------:|----------:|
-| RequiresEqual      | Int32       |                      |                  |                   |  1.2221 ns | 0.0527 ns | 0.0704 ns |         - |
-| RequiresEqual      | Int32       |                      | X                |                   |  3.6139 ns | 0.0283 ns | 0.0265 ns |         - |
-| RequiresEqual      | Int32       |                      |                  | X                 |  3.2580 ns | 0.0156 ns | 0.0131 ns |         - |
-| RequiresEqual      | Int32       |                      | X                | X                 |  2.0926 ns | 0.0205 ns | 0.0191 ns |         - |
-| RequiresEqual      | Int32       | IEqualityComparer<T> |                  |                   |  0.0049 ns | 0.0130 ns | 0.0109 ns |         - |
-| RequiresEqual      | Int32       | IEqualityComparer<T> | X                |                   |  0.0039 ns | 0.0053 ns | 0.0047 ns |         - |
-| RequiresEqual      | Int32       | IEqualityComparer<T> |                  | X                 |  0.0025 ns | 0.0039 ns | 0.0036 ns |         - |
-| RequiresEqual      | Int32       | IEqualityComparer<T> | X                | X                 |  0.0091 ns | 0.0119 ns | 0.0111 ns |         - |
-| RequiresEqual      | String      |                      |                  |                   |  4.5864 ns | 0.0434 ns | 0.0406 ns |         - |
-| RequiresEqual      | String      |                      | X                |                   |  4.7503 ns | 0.0643 ns | 0.0602 ns |         - |
-| RequiresEqual      | String      |                      |                  | X                 |  4.6344 ns | 0.1034 ns | 0.0807 ns |         - |
-| RequiresEqual      | String      |                      | X                | X                 |  4.4326 ns | 0.0771 ns | 0.0721 ns |         - |
-| RequiresEqual      | String      | IEqualityComparer<T> |                  |                   |  1.6282 ns | 0.0271 ns | 0.0254 ns |         - |
-| RequiresEqual      | String      | IEqualityComparer<T> | X                |                   |  1.8676 ns | 0.0274 ns | 0.0242 ns |         - |
-| RequiresEqual      | String      | IEqualityComparer<T> |                  | X                 |  2.1668 ns | 0.0169 ns | 0.0150 ns |         - |
-| RequiresEqual      | String      | IEqualityComparer<T> | X                | X                 |  1.9697 ns | 0.0266 ns | 0.0222 ns |         - |
-| RequiresEqual      | String      | StringComparison     |                  |                   |  1.4707 ns | 0.0186 ns | 0.0155 ns |         - |
-| RequiresEqual      | String      | StringComparison     | X                |                   |  2.4579 ns | 0.0259 ns | 0.0217 ns |         - |
-| RequiresEqual      | String      | StringComparison     |                  | X                 |  4.0601 ns | 0.0268 ns | 0.0224 ns |         - |
-| RequiresEqual      | String      | StringComparison     | X                | X                 |  4.4613 ns | 0.0361 ns | 0.0338 ns |         - |
-| RequiresEqual      | Record      |                      |                  |                   | 14.1755 ns | 0.1201 ns | 0.1003 ns |         - |
-| RequiresEqual      | Record      |                      | X                |                   | 14.5214 ns | 0.2156 ns | 0.2017 ns |         - |
-| RequiresEqual      | Record      |                      |                  | X                 | 14.1793 ns | 0.0670 ns | 0.0626 ns |         - |
-| RequiresEqual      | Record      |                      | X                | X                 | 14.7373 ns | 0.0807 ns | 0.0754 ns |         - |
-| RequiresEqual      | Record      | IEqualityComparer<T> |                  |                   |  2.2255 ns | 0.0192 ns | 0.0180 ns |         - |
-| RequiresEqual      | Record      | IEqualityComparer<T> | X                |                   |  3.1703 ns | 0.0247 ns | 0.0219 ns |         - |
-| RequiresEqual      | Record      | IEqualityComparer<T> |                  | X                 |  5.6450 ns | 0.0411 ns | 0.0384 ns |         - |
-| RequiresEqual      | Record      | IEqualityComparer<T> | X                | X                 |  5.7490 ns | 0.0777 ns | 0.0727 ns |         - |
-| RequiresEqual      | Class       |                      |                  |                   |  8.1012 ns | 0.0730 ns | 0.0647 ns |         - |
-| RequiresEqual      | Class       |                      | X                |                   |  8.9902 ns | 0.0734 ns | 0.0650 ns |         - |
-| RequiresEqual      | Class       |                      |                  | X                 |  8.9700 ns | 0.0577 ns | 0.0482 ns |         - |
-| RequiresEqual      | Class       |                      | X                | X                 |  9.0753 ns | 0.1102 ns | 0.1031 ns |         - |
-| RequiresEqual      | Class       | IEqualityComparer<T> |                  |                   |  5.0150 ns | 0.0436 ns | 0.0408 ns |         - |
-| RequiresEqual      | Class       | IEqualityComparer<T> | X                |                   |  4.6248 ns | 0.0259 ns | 0.0229 ns |         - |
-| RequiresEqual      | Class       | IEqualityComparer<T> |                  | X                 |  8.0629 ns | 0.1107 ns | 0.1036 ns |         - |
-| RequiresEqual      | Class       | IEqualityComparer<T> | X                | X                 |  7.9168 ns | 0.0600 ns | 0.0501 ns |         - |
+|  Method       | Value Type  | Comparer             | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
+|:------------- |:------------|:--------------------:|:----------------:|:-----------------:|-----------:|----------:|----------:|----------:|
+| RequiresEqual | Int32       |                      |                  |                   |  1.2221 ns | 0.0527 ns | 0.0704 ns |         - |
+| RequiresEqual | Int32       |                      | X                |                   |  3.6139 ns | 0.0283 ns | 0.0265 ns |         - |
+| RequiresEqual | Int32       |                      |                  | X                 |  3.2580 ns | 0.0156 ns | 0.0131 ns |         - |
+| RequiresEqual | Int32       |                      | X                | X                 |  2.0926 ns | 0.0205 ns | 0.0191 ns |         - |
+| RequiresEqual | Int32       | IEqualityComparer<T> |                  |                   |  0.0049 ns | 0.0130 ns | 0.0109 ns |         - |
+| RequiresEqual | Int32       | IEqualityComparer<T> | X                |                   |  0.0039 ns | 0.0053 ns | 0.0047 ns |         - |
+| RequiresEqual | Int32       | IEqualityComparer<T> |                  | X                 |  0.0025 ns | 0.0039 ns | 0.0036 ns |         - |
+| RequiresEqual | Int32       | IEqualityComparer<T> | X                | X                 |  0.0091 ns | 0.0119 ns | 0.0111 ns |         - |
+| RequiresEqual | String      |                      |                  |                   |  4.5864 ns | 0.0434 ns | 0.0406 ns |         - |
+| RequiresEqual | String      |                      | X                |                   |  4.7503 ns | 0.0643 ns | 0.0602 ns |         - |
+| RequiresEqual | String      |                      |                  | X                 |  4.6344 ns | 0.1034 ns | 0.0807 ns |         - |
+| RequiresEqual | String      |                      | X                | X                 |  4.4326 ns | 0.0771 ns | 0.0721 ns |         - |
+| RequiresEqual | String      | IEqualityComparer<T> |                  |                   |  1.6282 ns | 0.0271 ns | 0.0254 ns |         - |
+| RequiresEqual | String      | IEqualityComparer<T> | X                |                   |  1.8676 ns | 0.0274 ns | 0.0242 ns |         - |
+| RequiresEqual | String      | IEqualityComparer<T> |                  | X                 |  2.1668 ns | 0.0169 ns | 0.0150 ns |         - |
+| RequiresEqual | String      | IEqualityComparer<T> | X                | X                 |  1.9697 ns | 0.0266 ns | 0.0222 ns |         - |
+| RequiresEqual | String      | StringComparison     |                  |                   |  1.4707 ns | 0.0186 ns | 0.0155 ns |         - |
+| RequiresEqual | String      | StringComparison     | X                |                   |  2.4579 ns | 0.0259 ns | 0.0217 ns |         - |
+| RequiresEqual | String      | StringComparison     |                  | X                 |  4.0601 ns | 0.0268 ns | 0.0224 ns |         - |
+| RequiresEqual | String      | StringComparison     | X                | X                 |  4.4613 ns | 0.0361 ns | 0.0338 ns |         - |
+| RequiresEqual | Record      |                      |                  |                   | 14.1755 ns | 0.1201 ns | 0.1003 ns |         - |
+| RequiresEqual | Record      |                      | X                |                   | 14.5214 ns | 0.2156 ns | 0.2017 ns |         - |
+| RequiresEqual | Record      |                      |                  | X                 | 14.1793 ns | 0.0670 ns | 0.0626 ns |         - |
+| RequiresEqual | Record      |                      | X                | X                 | 14.7373 ns | 0.0807 ns | 0.0754 ns |         - |
+| RequiresEqual | Record      | IEqualityComparer<T> |                  |                   |  2.2255 ns | 0.0192 ns | 0.0180 ns |         - |
+| RequiresEqual | Record      | IEqualityComparer<T> | X                |                   |  3.1703 ns | 0.0247 ns | 0.0219 ns |         - |
+| RequiresEqual | Record      | IEqualityComparer<T> |                  | X                 |  5.6450 ns | 0.0411 ns | 0.0384 ns |         - |
+| RequiresEqual | Record      | IEqualityComparer<T> | X                | X                 |  5.7490 ns | 0.0777 ns | 0.0727 ns |         - |
+| RequiresEqual | Class       |                      |                  |                   |  8.1012 ns | 0.0730 ns | 0.0647 ns |         - |
+| RequiresEqual | Class       |                      | X                |                   |  8.9902 ns | 0.0734 ns | 0.0650 ns |         - |
+| RequiresEqual | Class       |                      |                  | X                 |  8.9700 ns | 0.0577 ns | 0.0482 ns |         - |
+| RequiresEqual | Class       |                      | X                | X                 |  9.0753 ns | 0.1102 ns | 0.1031 ns |         - |
+| RequiresEqual | Class       | IEqualityComparer<T> |                  |                   |  5.0150 ns | 0.0436 ns | 0.0408 ns |         - |
+| RequiresEqual | Class       | IEqualityComparer<T> | X                |                   |  4.6248 ns | 0.0259 ns | 0.0229 ns |         - |
+| RequiresEqual | Class       | IEqualityComparer<T> |                  | X                 |  8.0629 ns | 0.1107 ns | 0.1036 ns |         - |
+| RequiresEqual | Class       | IEqualityComparer<T> | X                | X                 |  7.9168 ns | 0.0600 ns | 0.0501 ns |         - |
+
+### NotEqual Benchmarks
+
+| Method           | Value Type  | Comparer             | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|----------------- |:------------|:--------------------:|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresNotEqual | Int32       |                      |                  |                   |  1.535 ns | 0.0274 ns | 0.0256 ns |         - |
+| RequiresNotEqual | Int32       |                      | X                |                   |  2.014 ns | 0.0274 ns | 0.0256 ns |         - |
+| RequiresNotEqual | Int32       |                      |                  | X                 |  3.267 ns | 0.0195 ns | 0.0183 ns |         - |
+| RequiresNotEqual | Int32       |                      | X                | X                 |  2.103 ns | 0.0246 ns | 0.0205 ns |         - |
+| RequiresNotEqual | Int32       | IEqualityComparer<T> |                  |                   |  1.930 ns | 0.0484 ns | 0.0404 ns |         - |
+| RequiresNotEqual | Int32       | IEqualityComparer<T> | X                |                   |  1.650 ns | 0.0399 ns | 0.0373 ns |         - |
+| RequiresNotEqual | Int32       | IEqualityComparer<T> |                  | X                 |  3.695 ns | 0.0998 ns | 0.1298 ns |         - |
+| RequiresNotEqual | Int32       | IEqualityComparer<T> | X                | X                 |  4.174 ns | 0.0605 ns | 0.0537 ns |         - |
+| RequiresNotEqual | String      |                      |                  |                   |  4.678 ns | 0.0514 ns | 0.0481 ns |         - |
+| RequiresNotEqual | String      |                      | X                |                   |  5.045 ns | 0.0691 ns | 0.0612 ns |         - |
+| RequiresNotEqual | String      |                      |                  | X                 |  4.932 ns | 0.0485 ns | 0.0405 ns |         - |
+| RequiresNotEqual | String      |                      | X                | X                 |  4.895 ns | 0.0669 ns | 0.0593 ns |         - |
+| RequiresNotEqual | String      | IEqualityComparer<T> |                  |                   |  5.177 ns | 0.0577 ns | 0.0540 ns |         - |
+| RequiresNotEqual | String      | IEqualityComparer<T> | X                |                   |  5.339 ns | 0.0513 ns | 0.0480 ns |         - |
+| RequiresNotEqual | String      | IEqualityComparer<T> |                  | X                 |  7.660 ns | 0.1102 ns | 0.1031 ns |         - |
+| RequiresNotEqual | String      | IEqualityComparer<T> | X                | X                 |  8.530 ns | 0.1096 ns | 0.1025 ns |         - |
+| RequiresNotEqual | String      | StringComparison     |                  |                   |  2.163 ns | 0.0365 ns | 0.0341 ns |         - |
+| RequiresNotEqual | String      | StringComparison     | X                |                   |  1.825 ns | 0.0455 ns | 0.0426 ns |         - |
+| RequiresNotEqual | String      | StringComparison     |                  | X                 |  4.696 ns | 0.0333 ns | 0.0278 ns |         - |
+| RequiresNotEqual | String      | StringComparison     | X                | X                 |  4.744 ns | 0.0589 ns | 0.0551 ns |         - |
+| RequiresNotEqual | Record      |                      |                  |                   | 14.131 ns | 0.2875 ns | 0.2689 ns |         - |
+| RequiresNotEqual | Record      |                      | X                |                   | 14.839 ns | 0.2608 ns | 0.2439 ns |         - |
+| RequiresNotEqual | Record      |                      |                  | X                 | 14.963 ns | 0.1703 ns | 0.1593 ns |         - |
+| RequiresNotEqual | Record      |                      | X                | X                 | 14.403 ns | 0.1630 ns | 0.1525 ns |         - |
+| RequiresNotEqual | Record      | IEqualityComparer<T> |                  |                   |  3.938 ns | 0.1002 ns | 0.0937 ns |         - |
+| RequiresNotEqual | Record      | IEqualityComparer<T> | X                |                   |  4.369 ns | 0.0336 ns | 0.0314 ns |         - |
+| RequiresNotEqual | Record      | IEqualityComparer<T> |                  | X                 |  6.247 ns | 0.0599 ns | 0.0560 ns |         - |
+| RequiresNotEqual | Record      | IEqualityComparer<T> | X                | X                 |  6.866 ns | 0.0733 ns | 0.0612 ns |         - |
+| RequiresNotEqual | Class       |                      |                  |                   |  7.170 ns | 0.0387 ns | 0.0323 ns |         - |
+| RequiresNotEqual | Class       |                      | X                |                   |  8.000 ns | 0.0993 ns | 0.0880 ns |         - |
+| RequiresNotEqual | Class       |                      |                  | X                 |  8.010 ns | 0.1091 ns | 0.0967 ns |         - |
+| RequiresNotEqual | Class       |                      | X                | X                 |  7.085 ns | 0.0857 ns | 0.0760 ns |         - |
+| RequiresNotEqual | Class       | IEqualityComparer<T> |                  |                   |  4.629 ns | 0.0545 ns | 0.0510 ns |         - |
+| RequiresNotEqual | Class       | IEqualityComparer<T> | X                |                   |  4.593 ns | 0.0475 ns | 0.0444 ns |         - |
+| RequiresNotEqual | Class       | IEqualityComparer<T> |                  | X                 |  6.931 ns | 0.0844 ns | 0.0789 ns |         - |
+| RequiresNotEqual | Class       | IEqualityComparer<T> | X                | X                 |  6.909 ns | 0.1044 ns | 0.0977 ns |         - |

--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -21,33 +21,25 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 X indicates that the optional parameter was supplied; blank indicates that the 
 parameter was omitted.
 
-| Method          | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev |    Median | Allocated |
-|:--------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|----------:|
-| RequiresNotNull | Int32       |                  |                   | 0.0127 ns | 0.0168 ns | 0.0157 ns | 0.0056 ns |         - |
-| RequiresNotNull | Int32       | X                |                   | 0.0040 ns | 0.0062 ns | 0.0058 ns | 0.0000 ns |         - |
-| RequiresNotNull | Int32       |                  | X                 | 1.1554 ns | 0.0261 ns | 0.0244 ns | 1.1442 ns |         - |
-| RequiresNotNull | Int32       | X                | X                 | 1.1624 ns | 0.0248 ns | 0.0207 ns | 1.1623 ns |         - |
-| RequiresNotNull | String      |                  |                   | 0.0033 ns | 0.0049 ns | 0.0043 ns | 0.0008 ns |         - |
-| RequiresNotNull | String      | X                |                   | 0.0008 ns | 0.0023 ns | 0.0019 ns | 0.0000 ns |         - |
-| RequiresNotNull | String      |                  | X                 | 1.7635 ns | 0.0201 ns | 0.0168 ns | 1.7626 ns |         - |
-| RequiresNotNull | String      | X                | X                 | 2.2459 ns | 0.0288 ns | 0.0269 ns | 2.2467 ns |         - |
-| RequiresNotNull | List<T>     |                  |                   | 0.0064 ns | 0.0074 ns | 0.0070 ns | 0.0054 ns |         - |
-| RequiresNotNull | List<T>     | X                |                   | 0.0012 ns | 0.0025 ns | 0.0023 ns | 0.0000 ns |         - |
-| RequiresNotNull | List<T>     |                  | X                 | 1.7117 ns | 0.0305 ns | 0.0285 ns | 1.7042 ns |         - |
-| RequiresNotNull | List<T>     | X                | X                 | 2.4327 ns | 0.0197 ns | 0.0175 ns | 2.4263 ns |         - |
-| *************** | *********** | **************** | ***************** | ********* | ********* | ********* | ********* | ********* |
-| EnsuresNotNull  | Int32       |                  |                   | 0.0013 ns | 0.0030 ns | 0.0025 ns | 0.0000 ns |         - |
-| EnsuresNotNull  | Int32       | X                |                   | 0.0038 ns | 0.0059 ns | 0.0055 ns | 0.0015 ns |         - |
-| EnsuresNotNull  | Int32       |                  | X                 | 1.1545 ns | 0.0096 ns | 0.0090 ns | 1.1547 ns |         - |
-| EnsuresNotNull  | Int32       | X                | X                 | 1.1586 ns | 0.0111 ns | 0.0104 ns | 1.1562 ns |         - |
-| EnsuresNotNull  | String      |                  |                   | 0.0040 ns | 0.0057 ns | 0.0053 ns | 0.0023 ns |         - |
-| EnsuresNotNull  | String      | X                |                   | 0.0042 ns | 0.0073 ns | 0.0065 ns | 0.0009 ns |         - |
-| EnsuresNotNull  | String      |                  | X                 | 1.8425 ns | 0.0131 ns | 0.0116 ns | 1.8397 ns |         - |
-| EnsuresNotNull  | String      | X                | X                 | 2.0406 ns | 0.0271 ns | 0.0253 ns | 2.0303 ns |         - |
-| EnsuresNotNull  | List<T>     |                  |                   | 0.0030 ns | 0.0061 ns | 0.0051 ns | 0.0000 ns |         - |
-| EnsuresNotNull  | List<T>     | X                |                   | 0.0005 ns | 0.0014 ns | 0.0013 ns | 0.0000 ns |         - |
-| EnsuresNotNull  | List<T>     |                  | X                 | 1.8339 ns | 0.0122 ns | 0.0102 ns | 1.8344 ns |         - |
-| EnsuresNotNull  | List<T>     | X                | X                 | 1.5898 ns | 0.0128 ns | 0.0107 ns | 1.5866 ns |         - |
+| Method          | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:--------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresNotNull | String      |                  |                   | 0.0033 ns | 0.0049 ns | 0.0043 ns |         - |
+| RequiresNotNull | String      | X                |                   | 0.0008 ns | 0.0023 ns | 0.0019 ns |         - |
+| RequiresNotNull | String      |                  | X                 | 1.7635 ns | 0.0201 ns | 0.0168 ns |         - |
+| RequiresNotNull | String      | X                | X                 | 2.2459 ns | 0.0288 ns | 0.0269 ns |         - |
+| RequiresNotNull | List<T>     |                  |                   | 0.0064 ns | 0.0074 ns | 0.0070 ns |         - |
+| RequiresNotNull | List<T>     | X                |                   | 0.0012 ns | 0.0025 ns | 0.0023 ns |         - |
+| RequiresNotNull | List<T>     |                  | X                 | 1.7117 ns | 0.0305 ns | 0.0285 ns |         - |
+| RequiresNotNull | List<T>     | X                | X                 | 2.4327 ns | 0.0197 ns | 0.0175 ns |         - |
+| *************** | *********** | **************** | ***************** | ********* | ********* | ********* | ********* |
+| EnsuresNotNull  | String      |                  |                   | 0.0040 ns | 0.0057 ns | 0.0053 ns |         - |
+| EnsuresNotNull  | String      | X                |                   | 0.0042 ns | 0.0073 ns | 0.0065 ns |         - |
+| EnsuresNotNull  | String      |                  | X                 | 1.8425 ns | 0.0131 ns | 0.0116 ns |         - |
+| EnsuresNotNull  | String      | X                | X                 | 2.0406 ns | 0.0271 ns | 0.0253 ns |         - |
+| EnsuresNotNull  | List<T>     |                  |                   | 0.0030 ns | 0.0061 ns | 0.0051 ns |         - |
+| EnsuresNotNull  | List<T>     | X                |                   | 0.0005 ns | 0.0014 ns | 0.0013 ns |         - |
+| EnsuresNotNull  | List<T>     |                  | X                 | 1.8339 ns | 0.0122 ns | 0.0102 ns |         - |
+| EnsuresNotNull  | List<T>     | X                | X                 | 1.5898 ns | 0.0128 ns | 0.0107 ns |         - |
 
 ### NotDefault Benchmarks
 

--- a/DbC.Net.Examples/NotEqualExamples.cs
+++ b/DbC.Net.Examples/NotEqualExamples.cs
@@ -1,0 +1,98 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class NotEqualExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must not be equal to {Target}";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var currentDate = new DateOnly(2021, 12, 25);
+      var targetDate = new DateOnly(2021, 12, 25);
+
+      // Precondition with default message template/default exception factory.
+      currentDate.RequiresNotEqual(targetDate);
+
+      // Precondition with custom message template/default exception factory.
+      currentDate.RequiresNotEqual(targetDate, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      currentDate.RequiresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      currentDate.RequiresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      currentDate.EnsuresNotEqual(targetDate);
+
+      // Postcondition with custom message template/default exception factory.
+      currentDate.EnsuresNotEqual(targetDate, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      currentDate.EnsuresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      currentDate.EnsuresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+      var box = new Box(1, 1, 8, "Red");
+      var targetBox = new Box(2, 2, 2, "Blue");
+      var comparer = new BoxVolumeComparer();
+
+      // Precondition with default message template/default exception factory.
+      box.RequiresNotEqual(targetBox, comparer);
+
+      // Precondition with custom message template/default exception factory.
+      box.RequiresNotEqual(targetBox, comparer, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      box.RequiresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      box.RequiresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      box.EnsuresNotEqual(targetBox, comparer);
+
+      // Postcondition with custom message template/default exception factory.
+      box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      box.EnsuresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      var str = "qwerty";
+      var targetStr = "QWERTY";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+      // Precondition with default message template/default exception factory.
+      str.RequiresNotEqual(targetStr, comparisonType);
+
+      // Precondition with custom message template/default exception factory.
+      str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      str.RequiresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      str.EnsuresNotEqual(targetStr, comparisonType);
+
+      // Postcondition with custom message template/default exception factory.
+      str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      str.EnsuresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/NotEqualBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/NotEqualBenchmarks.cs
@@ -1,0 +1,261 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class NotEqualBenchmarks
+{
+   private const Int32 _intValue = 100;
+   private const Int32 _intTarget = 101;
+   private static readonly IEqualityComparer<Int32> _intComparer = EqualityComparer<Int32>.Default;
+
+   private const String _strValue = "asdf";
+   private const String _strTarget = "QWERTY";
+   private static readonly IEqualityComparer<String> _stringComparer = EqualityComparer<String>.Default;
+   private const StringComparison _comparisonType = StringComparison.OrdinalIgnoreCase;
+
+   private static readonly Box _boxValue = new(2, 4, 8, "Green");
+   private static readonly Box _boxTarget = new(2, 4, 8, "Blue");
+   private static readonly IEqualityComparer<Box> _boxComparer = BoxComparers.AllFieldsComparer;
+
+   private static readonly Observation _observationValue = new()
+   {
+      ObservationId = new Guid("f77d70bc-6eea-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2022, 11, 22, 9, 37, 46, 789),
+      ObservationType = ObservationType.Temperature,
+      Value = 6.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly Observation _observationTaget = new()
+   {
+      ObservationId = new Guid("66e1148d-ed17-4628-9a7f-530660f9b988"),
+      ObservationTimestamp = new DateTime(2021, 11, 22, 9, 37, 46, 789),
+      ObservationType = ObservationType.Concentration,
+      Value = 2.75,
+      Units = Units.KilogramsPerMeterCubed
+   };
+   private static readonly IEqualityComparer<Observation> _observationComparer = ObservationComparers.AllFieldsComparer;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must not be equal to {Target}";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P000()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P100()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P010()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P110()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P001()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, _intComparer);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P101()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, _intComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P011()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, _intComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Int32_P111()
+   {
+      var result = _intValue.RequiresNotEqual(_intTarget, _intComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P000()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P100()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P010()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P110()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P001()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _stringComparer);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P101()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _stringComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P011()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _stringComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P111()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _stringComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P002()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _comparisonType);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P102()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _comparisonType, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P012()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _comparisonType, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_String_P112()
+   {
+      var result = _strValue.RequiresNotEqual(_strTarget, _comparisonType, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P000()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P100()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P010()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P110()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P001()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, _boxComparer);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P101()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, _boxComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P011()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, _boxComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Record_P111()
+   {
+      var result = _boxValue.RequiresNotEqual(_boxTarget, _boxComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P000()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P100()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P010()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P110()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P001()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, _observationComparer);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P101()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, _observationComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P011()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, _observationComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEqual_Class_P111()
+   {
+      var result = _observationValue.RequiresNotEqual(_observationTaget, _observationComparer, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/NotNullBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/NotNullBenchmarks.cs
@@ -3,7 +3,6 @@
 [MemoryDiagnoser]
 public class NotNullBenchmarks
 {
-   private const Int32 _intValue = 1;
    private const String _stringValue = "This is a test";
    private static readonly List<Double> _listValue = new() { Double.MinValue, Double.MaxValue };
    private const String _messageTemplate = "Requires{RequirementName} failed: {ValueExpression} may not be null";
@@ -12,31 +11,7 @@ public class NotNullBenchmarks
    [Benchmark]
    public void ThrowAway()
    {
-      var result = _intValue.RequiresNotNull();
-   }
-
-   [Benchmark]
-   public void RequiresNotNull_Int32_P00()
-   {
-      var result = _intValue.RequiresNotNull();
-   }
-
-   [Benchmark]
-   public void RequiresNotNull_Int32_P10()
-   {
-      var result = _intValue.RequiresNotNull(_messageTemplate);
-   }
-
-   [Benchmark]
-   public void RequiresNotNull_Int32_P01()
-   {
-      var result = _intValue.RequiresNotNull(exceptionFactory: _exceptionFactory);
-   }
-
-   [Benchmark]
-   public void RequiresNotNull_Int32_P11()
-   {
-      var result = _intValue.RequiresNotNull(_messageTemplate, _exceptionFactory);
+      var result = _stringValue.RequiresNotNull();
    }
 
    [Benchmark]
@@ -85,30 +60,6 @@ public class NotNullBenchmarks
    public void RequiresNotNull_List_P11()
    {
       var result = _listValue.RequiresNotNull(_messageTemplate, _exceptionFactory);
-   }
-
-   [Benchmark]
-   public void EnsuresNotNull_Int32_P00()
-   {
-      var result = _intValue.EnsuresNotNull();
-   }
-
-   [Benchmark]
-   public void EnsuresNotNull_Int32_P10()
-   {
-      var result = _intValue.EnsuresNotNull(_messageTemplate);
-   }
-
-   [Benchmark]
-   public void EnsuresNotNull_Int32_P01()
-   {
-      var result = _intValue.EnsuresNotNull(exceptionFactory: _exceptionFactory);
-   }
-
-   [Benchmark]
-   public void EnsuresNotNull_Int32_P11()
-   {
-      var result = _intValue.EnsuresNotNull(_messageTemplate, _exceptionFactory);
    }
 
    [Benchmark]

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -1,3 +1,4 @@
 ﻿//BenchmarkRunner.Run<NotNullBenchmarks>();
 //BenchmarkRunner.Run<NotDefaultBenchmarks>(); 
-BenchmarkRunner.Run<EqualBenchmarks>();
+//BenchmarkRunner.Run<EqualBenchmarks>();
+BenchmarkRunner.Run<NotEqualBenchmarks>();

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -862,7 +862,7 @@ public class EqualsExtensionsTests
    {
       // Arrange.
       var value = BigInteger.MinusOne;
-      var target = BigInteger.MinusOne;;
+      var target = BigInteger.MinusOne;
       var comparer = new ReverseComparer<BigInteger>();
       var act = () => _ = value.RequiresEqual(target, comparer);
       var expectedParameterName = nameof(value);

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -80,14 +80,12 @@ public class EqualsExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = UInt32.MinValue;
+      var target = UInt32.MaxValue;
       var act = () => _ = value.EnsuresEqual(target);
 
       // Act/assert.
@@ -102,14 +100,12 @@ public class EqualsExtensionsTests
       ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = new BoxRecordData().EqualValue;
+      var target = new BoxRecordData().NotEqualValue;
       var act = () => _ = value.EnsuresEqual(target);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -118,14 +114,12 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = new Guid("75299d53-16e1-4969-acd8-840fc2f1f821");
+      var target = new Guid("d0d5aa44-1eba-4878-8930-2c9fba8151cd");
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, messageTemplate);
       var expectedMessage = $"Requirement Equal failed";
@@ -135,14 +129,12 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = SByte.MinValue;
+      var target = SByte.MaxValue;
       var act = () => _ = value.EnsuresEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -151,14 +143,12 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = "asdf";
+      var target = "qwerty";
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement Equal failed";
@@ -220,15 +210,13 @@ public class EqualsExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = 100M;
+      var target = 100M;
+      var comparer = new ReverseComparer<Decimal>();
       var act = () => _ = value.EnsuresEqual(target, comparer);
 
       // Act/assert.
@@ -243,15 +231,13 @@ public class EqualsExtensionsTests
       ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = true;
+      var target = true;
+      var comparer = new ReverseComparer<Boolean>();
       var act = () => _ = value.EnsuresEqual(target, comparer);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -260,15 +246,13 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = 'A';
+      var target = 'A';
+      var comparer = new ReverseComparer<Char>();
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, comparer, messageTemplate);
       var expectedMessage = $"Requirement Equal failed";
@@ -278,15 +262,13 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = new ObservationClassData().EqualValue;
+      var target = new ObservationClassData().EqualValue;
+      var comparer = new ReverseComparer<Observation>();
       var act = () => _ = value.EnsuresEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -295,15 +277,13 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = Int64.MaxValue;
+      var target = Int64.MaxValue;
+      var comparer = new ReverseComparer<Int64>();
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement Equal failed";
@@ -311,6 +291,21 @@ public class EqualsExtensionsTests
       // Act/assert.
       act.Should().Throw<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var value = new DateTimeData().EqualValue;
+      var target = value;
+      IEqualityComparer<DateTime> comparer = null!;
+      var act = () => _ = value.EnsuresEqual(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
 
    #endregion
@@ -679,14 +674,12 @@ public class EqualsExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = Single.Pi;
+      var target = Single.E;
       var act = () => _ = value.RequiresEqual(target);
 
       // Act/assert.
@@ -701,14 +694,12 @@ public class EqualsExtensionsTests
       ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = new PointStructData().EqualValue;
+      var target = new PointStructData().NotEqualValue;
       var act = () => _ = value.RequiresEqual(target);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
@@ -719,14 +710,12 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = DateTimeOffset.MaxValue;
+      var target = DateTimeOffset.MinValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -738,14 +727,12 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = TimeOnly.MinValue;
+      var target = TimeOnly.MaxValue;
       var act = () => _ = value.RequiresEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -754,14 +741,12 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.NotEqualValue;
+      var value = "asdf";
+      var target = "qwerty";
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement Equal failed";
@@ -851,15 +836,13 @@ public class EqualsExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = nint.MinValue;
+      var target = nint.MinValue;
+      var comparer = new ReverseComparer<nint>();
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
@@ -874,15 +857,13 @@ public class EqualsExtensionsTests
       ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = BigInteger.MinusOne;
+      var target = BigInteger.MinusOne;;
+      var comparer = new ReverseComparer<BigInteger>();
       var act = () => _ = value.RequiresEqual(target, comparer);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
@@ -893,15 +874,13 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = UInt16.MaxValue;
+      var target = UInt16.MaxValue;
+      var comparer = new ReverseComparer<UInt16>();
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, comparer, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -913,15 +892,13 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = Double.MaxValue;
+      var target = Double.MaxValue;
+      var comparer = new ReverseComparer<Double>();
       var act = () => _ = value.RequiresEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -930,15 +907,13 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
-   [Theory]
-   [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed<T>(
-      EquatableValue<T> data) where T : IEquatable<T>
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = data.EqualValue;
-      var target = data.EqualValue;
-      var comparer = data.ReverseComparer;
+      var value = DateTime.MaxValue;
+      var target = DateTime.MaxValue;
+      var comparer = new ReverseComparer<DateTime>();
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement Equal failed";
@@ -946,6 +921,21 @@ public class EqualsExtensionsTests
       // Act/assert.
       act.Should().Throw<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var value = Half.Pi;
+      var target = Half.Tau;
+      IEqualityComparer<Half> comparer = null!;
+      var act = () => _ = value.RequiresEqual(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -433,6 +433,7 @@ public class EqualsExtensionsTests
       String target,
       StringComparison comparisonType)
    {
+      // Arrange.
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
@@ -452,6 +453,7 @@ public class EqualsExtensionsTests
       String target,
       StringComparison comparisonType)
    {
+      // Arrange.
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
@@ -471,6 +473,7 @@ public class EqualsExtensionsTests
       String target,
       StringComparison comparisonType)
    {
+      // Arrange.
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
@@ -1063,6 +1066,7 @@ public class EqualsExtensionsTests
       String target,
       StringComparison comparisonType)
    {
+      // Arrange.
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
@@ -1082,6 +1086,7 @@ public class EqualsExtensionsTests
       String target,
       StringComparison comparisonType)
    {
+      // Arrange.
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
@@ -1101,6 +1106,7 @@ public class EqualsExtensionsTests
       String target,
       StringComparison comparisonType)
    {
+      // Arrange.
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -328,6 +328,258 @@ public class NotEqualExtensionsTests
 
    #endregion
 
+   #region EnsuresNotEqual (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresNotEqual(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresNotEqual(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_thTH(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresNotEqual(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   // Note: th-TH culture considers "a" and "a-" as equal.
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_thTH(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenAndTargetAreDefaultAndCurrentCultureIs_enUS(StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenAndTargetAreDefaultAndCurrentCultureIs_trTR(StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseDipthongAE;
+      var target = StringData.LowerCaseDipthongAE;
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseAE;
+      var target = StringData.UpperCaseAE;
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
+      var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseSlashedO;
+      var target = StringData.UpperCaseSlashedO;
+      var comparisonType = StringComparison.InvariantCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType, messageTemplate);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseI;
+      var target = StringData.LowerCaseI;
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseA;
+      var target = StringData.UpperCaseA;
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEqual(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
    #region RequiresNotEqual (IEquatable) Tests
    // ==========================================================================
    // ==========================================================================
@@ -653,6 +905,262 @@ public class NotEqualExtensionsTests
       act.Should().Throw<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
+   }
+
+   #endregion
+
+   #region RequiresNotEqual (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresNotEqual(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresNotEqual(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_thTH(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresNotEqual(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   // Note: th-TH culture considers "a" and "a-" as equal.
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_thTH(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenAndTargetAreDefaultAndCurrentCultureIs_enUS(StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenAndTargetAreDefaultAndCurrentCultureIs_trTR(StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseDipthongAE;
+      var target = StringData.LowerCaseDipthongAE;
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseAE;
+      var target = StringData.UpperCaseAE;
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseSlashedO;
+      var target = StringData.UpperCaseSlashedO;
+      var comparisonType = StringComparison.InvariantCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseI;
+      var target = StringData.LowerCaseI;
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseA;
+      var target = StringData.UpperCaseA;
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEqual(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace DbC.Net.Tests.Unit;
 
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
 public class NotEqualExtensionsTests
 {
    private const Int32 _dataCount = 6;

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -1,0 +1,166 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class NotEqualExtensionsTests
+{
+   private const Int32 _dataCount = 6;
+   private const Int32 _stringDataCount = 7;
+
+   #region RequiresNotEqual (IEquatable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      var target = data.NotEqualValue;
+
+      // Act.
+      var result = value.RequiresNotEqual(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var target = data.NonDefaultNotEqualValue;
+
+      // Act.
+      var result = value.RequiresNotEqual(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      T target = default!;
+
+      // Act.
+      var result = value.RequiresNotEqual(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrow_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      var target = data.EqualValue;
+      var act = () => _ = value.RequiresNotEqual(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrow_WhenValueAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var act = () => _ = value.RequiresNotEqual(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = 100;
+      var target = value;
+      var act = () => _ = value.RequiresNotEqual(target);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseAE;
+      var target = StringData.UpperCaseAE;
+      var act = () => _ = value.RequiresNotEqual(target);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = new ObservationClassData().EqualValue;
+      var target = new ObservationClassData().EqualValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEqual(target, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Double.Pi;
+      var target = Double.Pi;
+      var act = () => _ = value.RequiresNotEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = new PointStructData().EqualValue;
+      var target = new PointStructData().EqualValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEqual(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -7,6 +7,327 @@ public class NotEqualExtensionsTests
    private const Int32 _dataCount = 6;
    private const Int32 _stringDataCount = 7;
 
+   #region EnsuresNotEqual (IEquatable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      var target = data.NotEqualValue;
+
+      // Act.
+      var result = value.EnsuresNotEqual(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var target = data.NonDefaultNotEqualValue;
+
+      // Act.
+      var result = value.EnsuresNotEqual(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      T target = default!;
+
+      // Act.
+      var result = value.EnsuresNotEqual(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrow_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      var target = data.EqualValue;
+      var act = () => _ = value.EnsuresNotEqual(target);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrow_WhenValueAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var act = () => _ = value.EnsuresNotEqual(target);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = 100;
+      var target = value;
+      var act = () => _ = value.EnsuresNotEqual(target);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueEqualsTarget()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseAE;
+      var target = StringData.UpperCaseAE;
+      var act = () => _ = value.EnsuresNotEqual(target);
+      var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = new ObservationClassData().EqualValue;
+      var target = new ObservationClassData().EqualValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEqual(target, messageTemplate);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Double.Pi;
+      var target = Double.Pi;
+      var act = () => _ = value.EnsuresNotEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = new PointStructData().EqualValue;
+      var target = new PointStructData().EqualValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEqual(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
+   #region EnsuresNotEqual (IEqualityComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      var target = data.EqualValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.EnsuresNotEqual(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var target = data.EqualValue;
+      var comparer = EqualityComparer<T>.Default;
+
+      // Act.
+      var result = value.EnsuresNotEqual(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      T target = default!;
+      var comparer = EqualityComparer<T>.Default;
+
+      // Act.
+      var result = value.EnsuresNotEqual(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrow_WhenAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var comparer = EqualityComparer<T>.Default;
+      var act = () => _ = value.EnsuresNotEqual(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
+   {
+      // Arrange.
+      var value = nint.MinValue;
+      var target = nint.MaxValue;
+      var comparer = new ReverseComparer<nint>();
+      var act = () => _ = value.EnsuresNotEqual(target, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
+   {
+      // Arrange.
+      var value = BigInteger.MinusOne;
+      var target = BigInteger.One;
+      var comparer = new ReverseComparer<BigInteger>();
+      var act = () => _ = value.EnsuresNotEqual(target, comparer);
+      var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = UInt16.MaxValue;
+      var target = UInt16.MinValue;
+      var comparer = new ReverseComparer<UInt16>();
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEqual(target, comparer, messageTemplate);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Double.MaxValue;
+      var target = Double.MinValue;
+      var comparer = new ReverseComparer<Double>();
+      var act = () => _ = value.EnsuresNotEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = DateTime.MaxValue;
+      var target = DateTime.MinValue;
+      var comparer = new ReverseComparer<DateTime>();
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var value = Half.Pi;
+      var target = Half.Tau;
+      IEqualityComparer<Half> comparer = null!;
+      var act = () => _ = value.EnsuresNotEqual(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
+   }
+
+   #endregion
+
    #region RequiresNotEqual (IEquatable) Tests
    // ==========================================================================
    // ==========================================================================
@@ -162,6 +483,176 @@ public class NotEqualExtensionsTests
       // Act/assert.
       act.Should().Throw<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresNotEqual (IEqualityComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      var target = data.EqualValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.RequiresNotEqual(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var target = data.EqualValue;
+      var comparer = EqualityComparer<T>.Default;
+
+      // Act.
+      var result = value.RequiresNotEqual(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      var value = data.EqualValue;
+      T target = default!;
+      var comparer = EqualityComparer<T>.Default;
+
+      // Act.
+      var result = value.RequiresNotEqual(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(EquatableTypesTestData))]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrow_WhenAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var comparer = EqualityComparer<T>.Default;
+      var act = () => _ = value.RequiresNotEqual(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
+   {
+      // Arrange.
+      var value = nint.MinValue;
+      var target = nint.MaxValue;
+      var comparer = new ReverseComparer<nint>();
+      var act = () => _ = value.RequiresNotEqual(target, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
+   {
+      // Arrange.
+      var value = BigInteger.MinusOne;
+      var target = BigInteger.One;
+      var comparer = new ReverseComparer<BigInteger>();
+      var act = () => _ = value.RequiresNotEqual(target, comparer);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = UInt16.MaxValue;
+      var target = UInt16.MinValue;
+      var comparer = new ReverseComparer<UInt16>();
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEqual(target, comparer, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Double.MaxValue;
+      var target = Double.MinValue;
+      var comparer = new ReverseComparer<Double>();
+      var act = () => _ = value.RequiresNotEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = DateTime.MaxValue;
+      var target = DateTime.MinValue;
+      var comparer = new ReverseComparer<DateTime>();
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var value = Half.Pi;
+      var target = Half.Tau;
+      IEqualityComparer<Half> comparer = null!;
+      var act = () => _ = value.RequiresNotEqual(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/NotNullExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullExtensionsTests.cs
@@ -9,32 +9,6 @@ public class NotNullExtensionsTests
    // ==========================================================================
 
    [Fact]
-   public void NotNull_EnsuresNotNull_ShouldReturnOriginalValue_WhenValueIsValueTypeAndDefault()
-   {
-      // Arrange.
-      var value = default(Int32);
-
-      // Act.
-      var result = value.EnsuresNotNull();
-
-      // Assert.
-      result.Should().Be(value);
-   }
-
-   [Fact]
-   public void NotNull_EnsuresNotNull_ShouldReturnOriginalValue_WhenValueIsValueTypeAndIsNotDefault()
-   {
-      // Arrange.
-      var value = 42;
-
-      // Act.
-      var result = value.EnsuresNotNull();
-
-      // Assert.
-      result.Should().Be(value);
-   }
-
-   [Fact]
    public void NotNull_EnsuresNotNull_ShouldReturnOriginalValue_WhenValueIsReferenceTypeAndIsNotDefault()
    {
       // Arrange.
@@ -62,7 +36,7 @@ public class NotNullExtensionsTests
    public void NotNull_EnsuresNotNull_ShouldThrow_WhenValueIsReferenceTypeAndIsDefault()
    {
       // Arrange.
-      var value = default(List<Double>);
+      List<Double> value = default!;
       var act = () => _ = value.EnsuresNotNull();
 
       // Act/assert.
@@ -146,32 +120,6 @@ public class NotNullExtensionsTests
    // ==========================================================================
 
    [Fact]
-   public void NotNull_RequiresNotNull_ShouldReturnOriginalValue_WhenValueIsValueTypeAndDefault()
-   {
-      // Arrange.
-      var value = default(Int32);
-
-      // Act.
-      var result = value.RequiresNotNull();
-
-      // Assert.
-      result.Should().Be(value);
-   }
-
-   [Fact]
-   public void NotNull_RequiresNotNull_ShouldReturnOriginalValue_WhenValueIsValueTypeAndIsNotDefault()
-   {
-      // Arrange.
-      var value = 42;
-
-      // Act.
-      var result = value.RequiresNotNull();
-
-      // Assert.
-      result.Should().Be(value);
-   }
-
-   [Fact]
    public void NotNull_RequiresNotNull_ShouldReturnOriginalValue_WhenValueIsReferenceTypeAndIsNotDefault()
    {
       // Arrange.
@@ -199,7 +147,7 @@ public class NotNullExtensionsTests
    public void NotNull_RequiresNotNull_ShouldThrow_WhenValueIsReferenceTypeAndIsDefault()
    {
       // Arrange.
-      var value = default(List<Double>);
+      List<Double> value = default!;
       var act = () => _ = value.RequiresNotNull();
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/TestData/ObservationClassData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ObservationClassData.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace DbC.Net.Tests.Unit.TestData;
+﻿namespace DbC.Net.Tests.Unit.TestData;
 
 public class ObservationClassData : ComparableValue<Observation>
 {

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 	ProjectSection(SolutionItems) = preProject
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
+		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md
 	EndProjectSection
 EndProject

--- a/DbC.Net/EqualExtensions.cs
+++ b/DbC.Net/EqualExtensions.cs
@@ -95,6 +95,9 @@ public static class EqualExtensions
    ///   The tested <paramref name="value"/> is returned unaltered to support 
    ///   chaining requirements.
    /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
    public static T EnsuresEqual<T>(
       this T value,
       T target,
@@ -107,7 +110,7 @@ public static class EqualExtensions
       CheckEqual(
          value,
          target,
-         comparer,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
          RequirementType.Postcondition,
          messageTemplate,
          exceptionFactory,
@@ -265,6 +268,9 @@ public static class EqualExtensions
    ///   The tested <paramref name="value"/> is returned unaltered to support 
    ///   chaining requirements.
    /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
    public static T RequiresEqual<T>(
       this T value,
       T target,
@@ -277,7 +283,7 @@ public static class EqualExtensions
       CheckEqual(
          value,
          target,
-         comparer,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
          RequirementType.Precondition,
          messageTemplate,
          exceptionFactory,

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -79,6 +79,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}.
+        /// </summary>
+        internal static string NotEqualTemplate {
+            get {
+                return ResourceManager.GetString("NotEqualTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be null.
         /// </summary>
         internal static string NotNullTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -123,6 +123,9 @@
   <data name="NotDefaultTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
   </data>
+  <data name="NotEqualTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}</value>
+  </data>
   <data name="NotNullTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be null</value>
   </data>

--- a/DbC.Net/Messages.Designer.cs
+++ b/DbC.Net/Messages.Designer.cs
@@ -70,6 +70,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Comparer may not be null.
+        /// </summary>
+        internal static string ComparerIsNull {
+            get {
+                return ResourceManager.GetString("ComparerIsNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Constant value may not be null.
         /// </summary>
         internal static string ConstantValueIsNull {

--- a/DbC.Net/Messages.resx
+++ b/DbC.Net/Messages.resx
@@ -120,6 +120,9 @@
   <data name="BaseTransformIsNull" xml:space="preserve">
     <value>Decorator base transform may not be null</value>
   </data>
+  <data name="ComparerIsNull" xml:space="preserve">
+    <value>Comparer may not be null</value>
+  </data>
   <data name="ConstantValueIsNull" xml:space="preserve">
     <value>Constant value may not be null</value>
   </data>

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -15,11 +15,11 @@ public static class NotEqualExtensions
    ///   The value to check.
    /// </param>
    /// <param name="target">
-   ///   The target that <paramref name="value"/> should equal.
+   ///   The target that <paramref name="value"/> should not equal.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must be equal to {Target}".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must not be equal to {Target}".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
@@ -67,7 +67,7 @@ public static class NotEqualExtensions
    ///   The value to check.
    /// </param>
    /// <param name="target">
-   ///   The target that <paramref name="value"/> should equal.
+   ///   The target that <paramref name="value"/> should not equal.
    /// </param>
    /// <param name="comparer">
    ///   An <see cref="IEqualityComparer{T}"/> used to check for equality 
@@ -75,7 +75,7 @@ public static class NotEqualExtensions
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must be equal to {Target}".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must not be equal to {Target}".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
@@ -111,6 +111,66 @@ public static class NotEqualExtensions
          value,
          target,
          comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value NotEqual postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is not equal to the <see cref="String"/> 
+   ///   <paramref name="target"/> and throw an exception if it is.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should not equal.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must not be equal to {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String EnsuresNotEqual(
+      this String value,
+      String target,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckNotEqual(
+         value,
+         target,
+         comparisonType,
          RequirementType.Postcondition,
          messageTemplate,
          exceptionFactory,
@@ -180,7 +240,7 @@ public static class NotEqualExtensions
    ///   The value to check.
    /// </param>
    /// <param name="target">
-   ///   The target that <paramref name="value"/> should equal.
+   ///   The target that <paramref name="value"/> should not equal.
    /// </param>
    /// <param name="comparer">
    ///   An <see cref="IEqualityComparer{T}"/> used to check for equality 
@@ -188,7 +248,7 @@ public static class NotEqualExtensions
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must be equal to {Target}".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must not be equal to {Target}".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
@@ -224,6 +284,66 @@ public static class NotEqualExtensions
          value,
          target,
          comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value NotEqual precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is not equal to the <see cref="String"/> 
+   ///   <paramref name="target"/> and throw an exception if it is.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should not equal.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must not be equal to {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String RequiresNotEqual(
+      this String value,
+      String target,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckNotEqual(
+         value,
+         target,
+         comparisonType,
          RequirementType.Precondition,
          messageTemplate,
          exceptionFactory,
@@ -281,6 +401,34 @@ public static class NotEqualExtensions
             valueExpression,
             target,
             targetExpression);
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static void CheckNotEqual(
+      String value,
+      String target,
+      StringComparison comparisonType,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression)
+   {
+      if (ReferenceEquals(value, target) || (value is not null && value.Equals(target, comparisonType)))
+      {
+         messageTemplate ??= MessageTemplates.NotEqualTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = GetDataDictionary(
+            requirementType,
+            value,
+            valueExpression,
+            target,
+            targetExpression);
+         data[DataNames.StringComparison] = comparisonType;
 
          throw exceptionFactory.CreateException(data, messageTemplate);
       }

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -1,0 +1,103 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement NotEqual requirement for types that
+///   implement <see cref="IEquatable{T}"/> or that use 
+///   <see cref="IEqualityComparer{T}"/>
+/// </summary>
+public static class NotEqualExtensions
+{
+   /// <summary>
+   ///   Value NotEqual precondition. Confirm that <paramref name="value"/> is 
+   ///   not equal to <paramref name="target"/> and throw an exception if it is.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should not equal.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must not be equal to {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresNotEqual<T>(
+      this T value,
+      T target,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!) where T : IEquatable<T>
+   {
+      CheckNotEqual(
+         value,
+         target,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   private static void CheckNotEqual<T>(
+      T value,
+      T target,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression) where T : IEquatable<T>
+   {
+      if (ReferenceEquals(value, target) || (value is not null && value.Equals(target)))
+      {
+         messageTemplate ??= MessageTemplates.NotEqualTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = GetDataDictionary(
+            requirementType,
+            value!,
+            valueExpression,
+            target!,
+            targetExpression);
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static Dictionary<String, Object> GetDataDictionary<T>(
+      RequirementType requirementType,
+      T value,
+      String valueExpression,
+      T target,
+      String targetExpression)
+      => new()
+      {
+         {  DataNames.RequirementType, requirementType },
+         {  DataNames.RequirementName, RequirementNames.NotEqual },
+         {  DataNames.Value, value! },
+         {  DataNames.ValueExpression, valueExpression },
+         {  DataNames.Target, target! },
+         {  DataNames.TargetExpression, targetExpression }
+      };
+}

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -8,6 +8,119 @@
 public static class NotEqualExtensions
 {
    /// <summary>
+   ///   Value NotEqual postcondition. Confirm that <paramref name="value"/> is 
+   ///   not equal to <paramref name="target"/> and throw an exception if it is.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should equal.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must be equal to {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresNotEqual<T>(
+      this T value,
+      T target,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!) where T : IEquatable<T>
+   {
+      CheckNotEqual(
+         value,
+         target,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value NotEqual postcondition. Confirm that <paramref name="value"/> is 
+   ///   not equal to <paramref name="target"/> and throw an exception if it is.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should equal.
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IEqualityComparer{T}"/> used to check for equality 
+   ///   between <paramref name="value"/> and <paramref name="target"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must be equal to {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T EnsuresNotEqual<T>(
+      this T value,
+      T target,
+      IEqualityComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckNotEqual(
+         value,
+         target,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   Value NotEqual precondition. Confirm that <paramref name="value"/> is 
    ///   not equal to <paramref name="target"/> and throw an exception if it is.
    /// </summary>
@@ -59,6 +172,67 @@ public static class NotEqualExtensions
       return value;
    }
 
+   /// <summary>
+   ///   Value NotEqual precondition. Confirm that <paramref name="value"/> is 
+   ///   not equal to <paramref name="target"/> and throw an exception if it is.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should equal.
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IEqualityComparer{T}"/> used to check for equality 
+   ///   between <paramref name="value"/> and <paramref name="target"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must be equal to {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T RequiresNotEqual<T>(
+      this T value,
+      T target,
+      IEqualityComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckNotEqual(
+         value,
+         target,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
    private static void CheckNotEqual<T>(
       T value,
       T target,
@@ -79,6 +253,33 @@ public static class NotEqualExtensions
             value!,
             valueExpression,
             target!,
+            targetExpression);
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static void CheckNotEqual<T>(
+      T value,
+      T target,
+      IEqualityComparer<T> comparer,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression)
+   {
+      if (comparer.Equals(value, target))
+      {
+         messageTemplate ??= MessageTemplates.NotEqualTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = GetDataDictionary(
+            requirementType,
+            value,
+            valueExpression,
+            target,
             targetExpression);
 
          throw exceptionFactory.CreateException(data, messageTemplate);

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -362,7 +362,7 @@ public static class NotEqualExtensions
       String valueExpression,
       String targetExpression) where T : IEquatable<T>
    {
-      if (ReferenceEquals(value, target) || (value is not null && value.Equals(target)))
+      if ((value is null && target is null) || (value is not null && value.Equals(target)))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
          exceptionFactory ??= requirementType == RequirementType.Precondition
@@ -416,7 +416,7 @@ public static class NotEqualExtensions
       String valueExpression,
       String targetExpression)
    {
-      if (ReferenceEquals(value, target) || (value is not null && value.Equals(target, comparisonType)))
+      if ((value is null && target is null) || (value is not null && value.Equals(target, comparisonType)))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
          exceptionFactory ??= requirementType == RequirementType.Precondition

--- a/DbC.Net/NotNullExtensions.cs
+++ b/DbC.Net/NotNullExtensions.cs
@@ -6,8 +6,9 @@
 public static class NotNullExtensions
 {
    /// <summary>
-   ///   NotNull postcondition. Confirm that <paramref name="value"/> is not 
-   ///   <see langword="null"/> and throw an exception if it is null.
+   ///   NotNull postcondition. Confirm that the reference type 
+   ///   <paramref name="value"/> is not <see langword="null"/> and throw an 
+   ///   exception if it is null.
    /// </summary>
    /// <param name="value">
    ///   The value to check.
@@ -34,7 +35,7 @@ public static class NotNullExtensions
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression("value")] String valueExpression = null!)
+      [CallerArgumentExpression("value")] String valueExpression = null!) where T : class
    {
       CheckNotNull(
          value!,
@@ -47,8 +48,9 @@ public static class NotNullExtensions
    }
 
    /// <summary>
-   ///   NotNull precondition. Confirm that <paramref name="value"/> is not 
-   ///   <see langword="null"/> and throw an exception if it is null.
+   ///   NotNull precondition. Confirm that the reference type 
+   ///   <paramref name="value"/> is not <see langword="null"/> and throw an 
+   ///   exception if it is null.
    /// </summary>
    /// <param name="value">
    ///   The value to check.
@@ -75,7 +77,7 @@ public static class NotNullExtensions
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression("value")] String valueExpression = null!)
+      [CallerArgumentExpression("value")] String valueExpression = null!) where T : class
    {
       CheckNotNull(
          value!, 

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -7,5 +7,6 @@ public static class RequirementNames
 {
    public static String Equal = nameof(Equal);
    public static String NotDefault = nameof(NotDefault);
+   public static String NotEqual = nameof(NotEqual);
    public static String NotNull = nameof(NotNull);
 }

--- a/Documentation/NotEqual.md
+++ b/Documentation/NotEqual.md
@@ -1,0 +1,127 @@
+### NotEqual
+
+NotEqual requires that the value being checked is not equal to a target value. 
+RequiresNotEqual and EnsuresNotEqual have several overloads that support IEquatable<T> 
+and IEqualtiyComparer<T> as well as an overload for String that accepts a 
+StringComparison value that specifies how the comparison is performed.
+
+Method signatures:
+```C#
+T RequiresNotEqual<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IEquatable<T>
+
+T RequiresNotEqual<T>(this T value, T target, IEqualityComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String RequiresNotEqual<T>(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+T EnsuresNotEqual<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IEquatable<T>
+
+T EnsuresNotEqual<T>(this T value, T target, IEqualityComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String EnsuresNotEqual<T>(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+```
+
+The default message template for NotEqual is "{RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}".
+The default exception factory for RequiresNotEqual is StandardExceptionFactories.ArgumentExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresNotEqual.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, Target and TargetExpression. The data
+dictionary for the String overloads will contain an additional entry for 
+StringComparison.
+
+Examples:
+
+```C#
+var customMessageTemplate = "{ValueExpression} must not be equal to {Target}";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var currentDate = new DateOnly(2021, 12, 25);
+var targetDate = new DateOnly(2021, 12, 25);
+
+// Precondition with default message template/default exception factory.
+currentDate.RequiresNotEqual(targetDate);
+
+// Precondition with custom message template/default exception factory.
+currentDate.RequiresNotEqual(targetDate, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+currentDate.RequiresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+currentDate.RequiresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+currentDate.EnsuresNotEqual(targetDate);
+
+// Postcondition with custom message template/default exception factory.
+currentDate.EnsuresNotEqual(targetDate, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+currentDate.EnsuresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+currentDate.EnsuresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+var box = new Box(1, 1, 8, "Red");
+var targetBox = new Box(2, 2, 2, "Blue");
+var comparer = new BoxVolumeComparer();
+
+// Precondition with default message template/default exception factory.
+box.RequiresNotEqual(targetBox, comparer);
+
+// Precondition with custom message template/default exception factory.
+box.RequiresNotEqual(targetBox, comparer, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+box.RequiresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+box.RequiresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+box.EnsuresNotEqual(targetBox, comparer);
+
+// Postcondition with custom message template/default exception factory.
+box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+box.EnsuresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
+
+
+var str = "qwerty";
+var targetStr = "QWERTY";
+var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+// Precondition with default message template/default exception factory.
+str.RequiresNotEqual(targetStr, comparisonType);
+
+// Precondition with custom message template/default exception factory.
+str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+str.RequiresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+str.EnsuresNotEqual(targetStr, comparisonType);
+
+// Postcondition with custom message template/default exception factory.
+str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+str.EnsuresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+```
+

--- a/Documentation/NotNull.md
+++ b/Documentation/NotNull.md
@@ -1,13 +1,13 @@
 ### NotNull
 
-NotNull requires that the value being checked not be null. Use RequiresNotNull
-for preconditions and EnsuresNotNull for postconditions.
+NotNull requires that the reference type value being checked not be null. Use 
+RequiresNotNull for preconditions and EnsuresNotNull for postconditions.
 
 Method signatures:
 ```C#
-T RequiresNotNull<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
+T RequiresNotNull<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : class
 
-T EnsuresNotNull<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
+T EnsuresNotNull<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : class
 ```
 
 The default message template for NotNull is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null".

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
   - [Equality Requirements](#equality-requirements)
 
     - [Equal](/Documentation/Equal.md)
+    - [NotEqual](/Documentation/NotEqual.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a value is not equal to a target value.

Requirements:

  RequiresNotEqual (precondition), default ArgumentOutOfRangeException
  EnsuresNotEqual (postcondition), default PostconditionFailedException
  Support supplying an IEqualityComparer<T> to perform the comparison

DEFINITION OF DONE:

1. Implement RequiresNotEqual
2. Implement EnsuresNotEqual
3. Unit tests for Requires/Ensures NotEqual
4. Performance tests
5. Readme updates
6. Examples