### PR TITLE
S0007 approximately equal

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -16,6 +16,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [NotDefault Benchmarks](#notdefault-benchmarks)
   - [Equal Benchmarks](#equal-benchmarks)
   - [NotEqual Benchmarks](#notequal-benchmarks)
+  - [ApproximatelyEqual Benchmarks](#approximatelyequal-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -158,3 +159,24 @@ parameter was omitted.
 | RequiresNotEqual | Class       | IEqualityComparer<T> | X                |                   |  4.593 ns | 0.0475 ns | 0.0444 ns |         - |
 | RequiresNotEqual | Class       | IEqualityComparer<T> |                  | X                 |  6.931 ns | 0.0844 ns | 0.0789 ns |         - |
 | RequiresNotEqual | Class       | IEqualityComparer<T> | X                | X                 |  6.909 ns | 0.1044 ns | 0.0977 ns |         - |
+
+### ApproximatelyEqual Benchmarks
+
+| Method                     | Value Type | Comparer                  | Message Template | Exception Factory |     Mean |     Error |    StdDev | Allocated |
+|--------------------------- |:-----------|:-------------------------:|:----------------:|:-----------------:|---------:|----------:|----------:|----------:|
+| RequiresApproximatelyEqual | Double     | Fixed Epsilon Comparer    |                  |                   | 4.991 ns | 0.0467 ns | 0.0414 ns |         - |
+| RequiresApproximatelyEqual | Double     | Fixed Epsilon Comparer    | X                |                   | 4.841 ns | 0.0279 ns | 0.0233 ns |         - |
+| RequiresApproximatelyEqual | Double     | Fixed Epsilon Comparer    |                  | X                 | 5.344 ns | 0.1348 ns | 0.1753 ns |         - |
+| RequiresApproximatelyEqual | Double     | Fixed Epsilon Comparer    | X                | X                 | 5.283 ns | 0.0700 ns | 0.0546 ns |         - |
+| RequiresApproximatelyEqual | Double     | Relative Epsilon Comparer |                  |                   | 6.332 ns | 0.1121 ns | 0.1049 ns |         - |
+| RequiresApproximatelyEqual | Double     | Relative Epsilon Comparer | X                |                   | 6.748 ns | 0.0824 ns | 0.0771 ns |         - |
+| RequiresApproximatelyEqual | Double     | Relative Epsilon Comparer |                  | X                 | 7.569 ns | 0.0590 ns | 0.0493 ns |         - |
+| RequiresApproximatelyEqual | Double     | Relative Epsilon Comparer | X                | X                 | 6.154 ns | 0.1515 ns | 0.2359 ns |         - |
+| RequiresApproximatelyEqual | Single     | Fixed Epsilon Comparer    |                  |                   | 4.608 ns | 0.0569 ns | 0.0532 ns |         - |
+| RequiresApproximatelyEqual | Single     | Fixed Epsilon Comparer    | X                |                   | 4.542 ns | 0.0672 ns | 0.0596 ns |         - |
+| RequiresApproximatelyEqual | Single     | Fixed Epsilon Comparer    |                  | X                 | 5.881 ns | 0.1068 ns | 0.0999 ns |         - |
+| RequiresApproximatelyEqual | Single     | Fixed Epsilon Comparer    | X                | X                 | 4.582 ns | 0.0416 ns | 0.0390 ns |         - |
+| RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer |                  |                   | 6.490 ns | 0.1068 ns | 0.1272 ns |         - |
+| RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer | X                |                   | 6.544 ns | 0.0473 ns | 0.0419 ns |         - |
+| RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer |                  | X                 | 6.560 ns | 0.0335 ns | 0.0280 ns |         - |
+| RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer | X                | X                 | 7.393 ns | 0.0984 ns | 0.0822 ns |         - |

--- a/DbC.Net.Examples/ApproximatelyEqualExamples.cs
+++ b/DbC.Net.Examples/ApproximatelyEqualExamples.cs
@@ -1,0 +1,41 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class ApproximatelyEqualExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be close to {Target}";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = Double.Pi;
+      var target = 4.0;
+      var epsilon = 0.0001;
+      var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+
+
+      // Precondition with default message template/default exception factory.
+      value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+      // Precondition with custom message template/default exception factory.
+      value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+      // Postcondition with custom message template/default exception factory.
+      value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Examples/GlobalUsings.cs
+++ b/DbC.Net.Examples/GlobalUsings.cs
@@ -1,3 +1,3 @@
-﻿global using System.Diagnostics.CodeAnalysis;
-
+﻿global using DbC.Net.FloatingPoint;
 global using DbC.Net.TestAndExampleResources;
+

--- a/DbC.Net.Tests.Benchmarks/ApproximatelyEqualBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/ApproximatelyEqualBenchmarks.cs
@@ -6,14 +6,14 @@ public class ApproximatelyEqualBenchmarks
    private const Double _doubleValue = 3.141592653589793D;
    private const Double _doubleTarget = _doubleValue + 0.000000000000001D;
    private const Double _doubleFixedEpsilon = 0.000000000000003D;
-   private static IApproximateEqualityComparer<Double> _doubleFixedEpsilonComparer = StandardFloatingPointComparers.DoubleFixedEpsilonComparer;
+   private static IApproximateEqualityComparer<Double> _doubleFixedEpsilonComparer = StandardFloatingPointComparers.DoubleFixedErrorComparer;
    private const Double _doubleRelativeEpsilon = 0.0000000000000002D;
    private static IApproximateEqualityComparer<Double> _doubleRelativeEpsilonComparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
    
    private const Single _singleValue = 3.14152F;
    private const Single _singleTarget = _singleValue + 0.00001F;
    private const Single _singleFixedEpsilon = 0.00003F;
-   private static IApproximateEqualityComparer<Single> _singleFixedEpsilonComparer = StandardFloatingPointComparers.SingleFixedEpsilonComparer;
+   private static IApproximateEqualityComparer<Single> _singleFixedEpsilonComparer = StandardFloatingPointComparers.SingleFixedErrorComparer;
    private const Single _singleRelativeEpsilon = 0.000002F;
    private static IApproximateEqualityComparer<Single> _singleRelativeEpsilonComparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
 

--- a/DbC.Net.Tests.Benchmarks/ApproximatelyEqualBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/ApproximatelyEqualBenchmarks.cs
@@ -1,0 +1,124 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class ApproximatelyEqualBenchmarks
+{
+   private const Double _doubleValue = 3.141592653589793D;
+   private const Double _doubleTarget = _doubleValue + 0.000000000000001D;
+   private const Double _doubleFixedEpsilon = 0.000000000000003D;
+   private static IApproximateEqualityComparer<Double> _doubleFixedEpsilonComparer = StandardFloatingPointComparers.DoubleFixedEpsilonComparer;
+   private const Double _doubleRelativeEpsilon = 0.0000000000000002D;
+   private static IApproximateEqualityComparer<Double> _doubleRelativeEpsilonComparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+   
+   private const Single _singleValue = 3.14152F;
+   private const Single _singleTarget = _singleValue + 0.00001F;
+   private const Single _singleFixedEpsilon = 0.00003F;
+   private static IApproximateEqualityComparer<Single> _singleFixedEpsilonComparer = StandardFloatingPointComparers.SingleFixedEpsilonComparer;
+   private const Single _singleRelativeEpsilon = 0.000002F;
+   private static IApproximateEqualityComparer<Single> _singleRelativeEpsilonComparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be close to {Target}";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleFixedEpsilon, _doubleFixedEpsilonComparer);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P000()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleFixedEpsilon, _doubleFixedEpsilonComparer);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P010()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleFixedEpsilon, _doubleFixedEpsilonComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P001()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleFixedEpsilon, _doubleFixedEpsilonComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P011()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleFixedEpsilon, _doubleFixedEpsilonComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P100()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleRelativeEpsilon, _doubleRelativeEpsilonComparer);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P110()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleRelativeEpsilon, _doubleRelativeEpsilonComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P101()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleRelativeEpsilon, _doubleRelativeEpsilonComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Double_P111()
+   {
+      var result = _doubleValue.RequiresApproximatelyEqual(_doubleTarget, _doubleRelativeEpsilon, _doubleRelativeEpsilonComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P000()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleFixedEpsilon, _singleFixedEpsilonComparer);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P010()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleFixedEpsilon, _singleFixedEpsilonComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P001()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleFixedEpsilon, _singleFixedEpsilonComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P011()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleFixedEpsilon, _singleFixedEpsilonComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P100()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleRelativeEpsilon, _singleRelativeEpsilonComparer);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P110()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleRelativeEpsilon, _singleRelativeEpsilonComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P101()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleRelativeEpsilon, _singleRelativeEpsilonComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresApproximatelyEqual_Single_P111()
+   {
+      var result = _singleValue.RequiresApproximatelyEqual(_singleTarget, _singleRelativeEpsilon, _singleRelativeEpsilonComparer, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/GlobalUsings.cs
+++ b/DbC.Net.Tests.Benchmarks/GlobalUsings.cs
@@ -2,5 +2,6 @@
 global using BenchmarkDotNet.Running;
 
 global using DbC.Net.ExceptionFactories;
+global using DbC.Net.FloatingPoint;
 global using DbC.Net.TestAndExampleResources;
 global using DbC.Net.Tests.Benchmarks;

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 ﻿//BenchmarkRunner.Run<NotNullBenchmarks>();
 //BenchmarkRunner.Run<NotDefaultBenchmarks>(); 
 //BenchmarkRunner.Run<EqualBenchmarks>();
-BenchmarkRunner.Run<NotEqualBenchmarks>();
+//BenchmarkRunner.Run<NotEqualBenchmarks>();
+BenchmarkRunner.Run<ApproximatelyEqualBenchmarks>();

--- a/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
@@ -1,0 +1,338 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class ApproximatelyEqualExtensionsTests
+{
+   private const Int32 _dataCount = 8;
+
+   #region EnsuresApproximatelyEqual Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldReturnOriginalValue_WhenValueIsWithinPositiveEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value + data.WithinToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedEpsilonComparer;
+
+      // Act.
+      var result = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(NonDecimalFloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldReturnOriginalValue_WhenValueIsWithinNegativeEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value - data.WithinToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
+
+      // Act.
+      var result = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(NonDecimalFloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrow_WhenValueIsGreaterThanPositiveEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value + data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrow_WhenValueIsLessThanNegativeEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedEpsilonComparer;
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotApproximatelyEqualToTarget()
+   {
+      // Arrange.
+      var value = Single.Pi;
+      var target = Single.Tau;
+      var epsilon = 0.0001F;
+      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.ApproximatelyEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.Epsilon].Should().Be(epsilon);
+      ex.Data[DataNames.EpsilonExpression].Should().Be(nameof(epsilon));
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNotApproximatelyEqualToTarget()
+   {
+      // Arrange.
+      var value = Double.Pi;
+      var target = Double.Tau;
+      var epsilon = 0.0001;
+      var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+      var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = Half.Pi;
+      var target = Half.Tau;
+      var epsilon = (Half)0.001;
+      var comparer = StandardFloatingPointComparers.HalfFixedEpsilonComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, messageTemplate);
+      var expectedMessage = $"Requirement ApproximatelyEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Decimal.One;
+      var target = Decimal.MinusOne;
+      var epsilon = 0.0001M;
+      var comparer = StandardFloatingPointComparers.DecimalFixedEpsilonComparer;
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Single.Pi;
+      var target = Single.Tau;
+      var epsilon = 0.0001F;
+      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement ApproximatelyEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresApproximatelyEqual Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldReturnOriginalValue_WhenValueIsWithinPositiveEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value + data.WithinToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedEpsilonComparer;
+
+      // Act.
+      var result = value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(NonDecimalFloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldReturnOriginalValue_WhenValueIsWithinNegativeEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value - data.WithinToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
+
+      // Act.
+      var result = value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(NonDecimalFloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrow_WhenValueIsGreaterThanPositiveEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value + data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
+      var act = () => _ =  value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrow_WhenValueIsLessThanNegativeEpsilon<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedEpsilonComparer;
+      var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotApproximatelyEqualToTarget()
+   {
+      // Arrange.
+      var value = Single.Pi;
+      var target = Single.Tau;
+      var epsilon = 0.0001F;
+      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.ApproximatelyEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.Epsilon].Should().Be(epsilon);
+      ex.Data[DataNames.EpsilonExpression].Should().Be(nameof(epsilon));
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsNotApproximatelyEqualToTarget()
+   {
+      // Arrange.
+      var value = Double.Pi;
+      var target = Double.Tau;
+      var epsilon = 0.0001;
+      var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+      var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = Half.Pi;
+      var target = Half.Tau;
+      var epsilon = (Half)0.001;
+      var comparer = StandardFloatingPointComparers.HalfFixedEpsilonComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement ApproximatelyEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Decimal.One;
+      var target = Decimal.MinusOne;
+      var epsilon = 0.0001M;
+      var comparer = StandardFloatingPointComparers.DecimalFixedEpsilonComparer;
+      var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Single.Pi;
+      var target = Single.Tau;
+      var epsilon = 0.0001F;
+      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement ApproximatelyEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
@@ -17,7 +17,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = data.Value + data.WithinToleranceDelta;
       var target = data.Value;
       var epsilon = data.FixedEpsilon;
-      var comparer = data.FixedEpsilonComparer;
+      var comparer = data.FixedErrorComparer;
 
       // Act.
       var result = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
@@ -69,7 +69,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = data.Value - data.OutOfToleranceDelta;
       var target = data.Value;
       var epsilon = data.FixedEpsilon;
-      var comparer = data.FixedEpsilonComparer;
+      var comparer = data.FixedErrorComparer;
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
@@ -123,7 +123,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = Half.Pi;
       var target = Half.Tau;
       var epsilon = (Half)0.001;
-      var comparer = StandardFloatingPointComparers.HalfFixedEpsilonComparer;
+      var comparer = StandardFloatingPointComparers.HalfFixedErrorComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, messageTemplate);
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
@@ -140,7 +140,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = Decimal.One;
       var target = Decimal.MinusOne;
       var epsilon = 0.0001M;
-      var comparer = StandardFloatingPointComparers.DecimalFixedEpsilonComparer;
+      var comparer = StandardFloatingPointComparers.DecimalFixedErrorComparer;
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
@@ -181,7 +181,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = data.Value + data.WithinToleranceDelta;
       var target = data.Value;
       var epsilon = data.FixedEpsilon;
-      var comparer = data.FixedEpsilonComparer;
+      var comparer = data.FixedErrorComparer;
 
       // Act.
       var result = value.RequiresApproximatelyEqual(target, epsilon, comparer);
@@ -233,7 +233,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = data.Value - data.OutOfToleranceDelta;
       var target = data.Value;
       var epsilon = data.FixedEpsilon;
-      var comparer = data.FixedEpsilonComparer;
+      var comparer = data.FixedErrorComparer;
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
@@ -289,7 +289,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = Half.Pi;
       var target = Half.Tau;
       var epsilon = (Half)0.001;
-      var comparer = StandardFloatingPointComparers.HalfFixedEpsilonComparer;
+      var comparer = StandardFloatingPointComparers.HalfFixedErrorComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -308,7 +308,7 @@ public class ApproximatelyEqualExtensionsTests
       var value = Decimal.One;
       var target = Decimal.MinusOne;
       var epsilon = 0.0001M;
-      var comparer = StandardFloatingPointComparers.DecimalFixedEpsilonComparer;
+      var comparer = StandardFloatingPointComparers.DecimalFixedErrorComparer;
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -144,7 +144,7 @@ public class EqualsExtensionsTests
    }
 
    [Fact]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = "asdf";
@@ -278,7 +278,7 @@ public class EqualsExtensionsTests
    }
 
    [Fact]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = Int64.MaxValue;
@@ -587,7 +587,7 @@ public class EqualsExtensionsTests
    }
 
    [Fact]
-   public void EqualExtensions_EnsuresEqualString_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void EqualExtensions_EnsuresEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = StringData.LowerCaseA;
@@ -745,7 +745,7 @@ public class EqualsExtensionsTests
    }
 
    [Fact]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = "asdf";
@@ -911,7 +911,7 @@ public class EqualsExtensionsTests
    }
 
    [Fact]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = DateTime.MaxValue;
@@ -1224,7 +1224,7 @@ public class EqualsExtensionsTests
    }
 
    [Fact]
-   public void EqualExtensions_RequiresEqualString_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void EqualExtensions_RequiresEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = StringData.LowerCaseA;

--- a/DbC.Net.Tests.Unit/FloatingPoint/DoubleRelativeErrorComparerTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/DoubleRelativeErrorComparerTests.cs
@@ -1,0 +1,199 @@
+﻿namespace DbC.Net.Tests.Unit.FloatingPoint;
+
+#pragma warning disable xUnit1025 // InlineData should be unique within the Theory it belongs to
+public class DoubleRelativeErrorComparerTests
+{
+   private readonly DoubleRelativeErrorComparer _sut = new();
+
+   [Theory]
+   [InlineData(1000000D, 1000001D, 0.00001D, true)]
+   [InlineData(1000001D, 1000000D, 0.00001D, true)]
+   [InlineData(10000D, 10001D, 0.00001D, false)]
+   [InlineData(10001D, 10000D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForLargePositveValues(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-1000000D, -1000001D, 0.00001D, true)]
+   [InlineData(-1000001D, -1000000D, 0.00001D, true)]
+   [InlineData(-10000D, -10001D, 0.00001D, false)]
+   [InlineData(-10001D, -10000D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForLargeNegativeValues(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(1.0000001D, 1.0000002D, 0.00001D, true)]
+   [InlineData(1.0000002D, 1.0000001D, 0.00001D, true)]
+   [InlineData(1.0002D, 1.0001D, 0.00001D, false)]
+   [InlineData(1.0001D, 1.0002D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesAroundOne(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-1.0000001D, -1.0000002D, 0.00001D, true)]
+   [InlineData(-1.0000002D, -1.0000001D, 0.00001D, true)]
+   [InlineData(-1.0002D, -1.0001D, 0.00001D, false)]
+   [InlineData(-1.0001D, -1.0002D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesAroundNegativeOne(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0.000000001000001D, 0.000000001000002D, 0.00001D, true)]
+   [InlineData(0.000000001000002D, 0.000000001000001D, 0.00001D, true)]
+   [InlineData(0.000000000001002D, 0.000000000001001D, 0.00001D, false)]
+   [InlineData(0.000000000001001D, 0.000000000001002D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesBetweenOneAndZero(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-0.000000001000001D, -0.000000001000002D, 0.00001D, true)]
+   [InlineData(-0.000000001000002D, -0.000000001000001D, 0.00001D, true)]
+   [InlineData(-0.000000000001002D, -0.000000000001001D, 0.00001D, false)]
+   [InlineData(-0.000000000001001D, -0.000000000001002D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesBetweenNegativeOneAndZero(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0.3D, 0.30000003D, 0.00001D, true)]
+   [InlineData(-0.3D, -0.30000003D, 0.00001D, true)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_WhenSmallDifferenceFromZero(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0D, 0D, 0.00001D, true)]
+   [InlineData(0D, -0D, 0.00001D, true)]
+   [InlineData(-0D, 0D, 0.00001D, true)]
+   [InlineData(0.00000001D, 0D, 0.00001D, false)]
+   [InlineData(0D, 0.00000001D, 0.00001D, false)]
+   [InlineData(-0.00000001D, -0D, 0.00001D, false)]
+   [InlineData(-0D, -0.00000001D, 0.00001D, false)]
+
+   [InlineData(0D, 1E-310D, 0.01D, true)]
+   [InlineData(1e-310D, 0D, 0.01D, true)]
+   [InlineData(-1e-310D, 0D, 0.00000001D, false)]
+   [InlineData(0D, -1e-310D, 0.00000001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_WhenComparingToZero(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Double.MaxValue, Double.MaxValue, 0.00001D, true)]
+   [InlineData(Double.MaxValue, -Double.MaxValue, 0.00001D, false)]
+   [InlineData(-Double.MaxValue, Double.MaxValue, 0.00001D, false)]
+   [InlineData(Double.MaxValue, Double.MaxValue / 2, 0.00001D, false)]
+   [InlineData(Double.MaxValue, -Double.MaxValue / 2, 0.00001D, false)]
+   [InlineData(-Double.MaxValue, Double.MaxValue / 2, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForExtremeValues(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Double.PositiveInfinity, Double.PositiveInfinity, 0.00001D, true)]
+   [InlineData(Double.NegativeInfinity, Double.NegativeInfinity, 0.00001D, true)]
+   [InlineData(Double.NegativeInfinity, Double.PositiveInfinity, 0.00001D, false)]
+   [InlineData(Double.PositiveInfinity, Double.MaxValue, 0.00001D, false)]
+   [InlineData(Double.NegativeInfinity, Double.MinValue, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForInfinity(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Double.NaN, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, 0D, 0.00001D, false)]
+   [InlineData(Double.NaN, -0D, 0.00001D, false)]
+   [InlineData(-0D, Double.NaN, 0.00001D, false)]
+   [InlineData(0D, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, Double.PositiveInfinity, 0.00001D, false)]
+   [InlineData(Double.PositiveInfinity, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, Double.NegativeInfinity, 0.00001D, false)]
+   [InlineData(Double.NegativeInfinity, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, Double.MaxValue, 0.00001D, false)]
+   [InlineData(Double.MaxValue, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, -Double.MaxValue, 0.00001D, false)]
+   [InlineData(-Double.MaxValue, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, Double.MinValue, 0.00001D, false)]
+   [InlineData(Double.MinValue, Double.NaN, 0.00001D, false)]
+   [InlineData(Double.NaN, -Double.MinValue, 0.00001D, false)]
+   [InlineData(-Double.MinValue, Double.NaN, 0.00001D, false)]
+
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForNaN(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Double.Epsilon, -Double.Epsilon, 0.00001D, true)]
+   [InlineData(1.000000001D, -1D, 0.00001D, false)]
+   [InlineData(-1D, 1.000000001D, 0.00001D, false)]
+   [InlineData(-1.000000001D, 1D, 0.00001D, false)]
+   [InlineData(1D, -1.000000001D, 0.00001D, false)]
+   [InlineData(10 * Double.MinValue, 10 * -Double.MinValue, 0.00001D, false)]
+   [InlineData(10000 * Double.MinValue, 10000 * -Double.MinValue, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForOppositeSidesOfZero(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   // TODO: These tests should pass according to https://floating-point-gui.de/errors/NearlyEqualsTest.java
+   // TODO: but are not. Needs further investigation.
+   //[InlineData(Double.MinValue, Double.MinValue, 0.00001D, true)]
+   //[InlineData(Double.MinValue, Double.MaxValue, 0.00001D, true)]
+   //[InlineData(Double.MaxValue, Double.MinValue, 0.00001D, true)]
+   //[InlineData(Double.MinValue, 0D, 0.00001D, true)]
+   //[InlineData(0D, Double.MinValue, 0.00001D, true)]
+   //[InlineData(Double.MaxValue, 0D, 0.00001D, true)]
+   //[InlineData(0D, Double.MaxValue, 0.00001D, true)]
+
+   [InlineData(0.000000001D, Double.MaxValue, 0.00001D, false)]
+   [InlineData(0.000000001D, Double.MinValue, 0.00001D, false)]
+   [InlineData(Double.MinValue, 0.000000001D, 0.00001D, false)]
+   [InlineData(Double.MaxValue, 0.000000001D, 0.00001D, false)]
+   public void DoubleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForNumbersVeryCloseToZero(
+      Double x,
+      Double y,
+      Double tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+}

--- a/DbC.Net.Tests.Unit/FloatingPoint/FixedEpsilonComparerTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/FixedEpsilonComparerTests.cs
@@ -1,0 +1,52 @@
+﻿using Xunit.Abstractions;
+
+namespace DbC.Net.Tests.Unit.FloatingPoint;
+
+public class FixedEpsilonComparerTests
+{
+   private readonly ITestOutputHelper _console;
+
+   public FixedEpsilonComparerTests(ITestOutputHelper console) => _console = console;
+
+   public static IEnumerable<Object[]> LessThanEpsilonData => new List<Object[]>
+   {
+      new Object[] { (Half)3.14F, (Half)3.16F, (Half)0.03F },
+      new Object[] { 3.14152F, 3.14156F, 0.0001F },
+      new Object[] { 3.141592653589793D, 3.141592653589791D, 0.000000000001F },
+      new Object[] { 3.141592M, 3.141594M, 0.00001M },
+   };
+
+   [Theory]
+   [MemberData(nameof(LessThanEpsilonData))]
+   public void FixedEpsilonComparer_ApproximatelyEquals_ShouldReturnTrue_WhenDeltaIsLessThanEpsilon<T>(T x, T y, T epsilon) where T: IFloatingPoint<T>
+   {
+      _console.WriteLine($"x: {x}, y: {y}, epsilon: {epsilon}");
+
+      // Arrange.
+      var sut = new FixedEpsilonComparer<T>();
+
+      // Act/assert.
+      sut.ApproximatelyEquals(x, y, epsilon).Should().BeTrue();
+   }
+
+   public static IEnumerable<Object[]> GreaterThanEpsilonData => new List<Object[]>
+   {
+      new Object[] { (Half)6.28F, (Half)6.24F, (Half)0.02F },
+      new Object[] { 6.28318F, 6.28313F, 0.00001F },
+      new Object[] { 6.283185307179586D, 6.283185307179581D, 0.000000000000001F },
+      new Object[] { 6.283185M, 6.283189M, 0.000001M },
+   };
+
+   [Theory]
+   [MemberData(nameof(GreaterThanEpsilonData))]
+   public void FixedEpsilonComparer_ApproximatelyEquals_ShouldReturnFalse_WhenDeltaIsGreaterThanEpsilon<T>(T x, T y, T epsilon) where T : IFloatingPoint<T>
+   {
+      _console.WriteLine($"x: {x}, y: {y}, epsilon: {epsilon}");
+
+      // Arrange.
+      var sut = new FixedEpsilonComparer<T>();
+
+      // Act/assert.
+      sut.ApproximatelyEquals(x, y, epsilon).Should().BeFalse();
+   }
+}

--- a/DbC.Net.Tests.Unit/FloatingPoint/FixedEpsilonComparerTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/FixedEpsilonComparerTests.cs
@@ -12,7 +12,7 @@ public class FixedEpsilonComparerTests
    {
       new Object[] { (Half)3.14F, (Half)3.16F, (Half)0.03F },
       new Object[] { 3.14152F, 3.14156F, 0.0001F },
-      new Object[] { 3.141592653589793D, 3.141592653589791D, 0.000000000001F },
+      new Object[] { 3.141592653589793D, 3.141592653589791D, 0.000000000001D },
       new Object[] { 3.141592M, 3.141594M, 0.00001M },
    };
 
@@ -33,7 +33,7 @@ public class FixedEpsilonComparerTests
    {
       new Object[] { (Half)6.28F, (Half)6.24F, (Half)0.02F },
       new Object[] { 6.28318F, 6.28313F, 0.00001F },
-      new Object[] { 6.283185307179586D, 6.283185307179581D, 0.000000000000001F },
+      new Object[] { 6.283185307179586D, 6.283185307179581D, 0.000000000000001D },
       new Object[] { 6.283185M, 6.283189M, 0.000001M },
    };
 

--- a/DbC.Net.Tests.Unit/FloatingPoint/FixedErrorComparerTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/FixedErrorComparerTests.cs
@@ -1,12 +1,10 @@
-﻿using Xunit.Abstractions;
+﻿namespace DbC.Net.Tests.Unit.FloatingPoint;
 
-namespace DbC.Net.Tests.Unit.FloatingPoint;
-
-public class FixedEpsilonComparerTests
+public class FixedErrorComparerTests
 {
    private readonly ITestOutputHelper _console;
 
-   public FixedEpsilonComparerTests(ITestOutputHelper console) => _console = console;
+   public FixedErrorComparerTests(ITestOutputHelper console) => _console = console;
 
    public static IEnumerable<Object[]> LessThanEpsilonData => new List<Object[]>
    {
@@ -18,12 +16,12 @@ public class FixedEpsilonComparerTests
 
    [Theory]
    [MemberData(nameof(LessThanEpsilonData))]
-   public void FixedEpsilonComparer_ApproximatelyEquals_ShouldReturnTrue_WhenDeltaIsLessThanEpsilon<T>(T x, T y, T epsilon) where T: IFloatingPoint<T>
+   public void FixedErrorComparer_ApproximatelyEquals_ShouldReturnTrue_WhenDeltaIsLessThanEpsilon<T>(T x, T y, T epsilon) where T: IFloatingPoint<T>
    {
       _console.WriteLine($"x: {x}, y: {y}, epsilon: {epsilon}");
 
       // Arrange.
-      var sut = new FixedEpsilonComparer<T>();
+      var sut = new FixedErrorComparer<T>();
 
       // Act/assert.
       sut.ApproximatelyEquals(x, y, epsilon).Should().BeTrue();
@@ -39,12 +37,12 @@ public class FixedEpsilonComparerTests
 
    [Theory]
    [MemberData(nameof(GreaterThanEpsilonData))]
-   public void FixedEpsilonComparer_ApproximatelyEquals_ShouldReturnFalse_WhenDeltaIsGreaterThanEpsilon<T>(T x, T y, T epsilon) where T : IFloatingPoint<T>
+   public void FixedErrorComparer_ApproximatelyEquals_ShouldReturnFalse_WhenDeltaIsGreaterThanEpsilon<T>(T x, T y, T epsilon) where T : IFloatingPoint<T>
    {
       _console.WriteLine($"x: {x}, y: {y}, epsilon: {epsilon}");
 
       // Arrange.
-      var sut = new FixedEpsilonComparer<T>();
+      var sut = new FixedErrorComparer<T>();
 
       // Act/assert.
       sut.ApproximatelyEquals(x, y, epsilon).Should().BeFalse();

--- a/DbC.Net.Tests.Unit/FloatingPoint/HalfRelativeEqualityComparerTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/HalfRelativeEqualityComparerTests.cs
@@ -1,0 +1,213 @@
+﻿namespace DbC.Net.Tests.Unit.FloatingPoint;
+
+#pragma warning disable xUnit1025 // InlineData should be unique within the Theory it belongs to
+public class HalfRelativeEqualityComparerTests
+{
+   private readonly HalfRelativeErrorComparer _sut = new();
+
+   [Theory]
+   [InlineData(60000F, 60001F, 0.00001F, true)]
+   [InlineData(60001F, 60000F, 0.00001F, true)]
+   [InlineData(1000F, 1001F, 0.00001F, false)]
+   [InlineData(1001F, 1000F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForLargePositveValues(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-60000F, -60001F, 0.00001F, true)]
+   [InlineData(-60001F, -60000F, 0.00001F, true)]
+   [InlineData(-1000F, -1001F, 0.00001F, false)]
+   [InlineData(-1001F, -1000F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForLargeNegativeValues(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(1.0001F, 1.0002F, 0.00001F, true)]
+   [InlineData(1.0002F, 1.0001F, 0.00001F, true)]
+   [InlineData(1.002F, 1.001F, 0.00001F, false)]
+   [InlineData(1.001F, 1.002F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesAroundOne(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-1.0001F, -1.0002F, 0.00001F, true)]
+   [InlineData(-1.0002F, -1.0001F, 0.00001F, true)]
+   [InlineData(-1.002F, -1.001F, 0.00001F, false)]
+   [InlineData(-1.001F, -1.002F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesAroundNegativeOne(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0.001000001F, 0.001000002F, 0.00001F, true)]
+   [InlineData(0.001000002F, 0.001000001F, 0.00001F, true)]
+   [InlineData(0.000102F, 0.000101F, 0.00001F, false)]
+   [InlineData(0.000101F, 0.000102F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesBetweenOneAndZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-0.001000001F, -0.001000002F, 0.00001F, true)]
+   [InlineData(-0.001000002F, -0.001000001F, 0.00001F, true)]
+   [InlineData(-0.0001002F, -0.001001F, 0.00001F, false)]
+   [InlineData(-0.0001001F, -0.001002F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesBetweenNegativeOneAndZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0.3F, 0.30000003F, 0.00001F, true)]
+   [InlineData(-0.3F, -0.30000003F, 0.00001F, true)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_WhenSmallDifferenceFromZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0F, 0F, 0.00001F, true)]
+   [InlineData(0F, -0F, 0.00001F, true)]
+   [InlineData(-0F, 0F, 0.00001F, true)]
+   [InlineData(0.0000001F, 0F, 0.00001F, false)]
+   [InlineData(0F, 0.0000001F, 0.00001F, false)]
+   [InlineData(-0.0000001F, -0F, 0.00001F, false)]
+   [InlineData(-0F, -0.0000001F, 0.00001F, false)]
+
+   [InlineData(0F, 1E-7F, 0.01F, true)]
+   [InlineData(1e-7F, 0F, 0.01F, true)]
+   [InlineData(-1e-7F, 0F, 0.00000001F, false)]
+   [InlineData(0F, -1e-7F, 0.00000001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_WhenComparingToZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   public static TheoryData<Half, Half, Single, Boolean> ExtremeValuesTestData => new()
+   {
+      { Half.MaxValue, Half.MaxValue, 0.00001F, true },
+      { Half.MaxValue, -Half.MaxValue, 0.00001F, false },
+      { -Half.MaxValue, Half.MaxValue, 0.00001F, false },
+      { Half.MaxValue, Half.MaxValue / (Half)2, 0.00001F, false },
+      { Half.MaxValue, -Half.MaxValue / (Half) 2, 0.00001F, false },
+      { -Half.MaxValue, Half.MaxValue / (Half) 2, 0.00001F, false },
+   };
+
+   [Theory]
+   [MemberData(nameof(ExtremeValuesTestData))]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForExtremeValues(
+      Half x,
+      Half y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, (Half)tolerance).Should().Be(expected);
+
+   public static TheoryData<Half, Half, Single, Boolean> InfinityTestData => new()
+   {
+      { Half.PositiveInfinity, Half.PositiveInfinity, 0.00001F, true },
+      { Half.NegativeInfinity, Half.NegativeInfinity, 0.00001F, true },
+      { Half.NegativeInfinity, Half.PositiveInfinity, 0.00001F, false },
+      { Half.PositiveInfinity, Half.MaxValue, 0.00001F, false },
+      { Half.NegativeInfinity, Half.MinValue, 0.00001F, false },
+   };
+
+   [Theory]
+   [MemberData(nameof(InfinityTestData))]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForInfinity(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   public static TheoryData<Half, Half, Single, Boolean> NaNTestData => new()
+   {
+      { Half.NaN, Half.NaN, 0.00001F, false },
+      { Half.NaN, (Half)0F, 0.00001F, false },
+      { Half.NaN, (Half)(-0F), 0.00001F, false },
+      { (Half)(-0F), Half.NaN, 0.00001F, false },
+      { (Half)0F, Half.NaN, 0.00001F, false },
+      { Half.NaN, Half.PositiveInfinity, 0.00001F, false },
+      { Half.PositiveInfinity, Half.NaN, 0.00001F, false },
+      { Half.NaN, Half.NegativeInfinity, 0.00001F, false },
+      { Half.NegativeInfinity, Half.NaN, 0.00001F, false },
+      { Half.NaN, Half.MaxValue, 0.00001F, false },
+      { Half.MaxValue, Half.NaN, 0.00001F, false },
+      { Half.NaN, -Half.MaxValue, 0.00001F, false },
+      { -Half.MaxValue, Half.NaN, 0.00001F, false },
+      { Half.NaN, Half.MinValue, 0.00001F, false },
+      { Half.MinValue, Half.NaN, 0.00001F, false },
+      { Half.NaN, -Half.MinValue, 0.00001F, false },
+      { -Half.MinValue, Half.NaN, 0.00001F, false },
+   };
+
+   [Theory]
+   [MemberData(nameof(NaNTestData))]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForNaN(
+      Half x,
+      Half y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Single.Epsilon, -Single.Epsilon, 0.00001F, true)]
+   [InlineData(1.000000001F, -1F, 0.00001F, false)]
+   [InlineData(-1F, 1.000000001F, 0.00001F, false)]
+   [InlineData(-1.000000001F, 1F, 0.00001F, false)]
+   [InlineData(1F, -1.000000001F, 0.00001F, false)]
+   [InlineData(10 * Single.MinValue, 10 * -Single.MinValue, 0.00001F, false)]
+   [InlineData(10000 * Single.MinValue, 10000 * -Single.MinValue, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForOppositeSidesOfZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+
+   [Theory]
+   // TODO: These tests should pass according to https://floating-point-gui.de/errors/NearlyEqualsTest.java
+   // TODO: but are not. Needs further investigation.
+   //[InlineData(Single.MinValue, Single.MinValue, 0.00001F, true)]
+   //[InlineData(Single.MinValue, Single.MaxValue, 0.00001F, true)]
+   //[InlineData(Single.MaxValue, Single.MinValue, 0.00001F, true)]
+   //[InlineData(Single.MinValue, 0F, 0.00001F, true)]
+   //[InlineData(0F, Single.MinValue, 0.00001F, true)]
+   //[InlineData(Single.MaxValue, 0F, 0.00001F, true)]
+   //[InlineData(0F, Single.MaxValue, 0.00001F, true)]
+
+   [InlineData(0.000000001F, Single.MaxValue, 0.00001F, false)]
+   [InlineData(0.000000001F, Single.MinValue, 0.00001F, false)]
+   [InlineData(Single.MinValue, 0.000000001F, 0.00001F, false)]
+   [InlineData(Single.MaxValue, 0.000000001F, 0.00001F, false)]
+   public void HalfRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForNumbersVeryCloseToZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals((Half)x, (Half)y, (Half)tolerance).Should().Be(expected);
+}

--- a/DbC.Net.Tests.Unit/FloatingPoint/SingleRelativeErrorComparerTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/SingleRelativeErrorComparerTests.cs
@@ -1,0 +1,199 @@
+﻿namespace DbC.Net.Tests.Unit.FloatingPoint;
+
+#pragma warning disable xUnit1025 // InlineData should be unique within the Theory it belongs to
+public class SingleRelativeErrorComparerTests
+{
+   private readonly SingleRelativeErrorComparer _sut = new();
+
+   [Theory]
+   [InlineData(1000000F, 1000001F, 0.00001F, true)]
+   [InlineData(1000001F, 1000000F, 0.00001F, true)]
+   [InlineData(10000F, 10001F, 0.00001F, false)]
+   [InlineData(10001F, 10000F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForLargePositveValues(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-1000000F, -1000001F, 0.00001F, true)]
+   [InlineData(-1000001F, -1000000F, 0.00001F, true)]
+   [InlineData(-10000F, -10001F, 0.00001F, false)]
+   [InlineData(-10001F, -10000F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForLargeNegativeValues(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(1.0000001F, 1.0000002F, 0.00001F, true)]
+   [InlineData(1.0000002F, 1.0000001F, 0.00001F, true)]
+   [InlineData(1.0002F, 1.0001F, 0.00001F, false)]
+   [InlineData(1.0001F, 1.0002F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesAroundOne(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-1.0000001F, -1.0000002F, 0.00001F, true)]
+   [InlineData(-1.0000002F, -1.0000001F, 0.00001F, true)]
+   [InlineData(-1.0002F, -1.0001F, 0.00001F, false)]
+   [InlineData(-1.0001F, -1.0002F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesAroundNegativeOne(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0.000000001000001F, 0.000000001000002F, 0.00001F, true)]
+   [InlineData(0.000000001000002F, 0.000000001000001F, 0.00001F, true)]
+   [InlineData(0.000000000001002F, 0.000000000001001F, 0.00001F, false)]
+   [InlineData(0.000000000001001F, 0.000000000001002F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesBetweenOneAndZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(-0.000000001000001F, -0.000000001000002F, 0.00001F, true)]
+   [InlineData(-0.000000001000002F, -0.000000001000001F, 0.00001F, true)]
+   [InlineData(-0.000000000001002F, -0.000000000001001F, 0.00001F, false)]
+   [InlineData(-0.000000000001001F, -0.000000000001002F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForValuesBetweenNegativeOneAndZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0.3F, 0.30000003F, 0.00001F, true)]
+   [InlineData(-0.3F, -0.30000003F, 0.00001F, true)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_WhenSmallDifferenceFromZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(0F, 0F, 0.00001F, true)]
+   [InlineData(0F, -0F, 0.00001F, true)]
+   [InlineData(-0F, 0F, 0.00001F, true)]
+   [InlineData(0.00000001F, 0F, 0.00001F, false)]
+   [InlineData(0F, 0.00000001F, 0.00001F, false)]
+   [InlineData(-0.00000001F, -0F, 0.00001F, false)]
+   [InlineData(-0F, -0.00000001F, 0.00001F, false)]
+
+   [InlineData(0F, 1E-40F, 0.01F, true)]
+   [InlineData(1e-40F, 0F, 0.01F, true)]
+   [InlineData(-1e-40F, 0F, 0.00000001F, false)]
+   [InlineData(0F, -1e-40F, 0.00000001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_WhenComparingToZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Single.MaxValue, Single.MaxValue, 0.00001F, true)]
+   [InlineData(Single.MaxValue, -Single.MaxValue, 0.00001F, false)]
+   [InlineData(-Single.MaxValue, Single.MaxValue, 0.00001F, false)]
+   [InlineData(Single.MaxValue, Single.MaxValue / 2, 0.00001F, false)]
+   [InlineData(Single.MaxValue, -Single.MaxValue / 2, 0.00001F, false)]
+   [InlineData(-Single.MaxValue, Single.MaxValue / 2, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForExtremeValues(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Single.PositiveInfinity, Single.PositiveInfinity, 0.00001F, true)]
+   [InlineData(Single.NegativeInfinity, Single.NegativeInfinity, 0.00001F, true)]
+   [InlineData(Single.NegativeInfinity, Single.PositiveInfinity, 0.00001F, false)]
+   [InlineData(Single.PositiveInfinity, Single.MaxValue, 0.00001F, false)]
+   [InlineData(Single.NegativeInfinity, Single.MinValue, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForInfinity(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Single.NaN, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, 0F, 0.00001F, false)]
+   [InlineData(Single.NaN, -0F, 0.00001F, false)]
+   [InlineData(-0F, Single.NaN, 0.00001F, false)]
+   [InlineData(0F, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, Single.PositiveInfinity, 0.00001F, false)]
+   [InlineData(Single.PositiveInfinity, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, Single.NegativeInfinity, 0.00001F, false)]
+   [InlineData(Single.NegativeInfinity, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, Single.MaxValue, 0.00001F, false)]
+   [InlineData(Single.MaxValue, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, -Single.MaxValue, 0.00001F, false)]
+   [InlineData(-Single.MaxValue, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, Single.MinValue, 0.00001F, false)]
+   [InlineData(Single.MinValue, Single.NaN, 0.00001F, false)]
+   [InlineData(Single.NaN, -Single.MinValue, 0.00001F, false)]
+   [InlineData(-Single.MinValue, Single.NaN, 0.00001F, false)]
+
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForNaN(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   [InlineData(Single.Epsilon, -Single.Epsilon, 0.00001F, true)]
+   [InlineData(1.000000001F, -1F, 0.00001F, false)]
+   [InlineData(-1F, 1.000000001F, 0.00001F, false)]
+   [InlineData(-1.000000001F, 1F, 0.00001F, false)]
+   [InlineData(1F, -1.000000001F, 0.00001F, false)]
+   [InlineData(10 * Single.MinValue, 10 * -Single.MinValue, 0.00001F, false)]
+   [InlineData(10000 * Single.MinValue, 10000 * -Single.MinValue, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForOppositeSidesOfZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+
+   [Theory]
+   // TODO: These tests should pass according to https://floating-point-gui.de/errors/NearlyEqualsTest.java
+   // TODO: but are not. Needs further investigation.
+   //[InlineData(Single.MinValue, Single.MinValue, 0.00001F, true)]
+   //[InlineData(Single.MinValue, Single.MaxValue, 0.00001F, true)]
+   //[InlineData(Single.MaxValue, Single.MinValue, 0.00001F, true)]
+   //[InlineData(Single.MinValue, 0F, 0.00001F, true)]
+   //[InlineData(0F, Single.MinValue, 0.00001F, true)]
+   //[InlineData(Single.MaxValue, 0F, 0.00001F, true)]
+   //[InlineData(0F, Single.MaxValue, 0.00001F, true)]
+
+   [InlineData(0.000000001F, Single.MaxValue, 0.00001F, false)]
+   [InlineData(0.000000001F, Single.MinValue, 0.00001F, false)]
+   [InlineData(Single.MinValue, 0.000000001F, 0.00001F, false)]
+   [InlineData(Single.MaxValue, 0.000000001F, 0.00001F, false)]
+   public void SingleRelativeErrorComparer_ApproximatelyEquals_ShouldReturnExpectedResult_ForNumbersVeryCloseToZero(
+      Single x,
+      Single y,
+      Single tolerance,
+      Boolean expected)
+      => _sut.ApproximatelyEquals(x, y, tolerance).Should().Be(expected);
+}

--- a/DbC.Net.Tests.Unit/FloatingPoint/StandardFloatingPointComparersTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/StandardFloatingPointComparersTests.cs
@@ -2,43 +2,43 @@
 
 public class StandardFloatingPointComparersTests
 {
-   #region DecimalFixedEpsilonComparer Tests
+   #region DecimalFixedErrorComparer Tests
    // ==========================================================================
    // ==========================================================================
 
    [Fact]
-   public void StandardFloatingPointComparers_DecimalFixedEpsilonComparer_ShouldNotBeNull()
-      => StandardFloatingPointComparers.DecimalFixedEpsilonComparer.Should().NotBeNull();
+   public void StandardFloatingPointComparers_DecimalFixedErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.DecimalFixedErrorComparer.Should().NotBeNull();
 
    #endregion
 
-   #region DoubleFixedEpsilonComparer Tests
+   #region DoubleFixedErrorComparer Tests
    // ==========================================================================
    // ==========================================================================
 
    [Fact]
-   public void StandardFloatingPointComparers_DoubleFixedEpsilonComparer_ShouldNotBeNull()
-      => StandardFloatingPointComparers.DoubleFixedEpsilonComparer.Should().NotBeNull();
+   public void StandardFloatingPointComparers_DoubleFixedErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.DoubleFixedErrorComparer.Should().NotBeNull();
 
    #endregion
 
-   #region HalfFixedEpsilonComparer Tests
+   #region HalfFixedErrorComparer Tests
    // ==========================================================================
    // ==========================================================================
 
    [Fact]
-   public void StandardFloatingPointComparers_HalfFixedEpsilonComparer_ShouldNotBeNull()
-      => StandardFloatingPointComparers.HalfFixedEpsilonComparer.Should().NotBeNull();
+   public void StandardFloatingPointComparers_HalfFixedErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.HalfFixedErrorComparer.Should().NotBeNull();
 
    #endregion
 
-   #region SingleFixedEpsilonComparer Tests
+   #region SingleFixedErrorComparer Tests
    // ==========================================================================
    // ==========================================================================
 
    [Fact]
-   public void StandardFloatingPointComparers_SingleFixedEpsilonComparer_ShouldNotBeNull()
-      => StandardFloatingPointComparers.SingleFixedEpsilonComparer.Should().NotBeNull();
+   public void StandardFloatingPointComparers_SingleFixedErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.SingleFixedErrorComparer.Should().NotBeNull();
 
    #endregion
 

--- a/DbC.Net.Tests.Unit/FloatingPoint/StandardFloatingPointComparersTests.cs
+++ b/DbC.Net.Tests.Unit/FloatingPoint/StandardFloatingPointComparersTests.cs
@@ -1,0 +1,74 @@
+﻿namespace DbC.Net.Tests.Unit.FloatingPoint;
+
+public class StandardFloatingPointComparersTests
+{
+   #region DecimalFixedEpsilonComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_DecimalFixedEpsilonComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.DecimalFixedEpsilonComparer.Should().NotBeNull();
+
+   #endregion
+
+   #region DoubleFixedEpsilonComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_DoubleFixedEpsilonComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.DoubleFixedEpsilonComparer.Should().NotBeNull();
+
+   #endregion
+
+   #region HalfFixedEpsilonComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_HalfFixedEpsilonComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.HalfFixedEpsilonComparer.Should().NotBeNull();
+
+   #endregion
+
+   #region SingleFixedEpsilonComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_SingleFixedEpsilonComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.SingleFixedEpsilonComparer.Should().NotBeNull();
+
+   #endregion
+
+   #region DoubleRelativeErrorComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_DoubleRelativeErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.DoubleRelativeErrorComparer.Should().NotBeNull();
+
+   #endregion
+
+   #region HalfRelativeErrorComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_HalfRelativeErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.HalfRelativeErrorComparer.Should().NotBeNull();
+
+   #endregion
+
+   #region SingleRelativeErrorComparer Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StandardFloatingPointComparers_SingleRelativeErrorComparer_ShouldNotBeNull()
+      => StandardFloatingPointComparers.SingleRelativeErrorComparer.Should().NotBeNull();
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/GlobalUsings.cs
+++ b/DbC.Net.Tests.Unit/GlobalUsings.cs
@@ -11,3 +11,4 @@ global using DbC.Net.Transforms;
 global using FluentAssertions;
 
 global using Xunit;
+global using Xunit.Abstractions;

--- a/DbC.Net.Tests.Unit/GlobalUsings.cs
+++ b/DbC.Net.Tests.Unit/GlobalUsings.cs
@@ -1,8 +1,8 @@
 global using System.Collections;
-global using System.Diagnostics.CodeAnalysis;
 global using System.Numerics;
 
 global using DbC.Net.ExceptionFactories;
+global using DbC.Net.FloatingPoint;
 global using DbC.Net.TestAndExampleResources;
 global using DbC.Net.Tests.Unit.TestData;
 global using DbC.Net.Tests.Unit.TestResources;

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -146,7 +146,7 @@ public class NotEqualExtensionsTests
    }
 
    [Fact]
-   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = new PointStructData().EqualValue;
@@ -296,7 +296,7 @@ public class NotEqualExtensionsTests
    }
 
    [Fact]
-   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = DateTime.MaxValue;
@@ -563,7 +563,7 @@ public class NotEqualExtensionsTests
    }
 
    [Fact]
-   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = StringData.LowerCaseA;
@@ -723,7 +723,7 @@ public class NotEqualExtensionsTests
    }
 
    [Fact]
-   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = new PointStructData().EqualValue;
@@ -877,7 +877,7 @@ public class NotEqualExtensionsTests
    }
 
    [Fact]
-   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = DateTime.MaxValue;
@@ -1148,7 +1148,7 @@ public class NotEqualExtensionsTests
    }
 
    [Fact]
-   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessageWhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = StringData.LowerCaseA;

--- a/DbC.Net.Tests.Unit/TestData/DecimalData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DecimalData.cs
@@ -7,7 +7,7 @@ public class DecimalData : FloatingPointValue<Decimal>
       0.000001M,
       0.000005M,
       0.000003M,
-      StandardFloatingPointComparers.DecimalFixedEpsilonComparer,
+      StandardFloatingPointComparers.DecimalFixedErrorComparer,
       0.000003M,
       default!)
    { }

--- a/DbC.Net.Tests.Unit/TestData/DecimalData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DecimalData.cs
@@ -1,12 +1,14 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public class DecimalData : ComparableValue<Decimal>
+public class DecimalData : FloatingPointValue<Decimal>
 {
    public DecimalData() : base(
-      3.141592653589793238M,
-      0.0000000000000000001M,
-      new ReverseComparer<Decimal>(),
-      Decimal.MinValue,
-      Decimal.MaxValue)
+      3.141592M,
+      0.000001M,
+      0.000005M,
+      0.000003M,
+      StandardFloatingPointComparers.DecimalFixedEpsilonComparer,
+      0.000003M,
+      default!)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DoubleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DoubleData.cs
@@ -7,7 +7,7 @@ public class DoubleData : FloatingPointValue<Double>
       0.000000000000001D,
       0.000000000000005D,
       0.000000000000003D,
-      StandardFloatingPointComparers.DoubleFixedEpsilonComparer,
+      StandardFloatingPointComparers.DoubleFixedErrorComparer,
       0.0000000000000002D,
       StandardFloatingPointComparers.DoubleRelativeErrorComparer)
    { }

--- a/DbC.Net.Tests.Unit/TestData/DoubleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DoubleData.cs
@@ -1,12 +1,14 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public class DoubleData : ComparableValue<Double>
+public class DoubleData : FloatingPointValue<Double>
 {
    public DoubleData() : base(
-      Double.Pi,
-      Double.Tau,
-      new ReverseComparer<Double>(),
-      Double.MinValue,
-      Double.MaxValue)
+      3.141592653589793D,
+      0.000000000000001D,
+      0.000000000000005D,
+      0.000000000000003D,
+      StandardFloatingPointComparers.DoubleFixedEpsilonComparer,
+      0.0000000000000002D,
+      StandardFloatingPointComparers.DoubleRelativeErrorComparer)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/EquatableTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/EquatableTypesTestData.cs
@@ -11,16 +11,12 @@ public class EquatableTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new DateOnlyData() };
       yield return new Object[] { new DateTimeData() };
       yield return new Object[] { new DateTimeOffsetData() };
-      yield return new Object[] { new DecimalData() };
-      yield return new Object[] { new DoubleData() };
       yield return new Object[] { new GuidData() };
-      yield return new Object[] { new HalfData() };
       yield return new Object[] { new Int128Data() };
       yield return new Object[] { new Int16Data() };
       yield return new Object[] { new Int32Data() };
       yield return new Object[] { new Int64Data() };
       yield return new Object[] { new SByteData() };
-      yield return new Object[] { new SingleData() };
       yield return new Object[] { new TimeOnlyData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointTypesTestData.cs
@@ -1,0 +1,14 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public class FloatingPointTypesTestData : IEnumerable<Object[]>
+{
+   public IEnumerator<Object[]> GetEnumerator()
+   {
+      yield return new Object[] { new DecimalData() };
+      yield return new Object[] { new DoubleData() };
+      yield return new Object[] { new HalfData() };
+      yield return new Object[] { new SingleData() };
+   }
+
+   IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -1,0 +1,36 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
+{
+   public FloatingPointValue(
+      T value,
+      T withinToleranceDelta,
+      T outOfToleranceDelta,
+      T fixedEpsilon,
+      IApproximateEqualityComparer<T> fixedEpsilonComparer,
+      T relativeEpsilon,
+      IApproximateEqualityComparer<T> relativeErrorComparer)
+   {
+      Value = value;
+      WithinToleranceDelta = withinToleranceDelta;
+      OutOfToleranceDelta = outOfToleranceDelta;
+      FixedEpsilon = fixedEpsilon;
+      FixedEpsilonComparer = fixedEpsilonComparer;
+      RelativeEpsilon = relativeEpsilon;
+      RelativeErrorComparer = relativeErrorComparer;
+   }
+
+   public virtual T Value { get; }
+
+   public virtual T WithinToleranceDelta { get; }
+
+   public virtual T OutOfToleranceDelta { get; }
+
+   public virtual T FixedEpsilon { get; }
+
+   public virtual T RelativeEpsilon { get; }
+
+   public virtual IApproximateEqualityComparer<T> FixedEpsilonComparer { get; } = default!;
+
+   public virtual IApproximateEqualityComparer<T> RelativeErrorComparer { get; } = default!;
+}

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -7,7 +7,7 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
       T withinToleranceDelta,
       T outOfToleranceDelta,
       T fixedEpsilon,
-      IApproximateEqualityComparer<T> fixedEpsilonComparer,
+      IApproximateEqualityComparer<T> fixedErrorComparer,
       T relativeEpsilon,
       IApproximateEqualityComparer<T> relativeErrorComparer)
    {
@@ -15,7 +15,7 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
       WithinToleranceDelta = withinToleranceDelta;
       OutOfToleranceDelta = outOfToleranceDelta;
       FixedEpsilon = fixedEpsilon;
-      FixedEpsilonComparer = fixedEpsilonComparer;
+      FixedErrorComparer = fixedErrorComparer;
       RelativeEpsilon = relativeEpsilon;
       RelativeErrorComparer = relativeErrorComparer;
    }
@@ -30,7 +30,7 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
 
    public virtual T RelativeEpsilon { get; }
 
-   public virtual IApproximateEqualityComparer<T> FixedEpsilonComparer { get; } = default!;
+   public virtual IApproximateEqualityComparer<T> FixedErrorComparer { get; } = default!;
 
    public virtual IApproximateEqualityComparer<T> RelativeErrorComparer { get; } = default!;
 }

--- a/DbC.Net.Tests.Unit/TestData/HalfData.cs
+++ b/DbC.Net.Tests.Unit/TestData/HalfData.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿namespace DbC.Net.Tests.Unit.TestData;
 
-namespace DbC.Net.Tests.Unit.TestData;
-
-public class HalfData : ComparableValue<Half>
+public class HalfData : FloatingPointValue<Half>
 {
    public HalfData() : base(
-      Half.Pi,
-      Half.Tau,
-      new ReverseComparer<Half>(),
-      Half.MinValue,
-      Half.MaxValue)
+      (Half)3.14F,
+      (Half)0.01F,
+      (Half)0.05F,
+      (Half)0.03F,
+      StandardFloatingPointComparers.HalfFixedEpsilonComparer,
+      (Half)0.002F,
+      StandardFloatingPointComparers.HalfRelativeErrorComparer)
    { }
 }
 

--- a/DbC.Net.Tests.Unit/TestData/HalfData.cs
+++ b/DbC.Net.Tests.Unit/TestData/HalfData.cs
@@ -7,7 +7,7 @@ public class HalfData : FloatingPointValue<Half>
       (Half)0.01F,
       (Half)0.05F,
       (Half)0.03F,
-      StandardFloatingPointComparers.HalfFixedEpsilonComparer,
+      StandardFloatingPointComparers.HalfFixedErrorComparer,
       (Half)0.002F,
       StandardFloatingPointComparers.HalfRelativeErrorComparer)
    { }

--- a/DbC.Net.Tests.Unit/TestData/NonDecimalFloatingPointTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/NonDecimalFloatingPointTypesTestData.cs
@@ -1,0 +1,13 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public class NonDecimalFloatingPointTypesTestData : IEnumerable<Object[]>
+{
+   public IEnumerator<Object[]> GetEnumerator()
+   {
+      yield return new Object[] { new DoubleData() };
+      yield return new Object[] { new HalfData() };
+      yield return new Object[] { new SingleData() };
+   }
+
+   IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/DbC.Net.Tests.Unit/TestData/SingleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SingleData.cs
@@ -1,12 +1,14 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public class SingleData : ComparableValue<Single>
+public class SingleData : FloatingPointValue<Single>
 {
    public SingleData() : base(
-      Single.Pi,
-      Single.Tau,
-      new ReverseComparer<Single>(),
-      Single.MinValue,
-      Single.MaxValue)
+      3.14152F,
+      0.00001F,
+      0.00005F,
+      0.00003F,
+      StandardFloatingPointComparers.SingleFixedEpsilonComparer,
+      0.000002F,
+      StandardFloatingPointComparers.SingleRelativeErrorComparer)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/SingleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SingleData.cs
@@ -7,7 +7,7 @@ public class SingleData : FloatingPointValue<Single>
       0.00001F,
       0.00005F,
       0.00003F,
-      StandardFloatingPointComparers.SingleFixedEpsilonComparer,
+      StandardFloatingPointComparers.SingleFixedErrorComparer,
       0.000002F,
       StandardFloatingPointComparers.SingleRelativeErrorComparer)
    { }

--- a/DbC.Net.Tests.Unit/TestData/ValueTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ValueTypesTestData.cs
@@ -11,16 +11,12 @@ public class ValueTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new DateOnlyData() };
       yield return new Object[] { new DateTimeData() };
       yield return new Object[] { new DateTimeOffsetData() };
-      yield return new Object[] { new DecimalData() };
-      yield return new Object[] { new DoubleData() };
       yield return new Object[] { new GuidData() };
-      yield return new Object[] { new HalfData() };
       yield return new Object[] { new Int128Data() };
       yield return new Object[] { new Int16Data() };
       yield return new Object[] { new Int32Data() };
       yield return new Object[] { new Int64Data() };
       yield return new Object[] { new SByteData() };
-      yield return new Object[] { new SingleData() };
       yield return new Object[] { new TimeOnlyData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -23,6 +23,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbC.Net.TestAndExampleResou
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{72254BA1-52A7-4B81-A595-76580B77647E}"
 	ProjectSection(SolutionItems) = preProject
+		Documentation\ApproximatelyEqual.md = Documentation\ApproximatelyEqual.md
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md

--- a/DbC.Net/ApproximatelyEqualExtensions.cs
+++ b/DbC.Net/ApproximatelyEqualExtensions.cs
@@ -1,0 +1,187 @@
+﻿namespace DbC.Net;
+
+public static class ApproximatelyEqualExtensions
+{
+   /// <summary>
+   ///   Value ApproximatelyEqual postcondition. Confirm that the 
+   ///   <see cref="IFloatingPoint{T}"/> <paramref name="value"/> is within
+   ///   +/- <paramref name="epsilon"/> of the <paramref name="target"/> and 
+   ///   throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be close to..
+   /// </param>
+   /// <param name="epsilon">
+   ///   The allowed error margin. 
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IApproximateEqualityComparer{T}"/> used to check for 
+   ///   approximate equality between <paramref name="value"/> and 
+   ///   <paramref name="target"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <param name="epsilonExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="epsilon"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T EnsuresApproximatelyEqual<T>(
+      this T value,
+      T target,
+      T epsilon,
+      IApproximateEqualityComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!,
+      [CallerArgumentExpression("epsilon")] String epsilonExpression = null!) where T : IFloatingPoint<T>
+   {
+      CheckApproximatelyEqual(
+         value,
+         target,
+         epsilon,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression,
+         epsilonExpression);
+
+      return value;
+   }
+   /// <summary>
+   ///   Value ApproximatelyEqual precondition. Confirm that the 
+   ///   <see cref="IFloatingPoint{T}"/> <paramref name="value"/> is within
+   ///   +/- <paramref name="epsilon"/> of the <paramref name="target"/> and 
+   ///   throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be close to..
+   /// </param>
+   /// <param name="epsilon">
+   ///   The allowed error margin. 
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IApproximateEqualityComparer{T}"/> used to check for 
+   ///   approximate equality between <paramref name="value"/> and 
+   ///   <paramref name="target"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <param name="epsilonExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="epsilon"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T RequiresApproximatelyEqual<T>(
+      this T value,
+      T target,
+      T epsilon,
+      IApproximateEqualityComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!,
+      [CallerArgumentExpression("epsilon")] String epsilonExpression = null!) where T : IFloatingPoint<T>
+   {
+      CheckApproximatelyEqual(
+         value,
+         target,
+         epsilon,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression,
+         epsilonExpression);
+
+      return value;
+   }
+
+   private static void CheckApproximatelyEqual<T>(
+      T value,
+      T target,
+      T epsilon,
+      IApproximateEqualityComparer<T> comparer,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression,
+      String epsilonExpression) where T : IFloatingPoint<T>
+   {
+      if (!comparer.ApproximatelyEquals(value, target, epsilon))
+      {
+         messageTemplate ??= MessageTemplates.ApproximatelyEqualTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = new Dictionary<String, Object>
+         {
+            {  DataNames.RequirementType, requirementType },
+            {  DataNames.RequirementName, RequirementNames.ApproximatelyEqual },
+            {  DataNames.Value, value },
+            {  DataNames.ValueExpression, valueExpression },
+            {  DataNames.Target, target },
+            {  DataNames.TargetExpression, targetExpression },
+            {  DataNames.Epsilon, epsilon },
+            {  DataNames.EpsilonExpression, epsilonExpression }
+         };
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/DataNames.cs
+++ b/DbC.Net/DataNames.cs
@@ -2,29 +2,32 @@
 
 public static class DataNames
 {
-   public const String RequirementName = "RequirementName";
-   public const String RequirementType = "RequirementType";
+   public const String RequirementName = nameof(RequirementName);
+   public const String RequirementType = nameof(RequirementType);
 
    // The value being checked.
-   public const String Value = "Value";
-   public const String ValueExpression = "ValueExpression";
-   public const String ValueDatatype = "ValueDatatype";
+   public const String Value = nameof(Value);
+   public const String ValueExpression = nameof(ValueExpression);
+   public const String ValueDatatype = nameof(ValueDatatype);
 
    // The target for equality checks.
-   public const String Target = "Target";
-   public const String TargetExpression = "TargetExpression";
+   public const String Target = nameof(Target);
+   public const String TargetExpression = nameof(TargetExpression);
+
+   public const String Epsilon = nameof(Epsilon);
+   public const String EpsilonExpression = nameof(EpsilonExpression);
 
    // The limit for comparable checks.
-   public const String Limit = "Limit";
-   public const String LimitExpression = "LimitExpression";
+   public const String Limit = nameof(Limit);
+   public const String LimitExpression = nameof(LimitExpression);
 
    // String min/max length checks.
-   public const String MaxLength = "MaxLength";
-   public const String MaxLengthExpression = "MaxLengthExpression";
-   public const String MinLength = "MinLength";
-   public const String MinLengthExpression = "MinLengthExpression";
+   public const String MaxLength = nameof(MaxLength);
+   public const String MaxLengthExpression = nameof(MaxLengthExpression);
+   public const String MinLength = nameof(MinLength);
+   public const String MinLengthExpression = nameof(MinLengthExpression);
 
-   public const String Regex = "Regex";
+   public const String Regex = nameof(Regex);
 
-   public const String StringComparison = "StringComparison";
+   public const String StringComparison = nameof(StringComparison);
 }

--- a/DbC.Net/FloatingPoint/BaseRelativeErrorComparer.cs
+++ b/DbC.Net/FloatingPoint/BaseRelativeErrorComparer.cs
@@ -23,7 +23,7 @@ public abstract class BaseRelativeErrorComparer<T> : IApproximateEqualityCompare
    public BaseRelativeErrorComparer(T minNormal) => _minNormal = minNormal;
 
    /// <inheritdoc/>
-   public Boolean ApproximatelyEquals(T x, T y, T tolerance)
+   public Boolean ApproximatelyEquals(T x, T y, T epsilon)
    {
       var absX = T.Abs(x);
       var absY = T.Abs(y);
@@ -38,11 +38,10 @@ public abstract class BaseRelativeErrorComparer<T> : IApproximateEqualityCompare
       {
          // a or b is zero, or both are extremely close to it.
          // relative error is less meaningful here
-         var limit = tolerance * _minNormal;
-         return diff < (tolerance * _minNormal);
+         return diff < (epsilon * _minNormal);
       }
 
       // use relative error
-      return diff / T.Min(absX + absY, T.MaxValue) < tolerance;
+      return diff / T.Min(absX + absY, T.MaxValue) < epsilon;
    }
 }

--- a/DbC.Net/FloatingPoint/BaseRelativeErrorComparer.cs
+++ b/DbC.Net/FloatingPoint/BaseRelativeErrorComparer.cs
@@ -1,0 +1,48 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+/// <summary>
+///   Abstract base class for floating point approximate equality comparers that
+///   use the relative error approach described in https://floating-point-gui.de/errors/comparison/
+/// </summary>
+public abstract class BaseRelativeErrorComparer<T> : IApproximateEqualityComparer<T>
+   where T : IFloatingPointIeee754<T>, IMinMaxValue<T>
+{
+   private readonly T _minNormal;
+
+   /// <summary>
+   ///   Initialize a new <see cref="BaseRelativeErrorComparer{T}"/>.
+   /// </summary>
+   /// <param name="minNormal">
+   ///   The smallest normal value of <typeparamref name="T"/>. A normal value 
+   ///   has a 1 before the binary point (i.e. 1.significand bits × 2^exp)
+   ///   <para/>
+   ///   Java has constants for normal (Float.MIN_NORMAL) while C# does not.
+   ///   See https://stackoverflow.com/questions/3874627/floating-point-comparison-functions-for-c-sharp
+   ///   for description of how to calculate the normal value in C#.
+   /// </param>
+   public BaseRelativeErrorComparer(T minNormal) => _minNormal = minNormal;
+
+   /// <inheritdoc/>
+   public Boolean ApproximatelyEquals(T x, T y, T tolerance)
+   {
+      var absX = T.Abs(x);
+      var absY = T.Abs(y);
+      var diff = T.Abs(x - y);
+
+      if (x == y)
+      {
+         // Shortcut, handles infinities
+         return true;
+      }
+      else if (T.IsZero(x) || T.IsZero(y) || absX + absY < _minNormal)
+      {
+         // a or b is zero, or both are extremely close to it.
+         // relative error is less meaningful here
+         var limit = tolerance * _minNormal;
+         return diff < (tolerance * _minNormal);
+      }
+
+      // use relative error
+      return diff / T.Min(absX + absY, T.MaxValue) < tolerance;
+   }
+}

--- a/DbC.Net/FloatingPoint/DoubleRelativeErrorComparer.cs
+++ b/DbC.Net/FloatingPoint/DoubleRelativeErrorComparer.cs
@@ -1,0 +1,12 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+/// <summary>
+///   Floating point approximate equality comparer that uses the relative error
+///   approach for type <see cref="Double"/>.
+/// </summary>
+public sealed class DoubleRelativeErrorComparer : BaseRelativeErrorComparer<Double>
+{
+   // 52 = # of significand bits for double precision.
+   public DoubleRelativeErrorComparer()
+      : base((1L << 52) * Double.Epsilon) { }
+}

--- a/DbC.Net/FloatingPoint/FixedEpsilonComparer.cs
+++ b/DbC.Net/FloatingPoint/FixedEpsilonComparer.cs
@@ -1,0 +1,18 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+/// <summary>
+///   Floating point approximate equality comparer that uses a fixed epsilon.
+/// </summary>
+/// <remarks>
+///   A fixed epsilon, while commonly recommended, can be considered a naive 
+///   approach (see https://floating-point-gui.de/errors/comparison/ for more
+///   detail). Unless you are certain that a fixed epsilon is sufficient, you 
+///   should consider using a relative error approach, such as 
+///   <see cref="DoubleRelativeErrorComparer"/> or implementing your own 
+///   comparer that implements <see cref="IApproximateEqualityComparer{T}"/>.
+/// </remarks>
+public sealed class FixedEpsilonComparer<T> : IApproximateEqualityComparer<T> where T : IFloatingPoint<T>
+{
+   /// <inheritdoc/>
+   public Boolean ApproximatelyEquals(T x, T y, T epsilon) => T.Abs(x - y) < epsilon;
+}

--- a/DbC.Net/FloatingPoint/FixedErrorComparer.cs
+++ b/DbC.Net/FloatingPoint/FixedErrorComparer.cs
@@ -1,17 +1,17 @@
 ﻿namespace DbC.Net.FloatingPoint;
 
 /// <summary>
-///   Floating point approximate equality comparer that uses a fixed epsilon.
+///   Floating point approximate equality comparer that uses a fixed error.
 /// </summary>
 /// <remarks>
-///   A fixed epsilon, while commonly recommended, can be considered a naive 
+///   A fixed error, while commonly recommended, can be considered a naive 
 ///   approach (see https://floating-point-gui.de/errors/comparison/ for more
-///   detail). Unless you are certain that a fixed epsilon is sufficient, you 
+///   detail). Unless you are certain that a fixed error is sufficient, you 
 ///   should consider using a relative error approach, such as 
 ///   <see cref="DoubleRelativeErrorComparer"/> or implementing your own 
 ///   comparer that implements <see cref="IApproximateEqualityComparer{T}"/>.
 /// </remarks>
-public sealed class FixedEpsilonComparer<T> : IApproximateEqualityComparer<T> where T : IFloatingPoint<T>
+public sealed class FixedErrorComparer<T> : IApproximateEqualityComparer<T> where T : IFloatingPoint<T>
 {
    /// <inheritdoc/>
    public Boolean ApproximatelyEquals(T x, T y, T epsilon) => T.Abs(x - y) < epsilon;

--- a/DbC.Net/FloatingPoint/HalfRelativeErrorComparer.cs
+++ b/DbC.Net/FloatingPoint/HalfRelativeErrorComparer.cs
@@ -1,0 +1,12 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+/// <summary>
+///   Floating point approximate equality comparer that uses the relative error
+///   approach for type <see cref="Half"/>.
+/// </summary>
+public sealed class HalfRelativeErrorComparer : BaseRelativeErrorComparer<Half>
+{
+   // 10 = # of significand bits for half precision.
+   public HalfRelativeErrorComparer()
+      : base((Half)((Int16)1 << 10) * Half.Epsilon) { }
+}

--- a/DbC.Net/FloatingPoint/IApproximateEqualityComparer.cs
+++ b/DbC.Net/FloatingPoint/IApproximateEqualityComparer.cs
@@ -1,6 +1,6 @@
 ﻿namespace DbC.Net.FloatingPoint;
 
-public interface IApproximateEqualityComparer<T> where T : IFloatingPointIeee754<T>
+public interface IApproximateEqualityComparer<T> where T : IFloatingPoint<T>
 {
    /// <summary>
    ///   Determines if the difference between <paramref name="x"/> and 
@@ -13,8 +13,8 @@ public interface IApproximateEqualityComparer<T> where T : IFloatingPointIeee754
    /// <param name="y">
    ///   The right side value of the equality check.
    /// </param>
-   /// <param name="tolerance">
-   ///   The tolerance to use when comparing the values for equality.
+   /// <param name="epsilon">
+   ///   The error margin to use when comparing the values for equality.
    /// </param>
    /// <returns>
    ///   <see langword="true"/> if the difference between <paramref name="x"/> 
@@ -22,5 +22,5 @@ public interface IApproximateEqualityComparer<T> where T : IFloatingPointIeee754
    ///   considered equal floating point values; otherwise 
    ///   <see langword="false"/>.
    /// </returns>
-   Boolean ApproximatelyEquals(T x, T y, T tolerance);
+   Boolean ApproximatelyEquals(T x, T y, T epsilon);
 }

--- a/DbC.Net/FloatingPoint/IApproximateEqualityComparer.cs
+++ b/DbC.Net/FloatingPoint/IApproximateEqualityComparer.cs
@@ -1,0 +1,26 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+public interface IApproximateEqualityComparer<T> where T : IFloatingPointIeee754<T>
+{
+   /// <summary>
+   ///   Determines if the difference between <paramref name="x"/> and 
+   ///   <paramref name="y"/> is small enough for the values to be considered 
+   ///   equal floating point values.
+   /// </summary>
+   /// <param name="x">
+   ///   The left side value of the equality check.
+   /// </param>
+   /// <param name="y">
+   ///   The right side value of the equality check.
+   /// </param>
+   /// <param name="tolerance">
+   ///   The tolerance to use when comparing the values for equality.
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if the difference between <paramref name="x"/> 
+   ///   and <paramref name="y"/> is small enough for the values to be 
+   ///   considered equal floating point values; otherwise 
+   ///   <see langword="false"/>.
+   /// </returns>
+   Boolean ApproximatelyEquals(T x, T y, T tolerance);
+}

--- a/DbC.Net/FloatingPoint/SingleRelativeErrorComparer.cs
+++ b/DbC.Net/FloatingPoint/SingleRelativeErrorComparer.cs
@@ -1,0 +1,12 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+/// <summary>
+///   Floating point approximate equality comparer that uses the relative error
+///   approach for type <see cref="Single"/>.
+/// </summary>
+public sealed class SingleRelativeErrorComparer : BaseRelativeErrorComparer<Single>
+{
+   // 23 = # of significand bits for single precision.
+   public SingleRelativeErrorComparer()
+      : base((1 << 23) * Single.Epsilon) { }
+}

--- a/DbC.Net/FloatingPoint/StandardFloatingPointComparers.cs
+++ b/DbC.Net/FloatingPoint/StandardFloatingPointComparers.cs
@@ -1,0 +1,55 @@
+﻿namespace DbC.Net.FloatingPoint;
+
+public class StandardFloatingPointComparers
+{
+   private static readonly Lazy<FixedEpsilonComparer<Decimal>> _decimalFixedEpsilonComparer =
+      new(() => new FixedEpsilonComparer<Decimal>());
+   private static readonly Lazy<FixedEpsilonComparer<Double>> _doubleFixedEpsilonComparer =
+      new(() => new FixedEpsilonComparer<Double>());
+   private static readonly Lazy<FixedEpsilonComparer<Half>> _halfFixedEpsilonComparer =
+      new(() => new FixedEpsilonComparer<Half>());
+   private static readonly Lazy<FixedEpsilonComparer<Single>> _singleFixedEpsilonComparer =
+      new(() => new FixedEpsilonComparer<Single>());
+
+   private static readonly Lazy<DoubleRelativeErrorComparer> _doubleRelativeErrorComparer =
+      new(() => new DoubleRelativeErrorComparer());
+   private static readonly Lazy<HalfRelativeErrorComparer> _halfRelativeErrorComparer =
+      new(() => new HalfRelativeErrorComparer());
+   private static readonly Lazy<SingleRelativeErrorComparer> _singleRelativeErrorComparer =
+      new(() => new SingleRelativeErrorComparer());
+
+   /// <summary>
+   ///   Fixed epsilon comparer for type <see cref="Decimal"/>.
+   /// </summary>
+   public static FixedEpsilonComparer<Decimal> DecimalFixedEpsilonComparer => _decimalFixedEpsilonComparer.Value;
+
+   /// <summary>
+   ///   Fixed epsilon comparer for type <see cref="Double"/>.
+   /// </summary>
+   public static FixedEpsilonComparer<Double> DoubleFixedEpsilonComparer => _doubleFixedEpsilonComparer.Value;
+
+   /// <summary>
+   ///   Fixed epsilon comparer for type <see cref="Half"/>.
+   /// </summary>
+   public static FixedEpsilonComparer<Half> HalfFixedEpsilonComparer => _halfFixedEpsilonComparer.Value;
+
+   /// <summary>
+   ///   Fixed epsilon comparer for type <see cref="Single"/>.
+   /// </summary>
+   public static FixedEpsilonComparer<Single> SingleFixedEpsilonComparer => _singleFixedEpsilonComparer.Value;
+
+   /// <summary>
+   ///   Relative error comparer for type <see cref="Double"/>.
+   /// </summary>
+   public static DoubleRelativeErrorComparer DoubleRelativeErrorComparer => _doubleRelativeErrorComparer.Value;
+
+   /// <summary>
+   ///   Relative error comparer for type <see cref="Half"/>.
+   /// </summary>
+   public static HalfRelativeErrorComparer HalfRelativeErrorComparer => _halfRelativeErrorComparer.Value;
+
+   /// <summary>
+   ///   Relative error comparer for type <see cref="Single"/>.
+   /// </summary>
+   public static SingleRelativeErrorComparer SingleRelativeErrorComparer => _singleRelativeErrorComparer.Value;
+}

--- a/DbC.Net/FloatingPoint/StandardFloatingPointComparers.cs
+++ b/DbC.Net/FloatingPoint/StandardFloatingPointComparers.cs
@@ -2,14 +2,14 @@
 
 public class StandardFloatingPointComparers
 {
-   private static readonly Lazy<FixedEpsilonComparer<Decimal>> _decimalFixedEpsilonComparer =
-      new(() => new FixedEpsilonComparer<Decimal>());
-   private static readonly Lazy<FixedEpsilonComparer<Double>> _doubleFixedEpsilonComparer =
-      new(() => new FixedEpsilonComparer<Double>());
-   private static readonly Lazy<FixedEpsilonComparer<Half>> _halfFixedEpsilonComparer =
-      new(() => new FixedEpsilonComparer<Half>());
-   private static readonly Lazy<FixedEpsilonComparer<Single>> _singleFixedEpsilonComparer =
-      new(() => new FixedEpsilonComparer<Single>());
+   private static readonly Lazy<FixedErrorComparer<Decimal>> _decimalFixedErrorComparer =
+      new(() => new FixedErrorComparer<Decimal>());
+   private static readonly Lazy<FixedErrorComparer<Double>> _doubleFixedErrorComparer =
+      new(() => new FixedErrorComparer<Double>());
+   private static readonly Lazy<FixedErrorComparer<Half>> _halfFixedErrorComparer =
+      new(() => new FixedErrorComparer<Half>());
+   private static readonly Lazy<FixedErrorComparer<Single>> _singleFixedErrorComparer =
+      new(() => new FixedErrorComparer<Single>());
 
    private static readonly Lazy<DoubleRelativeErrorComparer> _doubleRelativeErrorComparer =
       new(() => new DoubleRelativeErrorComparer());
@@ -19,24 +19,24 @@ public class StandardFloatingPointComparers
       new(() => new SingleRelativeErrorComparer());
 
    /// <summary>
-   ///   Fixed epsilon comparer for type <see cref="Decimal"/>.
+   ///   Fixed error comparer for type <see cref="Decimal"/>.
    /// </summary>
-   public static FixedEpsilonComparer<Decimal> DecimalFixedEpsilonComparer => _decimalFixedEpsilonComparer.Value;
+   public static FixedErrorComparer<Decimal> DecimalFixedErrorComparer => _decimalFixedErrorComparer.Value;
 
    /// <summary>
-   ///   Fixed epsilon comparer for type <see cref="Double"/>.
+   ///   Fixed error comparer for type <see cref="Double"/>.
    /// </summary>
-   public static FixedEpsilonComparer<Double> DoubleFixedEpsilonComparer => _doubleFixedEpsilonComparer.Value;
+   public static FixedErrorComparer<Double> DoubleFixedErrorComparer => _doubleFixedErrorComparer.Value;
 
    /// <summary>
-   ///   Fixed epsilon comparer for type <see cref="Half"/>.
+   ///   Fixed error comparer for type <see cref="Half"/>.
    /// </summary>
-   public static FixedEpsilonComparer<Half> HalfFixedEpsilonComparer => _halfFixedEpsilonComparer.Value;
+   public static FixedErrorComparer<Half> HalfFixedErrorComparer => _halfFixedErrorComparer.Value;
 
    /// <summary>
-   ///   Fixed epsilon comparer for type <see cref="Single"/>.
+   ///   Fixed error comparer for type <see cref="Single"/>.
    /// </summary>
-   public static FixedEpsilonComparer<Single> SingleFixedEpsilonComparer => _singleFixedEpsilonComparer.Value;
+   public static FixedErrorComparer<Single> SingleFixedErrorComparer => _singleFixedErrorComparer.Value;
 
    /// <summary>
    ///   Relative error comparer for type <see cref="Double"/>.

--- a/DbC.Net/GlobalUsings.cs
+++ b/DbC.Net/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using System.Runtime.CompilerServices;
+﻿global using System.Numerics;
+global using System.Runtime.CompilerServices;
 
 global using DbC.Net.ExceptionFactories;
 global using DbC.Net.Transforms;

--- a/DbC.Net/GlobalUsings.cs
+++ b/DbC.Net/GlobalUsings.cs
@@ -2,4 +2,5 @@
 global using System.Runtime.CompilerServices;
 
 global using DbC.Net.ExceptionFactories;
+global using DbC.Net.FloatingPoint;
 global using DbC.Net.Transforms;

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -61,6 +61,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}.
+        /// </summary>
+        internal static string ApproximatelyEqualTemplate {
+            get {
+                return ResourceManager.GetString("ApproximatelyEqualTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}.
         /// </summary>
         internal static string EqualTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ApproximatelyEqualTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}</value>
+  </data>
   <data name="EqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public static class RequirementNames
 {
+   public static String ApproximatelyEqual = nameof(ApproximatelyEqual);
    public static String Equal = nameof(Equal);
    public static String NotDefault = nameof(NotDefault);
    public static String NotEqual = nameof(NotEqual);

--- a/Documentation/ApproximatelyEqual.md
+++ b/Documentation/ApproximatelyEqual.md
@@ -1,0 +1,106 @@
+### ApproximatelyEqual
+
+ApproximatelyEqual requires that the floating point value being checked be 
+approximately equal to a target value. Two parameters are used to check the 
+approximate equality: the allowed error margin (i.e. amount that the value is 
+allowed to differ from the target and still be considered equal), known as 
+*epsilon*, and a comparer object of type IApproximateEqualityComparer<T> that 
+performs the actual equality check.
+
+Due to the possibility of rounding errors in floating point calculations it is 
+never a good idea to perform an exact equality check on floating point values. 
+Instead the standard practice is to check for approximate equality by determining 
+if the value is "close enough" to the target to be considered effectively equal.
+However, there are multiple methods for checking for approximate equality and 
+choosing the correct method requires knowledge of the values being checked and
+also of the ways that the values will be used. There simply isn't a universal
+approach that can be plugged into all use cases. Because of this, DbC.Net allows
+a developer to specify how the comparison is performed via supplying a comparer
+object to the Requires/EnsuresApproximatelyEqual methods.
+
+**Absolute Error and Relative Error**
+
+A common approach for checking approximate equality is to check 
+ABS(value - target) < epsilon. This is known as an absolute error. The issue
+with using an absolute error is that it can produce incorrect results for very
+large or very small values. For example, an epsilon of 0.0001 may seem like a 
+good choice, but when the target is 1,000,000,000 (1 billion), a value of 
+1,000,000,100 could be considered effectively equal even though the difference 
+is far greater than 0.0001.
+
+A much more accurate, though more complex approach is to use a relative 
+error as described in the [Floating Point Guide](https://floating-point-gui.de/errors/comparison/).
+
+DbC.Net supplies standard implementations of both absolute and relative error 
+comparers in the [StandardFloatingPointComparers](xyz) class and if these are 
+insufficient, you have the option of using your own comparer by implementing the 
+IApproximateEqualityComparer<T> interface.
+
+**Method signatures:**
+```C#
+T RequiresApproximatelyEqual<T>(
+   this T value, 
+   T target, 
+   T epsilon, 
+   IApproximateEqualityComparer<T> comparer, 
+   [String? messageTemplate = null], 
+   [IExceptionFactory? exceptionFactory = null], 
+   [String? valueExpression = null], 
+   [String? targetExpression = null]) where T : IFloatingPoint<T>
+
+T EnsuresApproximatelyEqual<T>(
+   this T value, 
+   T target, 
+   T epsilon, 
+   IApproximateEqualityComparer<T> comparer, 
+   [String? messageTemplate = null], 
+   [IExceptionFactory? exceptionFactory = null], 
+   [String? valueExpression = null], 
+   [String? targetExpression = null]) where T : IFloatingPoint<T>
+```
+
+The default message template for ApproximatelyEqual is "{RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}".
+The default exception factory for RequiresApproximatelyEqual is StandardExceptionFactories.ArgumentExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresApproximatelyEqual.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, Target, TargetExpression, Epsilon and 
+EpsilonExpression.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be close to {Target}";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = Double.Pi;
+var target = 4.0;
+var epsilon = 0.0001;
+var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+
+
+// Precondition with default message template/default exception factory.
+value.RequiresApproximatelyEqual(target, epsilon, comparer);
+
+// Precondition with custom message template/default exception factory.
+value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+value.EnsuresApproximatelyEqual(target, epsilon, comparer);
+
+// Postcondition with custom message template/default exception factory.
+value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
+```

--- a/Documentation/ApproximatelyEqual.md
+++ b/Documentation/ApproximatelyEqual.md
@@ -107,7 +107,7 @@ value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate
 
 ### StandardFloatingPointComparers
 
-The StandardFloatingPointComparers class (DbC.Net.FloatingPoint) has properties 
+The DbC.Net.FloatingPoint.StandardFloatingPointComparers class has properties 
 that give you access to both fixed error and relative error implementations of 
 IApproximateEqualityComparer<T> as lazily created singleton objects. The comparers 
 available are:

--- a/Documentation/ApproximatelyEqual.md
+++ b/Documentation/ApproximatelyEqual.md
@@ -18,11 +18,11 @@ approach that can be plugged into all use cases. Because of this, DbC.Net allows
 a developer to specify how the comparison is performed via supplying a comparer
 object to the Requires/EnsuresApproximatelyEqual methods.
 
-**Absolute Error and Relative Error**
+**Fixed Error and Relative Error**
 
 A common approach for checking approximate equality is to check 
-ABS(value - target) < epsilon. This is known as an absolute error. The issue
-with using an absolute error is that it can produce incorrect results for very
+ABS(value - target) < epsilon. This is known as an fixed error. The issue
+with using an fixed error is that it can produce incorrect results for very
 large or very small values. For example, an epsilon of 0.0001 may seem like a 
 good choice, but when the target is 1,000,000,000 (1 billion), a value of 
 1,000,000,100 could be considered effectively equal even though the difference 
@@ -31,8 +31,8 @@ is far greater than 0.0001.
 A much more accurate, though more complex approach is to use a relative 
 error as described in the [Floating Point Guide](https://floating-point-gui.de/errors/comparison/).
 
-DbC.Net supplies standard implementations of both absolute and relative error 
-comparers in the [StandardFloatingPointComparers](xyz) class and if these are 
+DbC.Net supplies standard implementations of both fixed and relative error 
+comparers in the [StandardFloatingPointComparers](#standardfloatingpointcomparers) class and if these are 
 insufficient, you have the option of using your own comparer by implementing the 
 IApproximateEqualityComparer<T> interface.
 
@@ -104,3 +104,27 @@ value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: cus
 // Postcondition with custom message template/custom exception factory.
 value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
 ```
+
+### StandardFloatingPointComparers
+
+The StandardFloatingPointComparers class (DbC.Net.FloatingPoint) has properties 
+that give you access to both fixed error and relative error implementations of 
+IApproximateEqualityComparer<T> as lazily created singleton objects. The comparers 
+available are:
+
+- DecimalFixedErrorComparer - fixed error comparer for type Decimal.
+
+- DoubleFixedErrorComparer - fixed error comparer for type Double.
+
+- HalfFixedErrorComparer - fixed error comparer for type Half.
+
+- SingleFixedErrorComparer - fixed error comparer for type Single.
+
+- DoubleRelativeErrorComparer - relative error comparer for type Double.
+
+- HalfRelativeErrorComparer - relative error comparer for type Half.
+
+- SingleRelativeErrorComparer - relative error comparer for type Single.
+
+(Note that there is no StandardFloatingPointComparers does not have relative
+error comparer for type Double.)

--- a/Documentation/Equal.md
+++ b/Documentation/Equal.md
@@ -5,7 +5,7 @@ and EnsuresEqual have several overloads that support IEquatable<T> and
 IEqualtiyComparer<T> as well as an overload for String that accepts a 
 StringComparison value that specifies how the comparison is performed.
 
-Method signatures:
+**Method signatures:**
 ```C#
 T RequiresEqual<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IEquatable<T>
 
@@ -30,8 +30,7 @@ RequirementName, Value, ValueExpression, Target and TargetExpression. The data
 dictionary for the String overloads will contain an additional entry for 
 StringComparison.
 
-Examples:
-
+**Examples:**
 ```C#
 var customMessageTemplate = "{ValueExpression} must be equal to {Target}";
 var customExceptionFactory = new CustomExceptionFactory();

--- a/Documentation/NotDefault.md
+++ b/Documentation/NotDefault.md
@@ -5,7 +5,7 @@ datatype of the value being checked (zero for value types, null for reference
 types). Use RequiresNotDefault for preconditions and EnsuresNotDefault for 
 postconditions.
 
-Method signatures:
+**Method signatures:**
 ```C#
 T RequiresNotDefault<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
 
@@ -20,7 +20,7 @@ EnsuresNotDefault.
 The data dictionary for exceptions thrown will contain entries for RequirementType,
 RequirementName, ValueExpression and ValueDatatype.
 
-Examples:
+**Examples:**
 ```C#
 var customMessageTemplate = "{ValueExpression} can not be default";
 var customExceptionFactory = new CustomExceptionFactory();

--- a/Documentation/NotEqual.md
+++ b/Documentation/NotEqual.md
@@ -5,7 +5,7 @@ RequiresNotEqual and EnsuresNotEqual have several overloads that support IEquata
 and IEqualtiyComparer<T> as well as an overload for String that accepts a 
 StringComparison value that specifies how the comparison is performed.
 
-Method signatures:
+**Method signatures:**
 ```C#
 T RequiresNotEqual<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IEquatable<T>
 
@@ -30,8 +30,7 @@ RequirementName, Value, ValueExpression, Target and TargetExpression. The data
 dictionary for the String overloads will contain an additional entry for 
 StringComparison.
 
-Examples:
-
+**Examples:**
 ```C#
 var customMessageTemplate = "{ValueExpression} must not be equal to {Target}";
 var customExceptionFactory = new CustomExceptionFactory();

--- a/Documentation/NotNull.md
+++ b/Documentation/NotNull.md
@@ -3,7 +3,7 @@
 NotNull requires that the reference type value being checked not be null. Use 
 RequiresNotNull for preconditions and EnsuresNotNull for postconditions.
 
-Method signatures:
+**Method signatures:**
 ```C#
 T RequiresNotNull<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : class
 
@@ -18,7 +18,7 @@ EnsuresNotNull.
 The data dictionary for exceptions thrown will contain entries for RequirementType,
 RequirementName and ValueExpression.
 
-Examples:
+**Examples:**
 ```C#
 var customMessageTemplate = "{ValueExpression} can not be null";
 var customExceptionFactory = new CustomExceptionFactory();

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
     - [Equal](/Documentation/Equal.md)
     - [NotEqual](/Documentation/NotEqual.md)
 
+    - [ApproximatelyEqual](/Documentation/ApproximatelyEqual.md)
+
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 
 	- Not currently released

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ exception data dictionary.
 
 ### StandardExceptionFactories
 
-The static StandardExceptionFactories class has properties that give you access
-to pre-configured exception factories as lazily created singletons. The exception
-factories available are:
+The static DbC.Net.ExceptionFactories.StandardExceptionFactories class has 
+properties that give you access to pre-configured exception factories as lazily 
+created singletons. The exception factories available are:
 
 - ArgumentExceptionFactory - an instance of [ArgumentExceptionFactory](#argumentexceptionfactory)
 that does not use any value transforms.
@@ -249,9 +249,9 @@ to determining the actual value.
 
 ### StandardTransforms
 
-The static StandardTransforms class has properties that give you access to 
-pre-configured value transforms as lazily created singletons. The value transforms
-available are:
+The static DbC.Net.Transforms.StandardTransforms class has properties that give 
+you access to pre-configured value transforms as lazily created singletons. The 
+value transforms available are:
 
 - AsteriskMaskTransform - a transform that converts a value to a string and then 
 replaces all characters in the string with an asterisk character ('*').


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a floating point value is approximately equal to a target value.

See https://floating-point-gui.de/errors/comparison/ for more info.

Requirements:

  RequiresApproximatelyEqual (precondition), default ArgumentOutOfRangeException
  EnsuresApproximatelyEqual (postcondition), default PostconditionFailedException
  Support supplying comparer object to perform the comparison
  Requirement Dropped: Default comparer should check ABS(value - target) < tolerance

DEFINITION OF DONE:

1. Implement RequiresApproximatelyEqual
2. Implement EnsuresApproximatelyEqual
3. Unit tests for Requires/Ensures ApproximatelyEqual
4. Performance tests
5. Readme updates
6. Examples