### PR TITLE
S0008 greater than

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -185,7 +185,7 @@ parameter was omitted.
 ### GreaterThan Benchmarks
 
 | Method              | Value Type  | Comparer         | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
-|-------------------- |:------------|:----------------:|:----------------:|:-----------------:|--- -------:|----------:|----------:|----------:|
+|-------------------- |:------------|:----------------:|:----------------:|:-----------------:|-----------:|----------:|----------:|----------:|
 | RequiresGreaterThan | Int32       |                  |                  |                   |  0.0033 ns | 0.0073 ns | 0.0068 ns |         - |
 | RequiresGreaterThan | Int32       |                  | X                |                   |  0.0062 ns | 0.0078 ns | 0.0069 ns |         - |
 | RequiresGreaterThan | Int32       |                  |                  | X                 |  1.6264 ns | 0.0053 ns | 0.0049 ns |         - |
@@ -194,18 +194,18 @@ parameter was omitted.
 | RequiresGreaterThan | Int32       | IComparer<T>     | X                |                   |  2.4138 ns | 0.0686 ns | 0.0573 ns |         - |
 | RequiresGreaterThan | Int32       | IComparer<T>     |                  | X                 |  2.7780 ns | 0.0334 ns | 0.0261 ns |         - |
 | RequiresGreaterThan | Int32       | IComparer<T>     | X                | X                 |  2.2379 ns | 0.0337 ns | 0.0315 ns |         - |
-| RequiresGreaterThan | String      |                  |                  |                   | 38.6920 ns | 0.4605 ns | 0.4308 ns |         - |
-| RequiresGreaterThan | String      |                  | X                |                   | 37.9370 ns | 0.2191 ns | 0.1830 ns |         - |
-| RequiresGreaterThan | String      |                  |                  | X                 | 40.1133 ns | 0.5171 ns | 0.4318 ns |         - |
-| RequiresGreaterThan | String      |                  | X                | X                 | 41.2393 ns | 0.3261 ns | 0.2723 ns |         - |
-| RequiresGreaterThan | String      | IComparer<T>     |                  |                   | 47.3337 ns | 0.2442 ns | 0.2164 ns |         - |
-| RequiresGreaterThan | String      | IComparer<T>     | X                |                   | 41.4094 ns | 0.4057 ns | 0.3388 ns |         - |
-| RequiresGreaterThan | String      | IComparer<T>     |                  | X                 | 43.7585 ns | 0.2490 ns | 0.2329 ns |         - |
-| RequiresGreaterThan | String      | IComparer<T>     | X                | X                 | 42.7079 ns | 0.2531 ns | 0.2368 ns |         - |
-| RequiresGreaterThan | String      | StringComparison |                  |                   |  5.6071 ns | 0.0380 ns | 0.0356 ns |         - |
-| RequiresGreaterThan | String      | StringComparison | X                |                   |  5.6291 ns | 0.0430 ns | 0.0402 ns |         - |
-| RequiresGreaterThan | String      | StringComparison |                  | X                 |  5.5199 ns | 0.0298 ns | 0.0249 ns |         - |
-| RequiresGreaterThan | String      | StringComparison | X                | X                 |  6.0922 ns | 0.0328 ns | 0.0291 ns |         - |
+| RequiresGreaterThan | String      |                  |                  |                   | 41.4850 ns | 0.3105 ns | 0.2905 ns |         - |
+| RequiresGreaterThan | String      |                  | X                |                   | 40.9680 ns | 0.3176 ns | 0.2815 ns |         - |
+| RequiresGreaterThan | String      |                  |                  | X                 | 40.3530 ns | 0.5610 ns | 0.5248 ns |         - |
+| RequiresGreaterThan | String      |                  | X                | X                 | 42.0430 ns | 0.2408 ns | 0.2134 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     |                  |                   |  6.7720 ns | 0.0450 ns | 0.0375 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     | X                |                   |  6.0890 ns | 0.0450 ns | 0.0399 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     |                  | X                 |  6.8730 ns | 0.0791 ns | 0.0740 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     | X                | X                 |  7.2860 ns | 0.0827 ns | 0.0773 ns |         - |
+| RequiresGreaterThan | String      | StringComparison |                  |                   |  5.6310 ns | 0.0349 ns | 0.0310 ns |         - |
+| RequiresGreaterThan | String      | StringComparison | X                |                   |  5.5750 ns | 0.0338 ns | 0.0299 ns |         - |
+| RequiresGreaterThan | String      | StringComparison |                  | X                 |  5.5400 ns | 0.0337 ns | 0.0315 ns |         - |
+| RequiresGreaterThan | String      | StringComparison | X                | X                 |  6.1180 ns | 0.0340 ns | 0.0318 ns |         - |
 | RequiresGreaterThan | Record      |                  |                  |                   |  4.9939 ns | 0.1279 ns | 0.1953 ns |         - |
 | RequiresGreaterThan | Record      |                  | X                |                   |  4.6437 ns | 0.0168 ns | 0.0157 ns |         - |
 | RequiresGreaterThan | Record      |                  |                  | X                 |  4.7160 ns | 0.0850 ns | 0.0795 ns |         - |

--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -17,6 +17,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [Equal Benchmarks](#equal-benchmarks)
   - [NotEqual Benchmarks](#notequal-benchmarks)
   - [ApproximatelyEqual Benchmarks](#approximatelyequal-benchmarks)
+  - [GreaterThan Benchmarks](#greaterthan-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -180,3 +181,44 @@ parameter was omitted.
 | RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer | X                |                   | 6.544 ns | 0.0473 ns | 0.0419 ns |         - |
 | RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer |                  | X                 | 6.560 ns | 0.0335 ns | 0.0280 ns |         - |
 | RequiresApproximatelyEqual | Single     | Relative Epsilon Comparer | X                | X                 | 7.393 ns | 0.0984 ns | 0.0822 ns |         - |
+
+### GreaterThan Benchmarks
+
+| Method              | Value Type  | Comparer         | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
+|-------------------- |:------------|:----------------:|:----------------:|:-----------------:|--- -------:|----------:|----------:|----------:|
+| RequiresGreaterThan | Int32       |                  |                  |                   |  0.0033 ns | 0.0073 ns | 0.0068 ns |         - |
+| RequiresGreaterThan | Int32       |                  | X                |                   |  0.0062 ns | 0.0078 ns | 0.0069 ns |         - |
+| RequiresGreaterThan | Int32       |                  |                  | X                 |  1.6264 ns | 0.0053 ns | 0.0049 ns |         - |
+| RequiresGreaterThan | Int32       |                  | X                | X                 |  0.0018 ns | 0.0035 ns | 0.0029 ns |         - |
+| RequiresGreaterThan | Int32       | IComparer<T>     |                  |                   |  2.6291 ns | 0.0679 ns | 0.0602 ns |         - |
+| RequiresGreaterThan | Int32       | IComparer<T>     | X                |                   |  2.4138 ns | 0.0686 ns | 0.0573 ns |         - |
+| RequiresGreaterThan | Int32       | IComparer<T>     |                  | X                 |  2.7780 ns | 0.0334 ns | 0.0261 ns |         - |
+| RequiresGreaterThan | Int32       | IComparer<T>     | X                | X                 |  2.2379 ns | 0.0337 ns | 0.0315 ns |         - |
+| RequiresGreaterThan | String      |                  |                  |                   | 38.6920 ns | 0.4605 ns | 0.4308 ns |         - |
+| RequiresGreaterThan | String      |                  | X                |                   | 37.9370 ns | 0.2191 ns | 0.1830 ns |         - |
+| RequiresGreaterThan | String      |                  |                  | X                 | 40.1133 ns | 0.5171 ns | 0.4318 ns |         - |
+| RequiresGreaterThan | String      |                  | X                | X                 | 41.2393 ns | 0.3261 ns | 0.2723 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     |                  |                   | 47.3337 ns | 0.2442 ns | 0.2164 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     | X                |                   | 41.4094 ns | 0.4057 ns | 0.3388 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     |                  | X                 | 43.7585 ns | 0.2490 ns | 0.2329 ns |         - |
+| RequiresGreaterThan | String      | IComparer<T>     | X                | X                 | 42.7079 ns | 0.2531 ns | 0.2368 ns |         - |
+| RequiresGreaterThan | String      | StringComparison |                  |                   |  5.6071 ns | 0.0380 ns | 0.0356 ns |         - |
+| RequiresGreaterThan | String      | StringComparison | X                |                   |  5.6291 ns | 0.0430 ns | 0.0402 ns |         - |
+| RequiresGreaterThan | String      | StringComparison |                  | X                 |  5.5199 ns | 0.0298 ns | 0.0249 ns |         - |
+| RequiresGreaterThan | String      | StringComparison | X                | X                 |  6.0922 ns | 0.0328 ns | 0.0291 ns |         - |
+| RequiresGreaterThan | Record      |                  |                  |                   |  4.9939 ns | 0.1279 ns | 0.1953 ns |         - |
+| RequiresGreaterThan | Record      |                  | X                |                   |  4.6437 ns | 0.0168 ns | 0.0157 ns |         - |
+| RequiresGreaterThan | Record      |                  |                  | X                 |  4.7160 ns | 0.0850 ns | 0.0795 ns |         - |
+| RequiresGreaterThan | Record      |                  | X                | X                 |  4.7240 ns | 0.0867 ns | 0.0768 ns |         - |
+| RequiresGreaterThan | Record      | IComparer<T>     |                  |                   |  6.0640 ns | 0.0488 ns | 0.0432 ns |         - |
+| RequiresGreaterThan | Record      | IComparer<T>     | X                |                   |  5.9618 ns | 0.0149 ns | 0.0116 ns |         - |
+| RequiresGreaterThan | Record      | IComparer<T>     |                  | X                 |  5.6564 ns | 0.0399 ns | 0.0333 ns |         - |
+| RequiresGreaterThan | Record      | IComparer<T>     | X                | X                 |  5.8100 ns | 0.0190 ns | 0.0159 ns |         - |
+| RequiresGreaterThan | Class       |                  |                  |                   |  4.8347 ns | 0.0153 ns | 0.0128 ns |         - |
+| RequiresGreaterThan | Class       |                  | X                |                   |  5.2207 ns | 0.1325 ns | 0.1361 ns |         - |
+| RequiresGreaterThan | Class       |                  |                  | X                 |  5.0445 ns | 0.0219 ns | 0.0183 ns |         - |
+| RequiresGreaterThan | Class       |                  | X                | X                 |  5.0650 ns | 0.0236 ns | 0.0221 ns |         - |
+| RequiresGreaterThan | Class       | IComparer<T>     |                  |                   |  5.6963 ns | 0.0493 ns | 0.0461 ns |         - |
+| RequiresGreaterThan | Class       | IComparer<T>     | X                |                   |  5.7535 ns | 0.0192 ns | 0.0170 ns |         - |
+| RequiresGreaterThan | Class       | IComparer<T>     |                  | X                 |  5.9751 ns | 0.0315 ns | 0.0295 ns |         - |
+| RequiresGreaterThan | Class       | IComparer<T>     | X                | X                 |  6.1536 ns | 0.0416 ns | 0.0347 ns |         - |

--- a/DbC.Net.Examples/GreaterThanExamples.cs
+++ b/DbC.Net.Examples/GreaterThanExamples.cs
@@ -1,0 +1,98 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class GreaterThanExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be greater than to {Target}";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var changeDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
+      var targetDate = new DateTime(2023, 1, 1);
+
+      // Precondition with default message template/default exception factory.
+      changeDate.RequiresGreaterThan(targetDate);
+
+      // Precondition with custom message template/default exception factory.
+      changeDate.RequiresGreaterThan(targetDate, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      changeDate.RequiresGreaterThan(targetDate, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      changeDate.RequiresGreaterThan(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      changeDate.EnsuresGreaterThan(targetDate);
+
+      // Postcondition with custom message template/default exception factory.
+      changeDate.EnsuresGreaterThan(targetDate, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      changeDate.EnsuresGreaterThan(targetDate, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      changeDate.EnsuresGreaterThan(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+      var point = new Point { X = 10, Y = 10 };
+      var targetPoint = new Point { X = 1, Y = 12 };
+      var comparer = new PointDistanceFromOriginComparer();
+
+      // Precondition with default message template/default exception factory.
+      point.RequiresGreaterThan(targetPoint, comparer);
+
+      // Precondition with custom message template/default exception factory.
+      point.RequiresGreaterThan(targetPoint, comparer, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      point.RequiresGreaterThan(targetPoint, comparer, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      point.RequiresGreaterThan(targetPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      point.EnsuresGreaterThan(targetPoint, comparer);
+
+      // Postcondition with custom message template/default exception factory.
+      point.EnsuresGreaterThan(targetPoint, comparer, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      point.EnsuresGreaterThan(targetPoint, comparer, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      point.EnsuresGreaterThan(targetPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      var str = "asdf";
+      var targetStr = "QWERTY";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+      // Precondition with default message template/default exception factory.
+      str.RequiresGreaterThan(targetStr, comparisonType);
+
+      // Precondition with custom message template/default exception factory.
+      str.RequiresGreaterThan(targetStr, comparisonType, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      str.RequiresGreaterThan(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      str.RequiresGreaterThan(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      str.EnsuresGreaterThan(targetStr, comparisonType);
+
+      // Postcondition with custom message template/default exception factory.
+      str.EnsuresGreaterThan(targetStr, comparisonType, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      str.EnsuresGreaterThan(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      str.EnsuresGreaterThan(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.TestAndExampleResources/Box.cs
+++ b/DbC.Net.TestAndExampleResources/Box.cs
@@ -4,5 +4,20 @@ public record Box(Int32 Height, Int32 Width, Int32 Length, String Color) : IComp
 {
    public Int32 Volume => Height * Width * Length;
 
-   public Int32 CompareTo(Box? other) => throw new NotImplementedException();
+   public Int32 CompareTo(Box? other)
+   {
+      // Compare to null will always evaluate as greater than, per MSDN documentation for IComparable<T>.CompareTo(T)
+      if (other == null) return 1;
+
+      var result = Height.CompareTo(other!.Height);
+      if (result != 0) return result;
+
+      result = Width.CompareTo(other!.Width);
+      if (result != 0) return result;
+
+      result = Length.CompareTo(other!.Length);
+      return result != 0 
+         ? result 
+         : Color.CompareTo(other!.Color);
+   }
 }

--- a/DbC.Net.TestAndExampleResources/BoxAllFieldsComparer.cs
+++ b/DbC.Net.TestAndExampleResources/BoxAllFieldsComparer.cs
@@ -1,7 +1,17 @@
 ﻿namespace DbC.Net.TestAndExampleResources;
 
-public sealed class BoxAllFieldsComparer : IEqualityComparer<Box>
+public sealed class BoxAllFieldsComparer : IEqualityComparer<Box>, IComparer<Box>
 {
+   public Int32 Compare(Box? x, Box? y)
+   {
+      if (x is null)
+      {
+         return y is null ? 0 : -1;
+      }
+
+      return x.CompareTo(y);
+   }
+
    public Boolean Equals(Box? x, Box? y)
    {
       if (ReferenceEquals(x, y))

--- a/DbC.Net.TestAndExampleResources/Observation.cs
+++ b/DbC.Net.TestAndExampleResources/Observation.cs
@@ -50,5 +50,26 @@ public sealed class Observation : IEquatable<Observation>, IComparable<Observati
          && left.Value == right.Value
          && left.Units == right.Units;
 
-    public Int32 CompareTo(Observation? other) => throw new NotImplementedException();
+   public Int32 CompareTo(Observation? other)
+   {
+      // Compare to null will always evaluate as greater than, per MSDN documentation for IComparable<T>.CompareTo(T)
+      if (other == null) return 1;
+
+      // This is a contrived example that simply compares all fields of an object.
+      // Otherwise, you'd want to consider if Id equality means that the objects
+      // are truly equal.
+      var result = ObservationId.CompareTo(other.ObservationId);
+      if (result != 0) return result;
+
+      result = ObservationTimestamp.CompareTo(other.ObservationTimestamp);
+      if (result != 0) return result;
+
+      result = ObservationType.CompareTo(other.ObservationType);
+      if (result != 0) return result;
+
+      result = Value.CompareTo(other.Value);
+      return result == 0
+         ? result
+         : Units.CompareTo(other.Units);
+   }
 }

--- a/DbC.Net.TestAndExampleResources/Observation.cs
+++ b/DbC.Net.TestAndExampleResources/Observation.cs
@@ -68,7 +68,7 @@ public sealed class Observation : IEquatable<Observation>, IComparable<Observati
       if (result != 0) return result;
 
       result = Value.CompareTo(other.Value);
-      return result == 0
+      return result != 0
          ? result
          : Units.CompareTo(other.Units);
    }

--- a/DbC.Net.TestAndExampleResources/ObservationAllFieldsComparer.cs
+++ b/DbC.Net.TestAndExampleResources/ObservationAllFieldsComparer.cs
@@ -1,7 +1,17 @@
 ﻿namespace DbC.Net.TestAndExampleResources;
 
-public sealed class ObservationAllFieldsComparer : IEqualityComparer<Observation>
+public sealed class ObservationAllFieldsComparer : IEqualityComparer<Observation>, IComparer<Observation>
 {
+   public Int32 Compare(Observation? x, Observation? y)
+   {
+      if (x is null)
+      {
+         return y is null ? 0 : -1;
+      }
+
+      return x.CompareTo(y);
+   }
+
    public Boolean Equals(Observation? x, Observation? y)
    {
       if (ReferenceEquals(x, y))

--- a/DbC.Net.TestAndExampleResources/ObservationComparers.cs
+++ b/DbC.Net.TestAndExampleResources/ObservationComparers.cs
@@ -3,6 +3,4 @@
 public static class ObservationComparers
 {
    public static readonly ObservationAllFieldsComparer AllFieldsComparer = new();
-
-   public static readonly ObservationIdComparer IdComparer = new();
 }

--- a/DbC.Net.TestAndExampleResources/Point.cs
+++ b/DbC.Net.TestAndExampleResources/Point.cs
@@ -6,9 +6,15 @@ public struct Point : IEquatable<Point>, IComparable<Point>
 
    public Int32 Y { get; set; }
 
-    public Int32 CompareTo(Point other) => throw new NotImplementedException();
+   public Int32 CompareTo(Point other)
+   {
+      var result = X.CompareTo(other.X);
+      return result != 0
+         ? result
+         : Y.CompareTo(other.Y);
+   }
 
-    public override Boolean Equals([NotNullWhen(true)] Object? obj)
+   public override Boolean Equals([NotNullWhen(true)] Object? obj)
    {
       if (obj is null)
       {

--- a/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs
+++ b/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs
@@ -1,0 +1,12 @@
+﻿namespace DbC.Net.TestAndExampleResources;
+
+public sealed class PointDistanceFromOriginComparer : IComparer<Point>
+{
+   public Int32 Compare(Point a, Point b)
+   {
+      var aDistance = Math.Sqrt(a.X * a.X + a.Y * a.Y);
+      var bDistance = Math.Sqrt(b.X * b.X + b.Y * b.Y);
+
+      return aDistance.CompareTo(bDistance);
+   }
+}

--- a/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs
+++ b/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs
@@ -1,8 +1,8 @@
 ﻿namespace DbC.Net.TestAndExampleResources;
 
-public sealed class PointDistanceFromOriginComparer : IComparer<Point>
+public sealed class PointDistanceFromOriginComparer : Comparer<Point>
 {
-   public Int32 Compare(Point a, Point b)
+   public override Int32 Compare(Point a, Point b)
    {
       var aDistance = Math.Sqrt(a.X * a.X + a.Y * a.Y);
       var bDistance = Math.Sqrt(b.X * b.X + b.Y * b.Y);

--- a/DbC.Net.Tests.Benchmarks/GreaterThanBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/GreaterThanBenchmarks.cs
@@ -1,0 +1,261 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class GreaterThanBenchmarks
+{
+   private const Int32 _intValue = 100;
+   private const Int32 _intTarget = 99;
+   private static readonly IComparer<Int32> _intComparer = Comparer<Int32>.Default;
+
+   private const String _strValue = "qwerty";
+   private const String _strTarget = "ASDF";
+   private static readonly IComparer<String> _stringComparer = Comparer<String>.Default;
+   private const StringComparison _comparisonType = StringComparison.OrdinalIgnoreCase;
+
+   private static readonly Box _boxValue = new(4, 16, 36, "Purple");
+   private static readonly Box _boxTarget = new(2, 4, 8, "Green");
+   private static readonly IComparer<Box> _boxComparer = BoxComparers.AllFieldsComparer;
+
+   private static readonly Observation _observationValue = new()
+   {
+      ObservationId = new Guid("f77e70ee-6fff-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2023, 12, 23, 10, 38, 47, 889),
+      ObservationType = ObservationType.Temperature,
+      Value = 16.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly Observation _observationTaget = new()
+   {
+      ObservationId = new Guid("f77d70bc-6eea-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2022, 11, 22, 9, 37, 46, 789),
+      ObservationType = ObservationType.Temperature,
+      Value = 6.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly IComparer<Observation> _observationComparer = ObservationComparers.AllFieldsComparer;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be greater than to {Target}";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P000()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P100()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P010()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P110()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P001()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, _intComparer);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P101()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, _intComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P011()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, _intComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Int32_P111()
+   {
+      var result = _intValue.RequiresGreaterThan(_intTarget, _intComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P000()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P100()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P010()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P110()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P001()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _stringComparer);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P101()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _stringComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P011()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _stringComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P111()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _stringComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P002()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _comparisonType);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P102()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _comparisonType, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P012()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _comparisonType, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_String_P112()
+   {
+      var result = _strValue.RequiresGreaterThan(_strTarget, _comparisonType, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P000()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P100()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P010()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P110()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P001()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, _boxComparer);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P101()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, _boxComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P011()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, _boxComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Record_P111()
+   {
+      var result = _boxValue.RequiresGreaterThan(_boxTarget, _boxComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P000()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P100()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P010()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P110()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P001()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, _observationComparer);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P101()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, _observationComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P011()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, _observationComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThan_Class_P111()
+   {
+      var result = _observationValue.RequiresGreaterThan(_observationTaget, _observationComparer, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/GreaterThanBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/GreaterThanBenchmarks.cs
@@ -9,7 +9,7 @@ public class GreaterThanBenchmarks
 
    private const String _strValue = "qwerty";
    private const String _strTarget = "ASDF";
-   private static readonly IComparer<String> _stringComparer = Comparer<String>.Default;
+   private static readonly IComparer<String> _stringComparer = StringComparer.OrdinalIgnoreCase;
    private const StringComparison _comparisonType = StringComparison.OrdinalIgnoreCase;
 
    private static readonly Box _boxValue = new(4, 16, 36, "Purple");

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -2,4 +2,5 @@
 //BenchmarkRunner.Run<NotDefaultBenchmarks>(); 
 //BenchmarkRunner.Run<EqualBenchmarks>();
 //BenchmarkRunner.Run<NotEqualBenchmarks>();
-BenchmarkRunner.Run<ApproximatelyEqualBenchmarks>();
+//BenchmarkRunner.Run<ApproximatelyEqualBenchmarks>();
+BenchmarkRunner.Run<GreaterThanBenchmarks>();

--- a/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
@@ -80,10 +80,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotApproximatelyEqualToTarget()
    {
       // Arrange.
-      var value = Single.Pi;
-      var target = Single.Tau;
-      var epsilon = 0.0001F;
-      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var data = new SingleData();
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
@@ -104,10 +105,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNotApproximatelyEqualToTarget()
    {
       // Arrange.
-      var value = Double.Pi;
-      var target = Double.Tau;
-      var epsilon = 0.0001;
-      var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+      var data = new DoubleData();
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
       var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
@@ -120,10 +122,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = Half.Pi;
-      var target = Half.Tau;
-      var epsilon = (Half)0.001;
-      var comparer = StandardFloatingPointComparers.HalfFixedErrorComparer;
+      var data = new HalfData();
+      var value = data.Value + data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedErrorComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, messageTemplate);
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
@@ -137,10 +140,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Decimal.One;
-      var target = Decimal.MinusOne;
-      var epsilon = 0.0001M;
-      var comparer = StandardFloatingPointComparers.DecimalFixedErrorComparer;
+      var data = new DecimalData();
+      var value = data.Value + data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedErrorComparer;
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
@@ -153,10 +157,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_EnsuresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Single.Pi;
-      var target = Single.Tau;
-      var epsilon = 0.0001F;
-      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var data = new SingleData();
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
@@ -244,10 +249,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotApproximatelyEqualToTarget()
    {
       // Arrange.
-      var value = Single.Pi;
-      var target = Single.Tau;
-      var epsilon = 0.0001F;
-      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var data = new SingleData();
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
@@ -268,10 +274,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsNotApproximatelyEqualToTarget()
    {
       // Arrange.
-      var value = Double.Pi;
-      var target = Double.Tau;
-      var epsilon = 0.0001;
-      var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
+      var data = new DoubleData();
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
@@ -286,10 +293,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = Half.Pi;
-      var target = Half.Tau;
-      var epsilon = (Half)0.001;
-      var comparer = StandardFloatingPointComparers.HalfFixedErrorComparer;
+      var data = new HalfData();
+      var value = data.Value + data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedErrorComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -305,10 +313,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Decimal.One;
-      var target = Decimal.MinusOne;
-      var epsilon = 0.0001M;
-      var comparer = StandardFloatingPointComparers.DecimalFixedErrorComparer;
+      var data = new DecimalData();
+      var value = data.Value + data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.FixedEpsilon;
+      var comparer = data.FixedErrorComparer;
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
@@ -321,10 +330,11 @@ public class ApproximatelyEqualExtensionsTests
    public void ApproximatelyEqualExtensions_RequiresApproximatelyEqual_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Single.Pi;
-      var target = Single.Tau;
-      var epsilon = 0.0001F;
-      var comparer = StandardFloatingPointComparers.SingleRelativeErrorComparer;
+      var data = new SingleData();
+      var value = data.Value - data.OutOfToleranceDelta;
+      var target = data.Value;
+      var epsilon = data.RelativeEpsilon;
+      var comparer = data.RelativeErrorComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement ApproximatelyEqual failed";

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -331,7 +331,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_EnsuresEqualString_ShouldReturnOriginalValue_WhenValueEqualsTargetAndCurrentCultureIs_enUS(
       String value,
       String target,
@@ -354,7 +354,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_EnsuresEqualString_ShouldReturnOriginalValue_WhenValueEqualsTargetAndCurrentCultureIs_trTR(
       String value,
       String target,
@@ -375,7 +375,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_EnsuresEqualString_ShouldReturnOriginalValue_WhenValueEqualsTargetAndCurrentCultureIs_thTH(
       String value,
       String target,
@@ -436,7 +436,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseA, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_EnsuresEqualString_ShouldThrow_WhenValueDoesNotEqualTargetAndCurrentCultureIs_enUS(
       String value,
@@ -456,7 +456,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_EnsuresEqualString_ShouldThrow_WhenValueDoesNotEqualTargetAndCurrentCultureIs_trTR(
       String value,
@@ -476,7 +476,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_EnsuresEqualString_ShouldThrow_WhenValueDoesNotEqualTargetAndCurrentCultureIs_thTH(
       String value,
@@ -532,7 +532,7 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualString_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = StringData.LowerCaseDipthongAE;
+      var value = StringData.LowerCaseDiphthongAE;
       var target = StringData.UpperCaseEszett;
       var comparisonType = StringComparison.Ordinal;
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
@@ -596,6 +596,7 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
+   [UseCulture(CultureData.EnglishUS)]
    [Fact]
    public void EqualExtensions_EnsuresEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
@@ -974,7 +975,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_RequiresEqualString_ShouldReturnOriginalValue_WhenValueEqualsTargetAndCurrentCultureIs_enUS(
       String value,
       String target,
@@ -997,7 +998,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_RequiresEqualString_ShouldReturnOriginalValue_WhenValueEqualsTargetAndCurrentCultureIs_trTR(
       String value,
       String target,
@@ -1018,7 +1019,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_RequiresEqualString_ShouldReturnOriginalValue_WhenValueEqualsTargetAndCurrentCultureIs_thTH(
       String value,
       String target,
@@ -1079,7 +1080,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseA, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_RequiresEqualString_ShouldThrow_WhenValueDoesNotEqualTargetAndCurrentCultureIs_enUS(
       String value,
@@ -1099,7 +1100,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_RequiresEqualString_ShouldThrow_WhenValueDoesNotEqualTargetAndCurrentCultureIs_trTR(
       String value,
@@ -1119,7 +1120,7 @@ public class EqualsExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void EqualExtensions_RequiresEqualString_ShouldThrow_WhenValueDoesNotEqualTargetAndCurrentCultureIs_thTH(
       String value,
@@ -1175,7 +1176,7 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualString_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = StringData.LowerCaseDipthongAE;
+      var value = StringData.LowerCaseDiphthongAE;
       var target = StringData.UpperCaseEszett;
       var comparisonType = StringComparison.Ordinal;
       var act = () => _ = value.RequiresEqual(target, comparisonType);
@@ -1243,6 +1244,7 @@ public class EqualsExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
+   [UseCulture(CultureData.EnglishUS)]
    [Fact]
    public void EqualExtensions_RequiresEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -13,7 +13,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -28,7 +28,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-    public void EqualExtensions_EnsuresEqualIEquatable_ShouldReturnOriginalValue_WhenValueAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+    public void EqualExtensions_EnsuresEqualIEquatable_ShouldReturnOriginalValue_WhenValueAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
     {
       // Arrange.
       T value = default!;
@@ -43,7 +43,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrow_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrow_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -56,7 +56,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrow_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrow_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -69,7 +69,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -166,7 +166,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -182,7 +182,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -198,7 +198,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrow_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrow_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -610,7 +610,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -625,7 +625,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldReturnOriginalValue_WhenValueAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldReturnOriginalValue_WhenValueAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -640,7 +640,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrow_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrow_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -653,7 +653,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrow_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrow_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -666,7 +666,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEquatable_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -767,7 +767,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueEqualsTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -783,7 +783,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldReturnOriginalValue_WhenAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -799,7 +799,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrow_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrow_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -813,7 +813,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrow_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrow_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -827,7 +827,7 @@ public class EqualsExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -84,8 +84,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = UInt32.MinValue;
-      var target = UInt32.MaxValue;
+      var data = new UInt32Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.EnsuresEqual(target);
 
       // Act/assert.
@@ -104,8 +105,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = new BoxRecordData().EqualValue;
-      var target = new BoxRecordData().NotEqualValue;
+      var data = new PointStructData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.EnsuresEqual(target);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -118,8 +120,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = new Guid("75299d53-16e1-4969-acd8-840fc2f1f821");
-      var target = new Guid("d0d5aa44-1eba-4878-8930-2c9fba8151cd");
+      var data = new GuidData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, messageTemplate);
       var expectedMessage = $"Requirement Equal failed";
@@ -133,8 +136,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = SByte.MinValue;
-      var target = SByte.MaxValue;
+      var data = new TimeOnlyData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.EnsuresEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -214,9 +218,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = 100M;
-      var target = 100M;
-      var comparer = new ReverseComparer<Decimal>();
+      var data = new nintData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.EnsuresEqual(target, comparer);
 
       // Act/assert.
@@ -235,9 +240,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = true;
-      var target = true;
-      var comparer = new ReverseComparer<Boolean>();
+      var data = new BooleanData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.EnsuresEqual(target, comparer);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -250,9 +256,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = 'A';
-      var target = 'A';
-      var comparer = new ReverseComparer<Char>();
+      var data = new UInt16Data();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, comparer, messageTemplate);
       var expectedMessage = $"Requirement Equal failed";
@@ -266,9 +273,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = new ObservationClassData().EqualValue;
-      var target = new ObservationClassData().EqualValue;
-      var comparer = new ReverseComparer<Observation>();
+      var data = new ObservationClassData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.EnsuresEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -281,9 +289,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Int64.MaxValue;
-      var target = Int64.MaxValue;
-      var comparer = new ReverseComparer<Int64>();
+      var data = new CharData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement Equal failed";
@@ -297,8 +306,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_EnsuresEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
    {
       // Arrange.
-      var value = new DateTimeData().EqualValue;
-      var target = value;
+      var data = new DateTimeData();
+      var value = data.MinValue;
+      var target = data.MinValue;
       IEqualityComparer<DateTime> comparer = null!;
       var act = () => _ = value.EnsuresEqual(target, comparer);
 
@@ -681,8 +691,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = Single.Pi;
-      var target = Single.E;
+      var data = new UInt32Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.RequiresEqual(target);
 
       // Act/assert.
@@ -701,8 +712,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = new PointStructData().EqualValue;
-      var target = new PointStructData().NotEqualValue;
+      var data = new PointStructData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.RequiresEqual(target);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
@@ -717,8 +729,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = DateTimeOffset.MaxValue;
-      var target = DateTimeOffset.MinValue;
+      var data = new GuidData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -734,8 +747,9 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = TimeOnly.MinValue;
-      var target = TimeOnly.MaxValue;
+      var data = new TimeOnlyData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.RequiresEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -843,9 +857,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = nint.MinValue;
-      var target = nint.MinValue;
-      var comparer = new ReverseComparer<nint>();
+      var data = new nintData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
@@ -864,9 +879,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = BigInteger.MinusOne;
-      var target = BigInteger.MinusOne;
-      var comparer = new ReverseComparer<BigInteger>();
+      var data = new BooleanData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.RequiresEqual(target, comparer);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
@@ -881,9 +897,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = UInt16.MaxValue;
-      var target = UInt16.MaxValue;
-      var comparer = new ReverseComparer<UInt16>();
+      var data = new UInt16Data();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, comparer, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -899,9 +916,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Double.MaxValue;
-      var target = Double.MaxValue;
-      var comparer = new ReverseComparer<Double>();
+      var data = new ObservationClassData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.RequiresEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
@@ -914,9 +932,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = DateTime.MaxValue;
-      var target = DateTime.MaxValue;
-      var comparer = new ReverseComparer<DateTime>();
+      var data = new CharData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement Equal failed";
@@ -930,9 +949,10 @@ public class EqualsExtensionsTests
    public void EqualExtensions_RequiresEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
    {
       // Arrange.
-      var value = Half.Pi;
-      var target = Half.Tau;
-      IEqualityComparer<Half> comparer = null!;
+      var data = new DateTimeData();
+      var value = data.MinValue;
+      var target = data.MinValue;
+      IEqualityComparer<DateTime> comparer = null!;
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
@@ -15,23 +15,7 @@ public class GreaterThanExtensionsTests
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenComparableValueIsGreaterThanTarget<T>(
-      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
-   {
-      // Arrange.
-      var value = data.MaxValue;
-      var target = data.MinValue;
-
-      // Act.
-      var result = value.RequiresGreaterThan(target);
-
-      // Assert.
-      result.Should().Be(value);
-   }
-
-   [Theory]
-   [ClassData(typeof(FloatingPointTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenFloatingPointValueIsGreaterThanTarget<T>(
-      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+      IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -47,7 +31,7 @@ public class GreaterThanExtensionsTests
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsNotNullAndTargetIsNull<T>(
-      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+      IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -63,21 +47,7 @@ public class GreaterThanExtensionsTests
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsEqualToTarget<T>(
-      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
-   {
-      // Arrange.
-      var value = data.MaxValue;
-      var target = data.MaxValue;
-      var act = () => _ = value.RequiresGreaterThan(target);
-
-      // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
-   }
-
-   [Theory]
-   [ClassData(typeof(FloatingPointTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenFloatingPointValueIsEqualToTarget<T>(
-      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+      IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -91,21 +61,7 @@ public class GreaterThanExtensionsTests
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsLessThanTarget<T>(
-      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
-   {
-      // Arrange.
-      var value = data.MinValue;
-      var target = data.MaxValue;
-      var act = () => _ = value.RequiresGreaterThan(target);
-
-      // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
-   }
-
-   [Theory]
-   [ClassData(typeof(FloatingPointTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenFloatingPointValueIsLessThanTarget<T>(
-      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+      IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -119,7 +75,7 @@ public class GreaterThanExtensionsTests
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenReferenceValueIsNullAndTargetIsNotNull<T>(
-      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+      IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
       T value = default!;
@@ -133,7 +89,7 @@ public class GreaterThanExtensionsTests
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_ReferenceValueIsNullAndTargetIsNull<T>(
-      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+      IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
       T value = default!;

--- a/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
@@ -14,7 +14,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
-   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldReturnOriginalValue_WhenComparableValueIsGreaterThanTarget<T>(
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsGreaterThanTarget<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -30,7 +30,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
-   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsNotNullAndTargetIsNull<T>(
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNotNullAndTargetIsNull<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -46,7 +46,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
-   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsEqualToTarget<T>(
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenCValueIsEqualToTarget<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -60,7 +60,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
-   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsLessThanTarget<T>(
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenValueIsLessThanTarget<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -104,8 +104,9 @@ public class GreaterThanExtensionsTests
    public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotGreaterThanTarget()
    {
       // Arrange.
-      var value = 10;
-      var target = 100;
+      var data = new Int32Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.EnsuresGreaterThan(target);
 
       // Act/assert.
@@ -139,8 +140,9 @@ public class GreaterThanExtensionsTests
    public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = Half.MinValue;
-      var target = Half.MinValue;
+      var data = new HalfData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresGreaterThan(target, messageTemplate);
       var expectedMessage = $"Requirement GreaterThan failed";
@@ -154,8 +156,9 @@ public class GreaterThanExtensionsTests
    public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = UInt128.MinValue;
-      var target = UInt128.MaxValue;
+      var data = new UInt128Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.EnsuresGreaterThan(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
 
@@ -181,13 +184,216 @@ public class GreaterThanExtensionsTests
 
    #endregion
 
+   #region EnsuresGreaterThan (IComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldReturnOriginalValue_WhenValueIsGreaterThanTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      var target = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.EnsuresGreaterThan(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldReturnOriginalValue_WhenReferenceValueIsNotNullAndTargetIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      T target = default!;
+      var comparer = Comparer<T>.Default;
+
+      // Act.
+      var result = value.EnsuresGreaterThan(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrow_WhenValueIsEqualToTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrow_WhenValueIsLessThanTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrow_WhenReferenceValueIsNullAndTargetIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = data.ReverseMaxValue;
+      var comparer = Comparer<T>.Default;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrow_ReferenceValueIsNullAndTargetIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var data = new DateTimeData();
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThan);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var data = new BoxRecordData();
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+      var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new ByteData();
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer, messageTemplate);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().Be(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new DoubleData();
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = "ABC";
+      var target = "abc";
+      var comparer = StringComparer.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var data = new TimeOnlyData();
+      var value = data.ReverseMaxValue;
+      var target = data.ReverseMinValue;
+      IComparer<TimeOnly> comparer = null!;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
+   }
+
+   #endregion
+
    #region RequiresGreaterThan (IComparable) Tests
    // ==========================================================================
    // ==========================================================================
 
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenComparableValueIsGreaterThanTarget<T>(
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsGreaterThanTarget<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -203,7 +409,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsNotNullAndTargetIsNull<T>(
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNotNullAndTargetIsNull<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -219,7 +425,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsEqualToTarget<T>(
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenValueIsEqualToTarget<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -233,7 +439,7 @@ public class GreaterThanExtensionsTests
 
    [Theory]
    [ClassData(typeof(ComparableTypesTestData))]
-   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsLessThanTarget<T>(
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenValueIsLessThanTarget<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -277,12 +483,13 @@ public class GreaterThanExtensionsTests
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotGreaterThanTarget()
    {
       // Arrange.
-      var value = 10;
-      var target = 100;
+      var data = new Int32Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.RequiresGreaterThan(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -315,8 +522,9 @@ public class GreaterThanExtensionsTests
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = Half.MinValue;
-      var target = Half.MinValue;
+      var data = new HalfData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresGreaterThan(target, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -333,8 +541,9 @@ public class GreaterThanExtensionsTests
    public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = UInt128.MinValue;
-      var target = UInt128.MaxValue;
+      var data = new UInt128Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
       var act = () => _ = value.RequiresGreaterThan(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
 
@@ -356,6 +565,215 @@ public class GreaterThanExtensionsTests
       // Act/assert.
       act.Should().Throw<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresGreaterThan (IComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldReturnOriginalValue_WhenValueIsGreaterThanTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      var target = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.RequiresGreaterThan(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldReturnOriginalValue_WhenReferenceValueIsNotNullAndTargetIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      T target = default!;
+      var comparer = Comparer<T>.Default;
+
+      // Act.
+      var result = value.RequiresGreaterThan(target, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrow_WhenValueIsEqualToTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrow_WhenValueIsLessThanTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrow_WhenReferenceValueIsNullAndTargetIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = data.ReverseMaxValue;
+      var comparer = Comparer<T>.Default;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrow_ReferenceValueIsNullAndTargetIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var data = new DateTimeData();
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThan);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var data = new BoxRecordData();
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new ByteData();
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThan(target, comparer, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new DoubleData();
+      var value = data.ReverseMinValue;
+      var target = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = "ABC";
+      var target = "abc";
+      var comparer = StringComparer.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThan(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var data = new TimeOnlyData();
+      var value = data.ReverseMaxValue;
+      var target = data.ReverseMinValue;
+      IComparer<TimeOnly> comparer = null!;
+      var act = () => _ = value.RequiresGreaterThan(target, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
@@ -387,6 +387,277 @@ public class GreaterThanExtensionsTests
 
    #endregion
 
+   #region EnsuresGreaterThan (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldReturnOriginalValue_WhenValueIsGreaterThanTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDottedI, StringData.LowerCaseI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseI, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseA, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseDottedI, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldReturnOriginalValue_WhenValueIsGreaterThanTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseA, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.UpperCaseAE, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldReturnOriginalValue_WhenValueIsGreaterThanTargetAndCurrentCultureIs_svSE(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrow_WhenValueIsEqualToTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseDotlessI, StringData.LowerCaseI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrow_WhenValueIsLessThanTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrow_WhenValueIsDefaultAndTargetIsNotAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      var target = "asdf";
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrow_WhenValueIsDefaultAndTargetIsNotAndCurrentCultureIs_svSE(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      var target = "asdf";
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrow_WhenValueAndTargetAreDefaultAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrow_WhenValueAndTargetAreDefaultAndCurrentCultureIs_daDK(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrowWithExpectedDataDictionary_WhenValueIsLessThanTarget()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseA;
+      var target = StringData.UpperCaseZ;
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThan);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsLessThanTarget()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseA;
+      var target = StringData.LowerCaseZ;
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType);
+      var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseH;
+      var target = StringData.LowerCaseJ;
+      var comparisonType = StringComparison.InvariantCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType, messageTemplate);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseJ;
+      var target = StringData.LowerCaseJ;
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseA;
+      var target = StringData.UpperCaseZ;
+      var comparisonType = StringComparison.CurrentCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThan(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
    #region RequiresGreaterThan (IComparable) Tests
    // ==========================================================================
    // ==========================================================================
@@ -774,6 +1045,281 @@ public class GreaterThanExtensionsTests
       act.Should().Throw<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
+   }
+
+   #endregion
+
+   #region RequiresGreaterThan (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldReturnOriginalValue_WhenValueIsGreaterThanTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresGreaterThan(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDottedI, StringData.LowerCaseI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseI, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseA, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseDottedI, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseAE, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldReturnOriginalValue_WhenValueIsGreaterThanTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresGreaterThan(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseA, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.UpperCaseAE, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldReturnOriginalValue_WhenValueIsGreaterThanTargetAndCurrentCultureIs_svSE(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresGreaterThan(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrow_WhenValueIsEqualToTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseDotlessI, StringData.LowerCaseI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrow_WhenValueIsLessThanTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrow_WhenValueIsDefaultAndTargetIsNotAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      var target = "asdf";
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrow_WhenValueIsDefaultAndTargetIsNotAndCurrentCultureIs_svSE(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      var target = "asdf";
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrow_WhenValueAndTargetAreDefaultAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrow_WhenValueAndTargetAreDefaultAndCurrentCultureIs_daDK(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String target = default!;
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrowWithExpectedDataDictionary_WhenValueIsLessThanTarget()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseA;
+      var target = StringData.UpperCaseZ;
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThan);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenValueIsLessThanTarget()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseA;
+      var target = StringData.LowerCaseZ;
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseH;
+      var target = StringData.LowerCaseJ;
+      var comparisonType = StringComparison.InvariantCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseJ;
+      var target = StringData.LowerCaseJ;
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseA;
+      var target = StringData.UpperCaseZ;
+      var comparisonType = StringComparison.CurrentCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThan(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
@@ -1,0 +1,233 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class GreaterThanExtensionsTests
+{
+   private const Int32 _dataCount = 6;
+   private const Int32 _stringDataCount = 7;
+
+   #region RequiresGreaterThan (IComparable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenComparableValueIsGreaterThanTarget<T>(
+      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var target = data.MinValue;
+
+      // Act.
+      var result = value.RequiresGreaterThan(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenFloatingPointValueIsGreaterThanTarget<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var target = data.MinValue;
+
+      // Act.
+      var result = value.RequiresGreaterThan(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsNotNullAndTargetIsNull<T>(
+      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      T target = default!;
+
+      // Act.
+      var result = value.RequiresGreaterThan(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsEqualToTarget<T>(
+      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenFloatingPointValueIsEqualToTarget<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsLessThanTarget<T>(
+      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(FloatingPointTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenFloatingPointValueIsLessThanTarget<T>(
+      FloatingPointValue<T> data) where T : IFloatingPoint<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_WhenReferenceValueIsNullAndTargetIsNotNull<T>(
+      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrow_ReferenceValueIsNullAndTargetIsNull<T>(
+      ComparableValue<T> data) where T : IComparable<T>, IEquatable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var value = 10;
+      var target = 100;
+      var act = () => _ = value.RequiresGreaterThan(target);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThan);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = Half.MinValue;
+      var target = Half.MinValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThan(target, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = UInt128.MinValue;
+      var target = UInt128.MaxValue;
+      var act = () => _ = value.RequiresGreaterThan(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThanIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var target = "ABC";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThan(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
@@ -8,6 +8,179 @@ public class GreaterThanExtensionsTests
    private const Int32 _dataCount = 6;
    private const Int32 _stringDataCount = 7;
 
+   #region EnsuresGreaterThan (IComparable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldReturnOriginalValue_WhenComparableValueIsGreaterThanTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var target = data.MinValue;
+
+      // Act.
+      var result = value.EnsuresGreaterThan(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldReturnOriginalValue_WhenValueIsNotNullAndTargetIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      T target = default!;
+
+      // Act.
+      var result = value.EnsuresGreaterThan(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsEqualToTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenComparableValueIsLessThanTarget<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_WhenReferenceValueIsNullAndTargetIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = data.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrow_ReferenceValueIsNullAndTargetIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T target = default!;
+      var act = () => _ = value.EnsuresGreaterThan(target);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowWithExpectedDataDictionary_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var value = 10;
+      var target = 100;
+      var act = () => _ = value.EnsuresGreaterThan(target);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThan);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNotGreaterThanTarget()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var value = data.MaxValue;
+      var target = data.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThan(target);
+      var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = Half.MinValue;
+      var target = Half.MinValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThan(target, messageTemplate);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = UInt128.MinValue;
+      var target = UInt128.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThan(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {target}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThanIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var target = "ABC";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThan(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThan failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
    #region RequiresGreaterThan (IComparable) Tests
    // ==========================================================================
    // ==========================================================================

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -13,7 +13,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -28,7 +28,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -43,7 +43,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -58,7 +58,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrow_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrow_WhenValueEqualsTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -71,7 +71,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrow_WhenValueAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrow_WhenValueAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -168,7 +168,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -184,7 +184,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -200,7 +200,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -216,7 +216,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrow_WhenAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrow_WhenAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -586,7 +586,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -601,7 +601,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -616,7 +616,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldReturnOriginalValue_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -631,7 +631,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrow_WhenValueEqualsTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrow_WhenValueEqualsTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -644,7 +644,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrow_WhenValueAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrow_WhenValueAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -745,7 +745,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueDoesNotEqualTarget<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -761,7 +761,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldReturnOriginalValue_WhenValueIsDefaultAndTargetIsNot<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;
@@ -777,7 +777,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrow_WhenValueIsNotDefaultAndTargetIs<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       var value = data.EqualValue;
@@ -793,7 +793,7 @@ public class NotEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(EquatableTypesTestData))]
-   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrow_WhenAndTargetAreDefault<T>(EquatableValue<T> data) where T : IEquatable<T>
+   public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrow_WhenAndTargetAreDefault<T>(IEquatableTestData<T> data) where T : IEquatable<T>
    {
       // Arrange.
       T value = default!;

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -86,8 +86,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
    {
       // Arrange.
-      var value = 100;
-      var target = value;
+      var data = new Int32Data();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var act = () => _ = value.EnsuresNotEqual(target);
 
       // Act/assert.
@@ -106,8 +107,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueEqualsTarget()
    {
       // Arrange.
-      var value = StringData.UpperCaseAE;
-      var target = StringData.UpperCaseAE;
+      var data = new StringData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var act = () => _ = value.EnsuresNotEqual(target);
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
@@ -120,8 +122,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = new ObservationClassData().EqualValue;
-      var target = new ObservationClassData().EqualValue;
+      var data = new PointStructData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresNotEqual(target, messageTemplate);
       var expectedMessage = $"Requirement NotEqual failed";
@@ -135,8 +138,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Double.Pi;
-      var target = Double.Pi;
+      var data = new DateOnlyData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var act = () => _ = value.EnsuresNotEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
@@ -149,8 +153,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = new PointStructData().EqualValue;
-      var target = new PointStructData().EqualValue;
+      var data = new ObservationClassData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresNotEqual(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement NotEqual failed";
@@ -232,9 +237,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = nint.MinValue;
-      var target = nint.MaxValue;
-      var comparer = new ReverseComparer<nint>();
+      var data = new nuintData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.EnsuresNotEqual(target, comparer);
 
       // Act/assert.
@@ -253,9 +259,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = BigInteger.MinusOne;
-      var target = BigInteger.One;
-      var comparer = new ReverseComparer<BigInteger>();
+      var data = new BigIntegerData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.EnsuresNotEqual(target, comparer);
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
@@ -268,9 +275,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = UInt16.MaxValue;
-      var target = UInt16.MinValue;
-      var comparer = new ReverseComparer<UInt16>();
+      var data = new UInt16Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresNotEqual(target, comparer, messageTemplate);
       var expectedMessage = $"Requirement NotEqual failed";
@@ -284,9 +292,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Double.MaxValue;
-      var target = Double.MinValue;
-      var comparer = new ReverseComparer<Double>();
+      var data = new BooleanData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.EnsuresNotEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
@@ -299,9 +308,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = DateTime.MaxValue;
-      var target = DateTime.MinValue;
-      var comparer = new ReverseComparer<DateTime>();
+      var data = new DateTimeData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.EnsuresNotEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement NotEqual failed";
@@ -315,9 +325,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
    {
       // Arrange.
-      var value = Half.Pi;
-      var target = Half.Tau;
-      IEqualityComparer<Half> comparer = null!;
+      var data = new Int64Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      IEqualityComparer<Int64> comparer = null!;
       var act = () => _ = value.EnsuresNotEqual(target, comparer);
 
       // Act/assert.
@@ -659,8 +670,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
    {
       // Arrange.
-      var value = 100;
-      var target = value;
+      var data = new Int32Data();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var act = () => _ = value.RequiresNotEqual(target);
 
       // Act/assert.
@@ -679,8 +691,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueEqualsTarget()
    {
       // Arrange.
-      var value = StringData.UpperCaseAE;
-      var target = StringData.UpperCaseAE;
+      var data = new StringData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var act = () => _ = value.RequiresNotEqual(target);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
@@ -695,8 +708,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = new ObservationClassData().EqualValue;
-      var target = new ObservationClassData().EqualValue;
+      var data = new PointStructData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresNotEqual(target, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -712,8 +726,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Double.Pi;
-      var target = Double.Pi;
+      var data = new DateOnlyData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var act = () => _ = value.RequiresNotEqual(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
@@ -726,8 +741,9 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEquatable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = new PointStructData().EqualValue;
-      var target = new PointStructData().EqualValue;
+      var data = new ObservationClassData();
+      var value = data.EqualValue;
+      var target = data.EqualValue;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresNotEqual(target, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement NotEqual failed";
@@ -809,9 +825,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowWithExpectedDataDictionary_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = nint.MinValue;
-      var target = nint.MaxValue;
-      var comparer = new ReverseComparer<nint>();
+      var data = new nuintData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.RequiresNotEqual(target, comparer);
 
       // Act/assert.
@@ -830,9 +847,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueDoesNotEqualTarget()
    {
       // Arrange.
-      var value = BigInteger.MinusOne;
-      var target = BigInteger.One;
-      var comparer = new ReverseComparer<BigInteger>();
+      var data = new BigIntegerData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.RequiresNotEqual(target, comparer);
       var expectedParameterName = nameof(value);
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
@@ -847,9 +865,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowArgumentExceptionWithExpectedMessage_WhenCustomMessageTemplateIsUsed()
    {
       // Arrange.
-      var value = UInt16.MaxValue;
-      var target = UInt16.MinValue;
-      var comparer = new ReverseComparer<UInt16>();
+      var data = new UInt16Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresNotEqual(target, comparer, messageTemplate);
       var expectedParameterName = nameof(value);
@@ -865,9 +884,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = Double.MaxValue;
-      var target = Double.MinValue;
-      var comparer = new ReverseComparer<Double>();
+      var data = new BooleanData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var act = () => _ = value.RequiresNotEqual(target, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
@@ -880,9 +900,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
-      var value = DateTime.MaxValue;
-      var target = DateTime.MinValue;
-      var comparer = new ReverseComparer<DateTime>();
+      var data = new DateTimeData();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      var comparer = data.ReverseComparer;
       var messageTemplate = "Requirement {RequirementName} failed";
       var act = () => _ = value.RequiresNotEqual(target, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
       var expectedMessage = $"Requirement NotEqual failed";
@@ -896,9 +917,10 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualIEqualityComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
    {
       // Arrange.
-      var value = Half.Pi;
-      var target = Half.Tau;
-      IEqualityComparer<Half> comparer = null!;
+      var data = new Int64Data();
+      var value = data.MinValue;
+      var target = data.MaxValue;
+      IEqualityComparer<Int64> comparer = null!;
       var act = () => _ = value.RequiresNotEqual(target, comparer);
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -349,7 +349,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseA, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_enUS(
       String value,
@@ -369,7 +369,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_trTR(
       String value,
@@ -389,7 +389,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_thTH(
       String value,
@@ -410,7 +410,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_enUS(
       String value,
       String target,
@@ -433,7 +433,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_trTR(
       String value,
       String target,
@@ -454,7 +454,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_thTH(
       String value,
       String target,
@@ -509,8 +509,8 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
    {
       // Arrange.
-      var value = StringData.LowerCaseDipthongAE;
-      var target = StringData.LowerCaseDipthongAE;
+      var value = StringData.LowerCaseDiphthongAE;
+      var target = StringData.LowerCaseDiphthongAE;
       var comparisonType = StringComparison.Ordinal;
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
@@ -573,6 +573,7 @@ public class NotEqualExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
+   [UseCulture(CultureData.EnglishUS)]
    [Fact]
    public void NotEqualExtensions_EnsuresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
@@ -941,7 +942,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseA, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_enUS(
       String value,
@@ -961,7 +962,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_trTR(
       String value,
@@ -981,7 +982,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.InvariantCultureIgnoreCase)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldReturnOriginalValue_WhenValueDoesNotEqualTargetAndCurrentCultureIs_thTH(
       String value,
@@ -1002,7 +1003,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_enUS(
       String value,
       String target,
@@ -1025,7 +1026,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_trTR(
       String value,
       String target,
@@ -1046,7 +1047,7 @@ public class NotEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
-   [InlineData(StringData.LowerCaseDipthongAE, StringData.UpperCaseDipthongAE, StringComparison.OrdinalIgnoreCase)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldThrow_WhenValueEqualsTargetAndCurrentCultureIs_thTH(
       String value,
       String target,
@@ -1101,8 +1102,8 @@ public class NotEqualExtensionsTests
    public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowWithExpectedDataDictionary_WhenValueEqualsTarget()
    {
       // Arrange.
-      var value = StringData.LowerCaseDipthongAE;
-      var target = StringData.LowerCaseDipthongAE;
+      var value = StringData.LowerCaseDiphthongAE;
+      var target = StringData.LowerCaseDiphthongAE;
       var comparisonType = StringComparison.Ordinal;
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
@@ -1169,6 +1170,7 @@ public class NotEqualExtensionsTests
          .And.Message.Should().StartWith(expectedMessage);
    }
 
+   [UseCulture(CultureData.EnglishUS)]
    [Fact]
    public void NotEqualExtensions_RequiresNotEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {

--- a/DbC.Net.Tests.Unit/TestData/ComparableTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableTypesTestData.cs
@@ -1,6 +1,6 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public sealed class EquatableTypesTestData : IEnumerable<Object[]>
+public sealed class ComparableTypesTestData : IEnumerable<Object[]>
 {
    public IEnumerator<Object[]> GetEnumerator()
    {

--- a/DbC.Net.Tests.Unit/TestData/ComparableTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableTypesTestData.cs
@@ -11,12 +11,16 @@ public sealed class ComparableTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new DateOnlyData() };
       yield return new Object[] { new DateTimeData() };
       yield return new Object[] { new DateTimeOffsetData() };
+      yield return new Object[] { new DecimalData() };
+      yield return new Object[] { new DoubleData() };
       yield return new Object[] { new GuidData() };
+      yield return new Object[] { new HalfData() };
       yield return new Object[] { new Int128Data() };
       yield return new Object[] { new Int16Data() };
       yield return new Object[] { new Int32Data() };
       yield return new Object[] { new Int64Data() };
       yield return new Object[] { new SByteData() };
+      yield return new Object[] { new SingleData() };
       yield return new Object[] { new TimeOnlyData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };

--- a/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
@@ -1,6 +1,6 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public abstract class ComparableValue<T> : EquatableValue<T>
+public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestData<T>
    where T : IEquatable<T>, IComparable<T>
 {
    public ComparableValue(

--- a/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
@@ -12,9 +12,15 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
    {
       MinValue = minValue;
       MaxValue = maxValue;
+      ReverseMaxValue = minValue;
+      ReverseMinValue = maxValue;
    }
 
    public T MaxValue { get; }
 
    public T MinValue { get; }
+
+   public T ReverseMaxValue { get; }
+
+   public T ReverseMinValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/CultureData.cs
+++ b/DbC.Net.Tests.Unit/TestData/CultureData.cs
@@ -1,0 +1,14 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public static class CultureData
+{
+   public const String DanishDenmark = "da-DK";
+
+   public const String EnglishUS = "en-US";
+
+   public const String SwedishSweden = "sv-SE";
+
+   public const String ThaiThailand = "th-TH";
+
+   public const String TurkishTurkey = "tr-TR";
+}

--- a/DbC.Net.Tests.Unit/TestData/DecimalData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DecimalData.cs
@@ -9,6 +9,8 @@ public class DecimalData : FloatingPointValue<Decimal>
       0.000003M,
       StandardFloatingPointComparers.DecimalFixedErrorComparer,
       0.000003M,
-      default!)
+      default!,
+      Decimal.MaxValue,
+      Decimal.MinValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DecimalData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DecimalData.cs
@@ -11,6 +11,7 @@ public class DecimalData : FloatingPointValue<Decimal>
       0.000003M,
       default!,
       Decimal.MaxValue,
-      Decimal.MinValue)
+      Decimal.MinValue,
+      new ReverseComparer<Decimal>())
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DoubleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DoubleData.cs
@@ -9,6 +9,8 @@ public class DoubleData : FloatingPointValue<Double>
       0.000000000000003D,
       StandardFloatingPointComparers.DoubleFixedErrorComparer,
       0.0000000000000002D,
-      StandardFloatingPointComparers.DoubleRelativeErrorComparer)
+      StandardFloatingPointComparers.DoubleRelativeErrorComparer,
+      Double.MaxValue,
+      Double.MinValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DoubleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DoubleData.cs
@@ -11,6 +11,7 @@ public class DoubleData : FloatingPointValue<Double>
       0.0000000000000002D,
       StandardFloatingPointComparers.DoubleRelativeErrorComparer,
       Double.MaxValue,
-      Double.MinValue)
+      Double.MinValue,
+      new ReverseComparer<Double>())
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/EquatableValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/EquatableValue.cs
@@ -1,6 +1,6 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public abstract class EquatableValue<T> where T : IEquatable<T>
+public abstract class EquatableValue<T> : IEquatableTestData<T> where T : IEquatable<T>
 {
     public EquatableValue(
        T equalValue,

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -1,6 +1,6 @@
 ﻿namespace DbC.Net.Tests.Unit.TestData;
 
-public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
+public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : IFloatingPoint<T>
 {
    public FloatingPointValue(
       T value,
@@ -11,7 +11,8 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
       T relativeEpsilon,
       IApproximateEqualityComparer<T> relativeErrorComparer,
       T maxValue,
-      T minValue)
+      T minValue,
+      ReverseComparer<T> reverseComparer)
    {
       Value = value;
       WithinToleranceDelta = withinToleranceDelta;
@@ -22,6 +23,7 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
       RelativeErrorComparer = relativeErrorComparer;
       MaxValue = maxValue;
       MinValue = minValue;
+      ReverseComparer = reverseComparer;
    }
 
    public virtual T Value { get; }
@@ -41,4 +43,6 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
    public T MaxValue { get; }
 
    public T MinValue { get; }
+
+   public ReverseComparer<T> ReverseComparer { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -24,6 +24,8 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
       MaxValue = maxValue;
       MinValue = minValue;
       ReverseComparer = reverseComparer;
+      ReverseMaxValue = minValue;
+      ReverseMinValue = maxValue;
    }
 
    public virtual T Value { get; }
@@ -45,4 +47,8 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
    public T MinValue { get; }
 
    public ReverseComparer<T> ReverseComparer { get; }
+
+   public T ReverseMaxValue { get; }
+
+   public T ReverseMinValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -9,7 +9,9 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
       T fixedEpsilon,
       IApproximateEqualityComparer<T> fixedErrorComparer,
       T relativeEpsilon,
-      IApproximateEqualityComparer<T> relativeErrorComparer)
+      IApproximateEqualityComparer<T> relativeErrorComparer,
+      T maxValue,
+      T minValue)
    {
       Value = value;
       WithinToleranceDelta = withinToleranceDelta;
@@ -18,6 +20,8 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
       FixedErrorComparer = fixedErrorComparer;
       RelativeEpsilon = relativeEpsilon;
       RelativeErrorComparer = relativeErrorComparer;
+      MaxValue = maxValue;
+      MinValue = minValue;
    }
 
    public virtual T Value { get; }
@@ -33,4 +37,8 @@ public abstract class FloatingPointValue<T> where T : IFloatingPoint<T>
    public virtual IApproximateEqualityComparer<T> FixedErrorComparer { get; } = default!;
 
    public virtual IApproximateEqualityComparer<T> RelativeErrorComparer { get; } = default!;
+
+   public T MaxValue { get; }
+
+   public T MinValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/HalfData.cs
+++ b/DbC.Net.Tests.Unit/TestData/HalfData.cs
@@ -9,7 +9,9 @@ public class HalfData : FloatingPointValue<Half>
       (Half)0.03F,
       StandardFloatingPointComparers.HalfFixedErrorComparer,
       (Half)0.002F,
-      StandardFloatingPointComparers.HalfRelativeErrorComparer)
+      StandardFloatingPointComparers.HalfRelativeErrorComparer,
+      Half.MaxValue,
+      Half.MinValue)
    { }
 }
 

--- a/DbC.Net.Tests.Unit/TestData/HalfData.cs
+++ b/DbC.Net.Tests.Unit/TestData/HalfData.cs
@@ -11,7 +11,8 @@ public class HalfData : FloatingPointValue<Half>
       (Half)0.002F,
       StandardFloatingPointComparers.HalfRelativeErrorComparer,
       Half.MaxValue,
-      Half.MinValue)
+      Half.MinValue,
+      new ReverseComparer<Half>())
    { }
 }
 

--- a/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
@@ -7,4 +7,8 @@ public interface IComparableTestData<T> where T : IComparable<T>
    T MinValue { get; }
 
    ReverseComparer<T> ReverseComparer { get; }
+
+   T ReverseMaxValue { get; }
+
+   T ReverseMinValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
@@ -1,0 +1,10 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public interface IComparableTestData<T> where T : IComparable<T>
+{
+   T MaxValue { get; }
+
+   T MinValue { get; }
+
+   ReverseComparer<T> ReverseComparer { get; }
+}

--- a/DbC.Net.Tests.Unit/TestData/IEquatableTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/IEquatableTestData.cs
@@ -1,0 +1,12 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public interface IEquatableTestData<T> where T : IEquatable<T>
+{
+   T EqualValue { get; }
+
+   T NotEqualValue { get; }
+
+   T NonDefaultNotEqualValue { get; }
+
+   ReverseComparer<T> ReverseComparer { get; }
+}

--- a/DbC.Net.Tests.Unit/TestData/SingleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SingleData.cs
@@ -9,6 +9,8 @@ public class SingleData : FloatingPointValue<Single>
       0.00003F,
       StandardFloatingPointComparers.SingleFixedErrorComparer,
       0.000002F,
-      StandardFloatingPointComparers.SingleRelativeErrorComparer)
+      StandardFloatingPointComparers.SingleRelativeErrorComparer,
+      Single.MaxValue,
+      Single.MinValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/SingleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SingleData.cs
@@ -11,6 +11,7 @@ public class SingleData : FloatingPointValue<Single>
       0.000002F,
       StandardFloatingPointComparers.SingleRelativeErrorComparer,
       Single.MaxValue,
-      Single.MinValue)
+      Single.MinValue,
+      new ReverseComparer<Single>())
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/StringData.cs
+++ b/DbC.Net.Tests.Unit/TestData/StringData.cs
@@ -13,16 +13,30 @@ public class StringData : ComparableValue<String>
    public const String UpperCaseA = "A";
    public const String LowerCaseA = "a";
 
+   // A with diaeresis sorts between A(overring) and O(diaeresis) in sv-SE culture (Swedish/Sweden)
+   public const String UpperCaseAWithDiaeresis = "\u00C4";
+   public const String LowerCaseAWithDiaeresis = "\u00E4";
+
+   // A with overring sorts as the last character, after O with slash, in da-DK culture (Danish/Denmark)
+   // and between Z and A(diaeresis) in sv-SE culture (Swedish/Sweden)
+   public const String UpperCaseAWithOverring = "\u00C5";
+   public const String LowerCaseAWithOverring = "\u00E5";
+
    public const String UpperCaseAE = "AE";
    public const String LowerCaseAE = "ae";
 
+   // a- is considered equal to a in th-TH culture (Thai/Thailand)
    public const String LowerCaseADash = "a-";
 
-   public const String UpperCaseDipthongAE = "\u00C6";
-   public const String LowerCaseDipthongAE = "\u00E6";
+   // Diphthong AE sorts between z and o with slash in da-DK culture (Danish/Denmark)
+   public const String UpperCaseDiphthongAE = "\u00C6";
+   public const String LowerCaseDiphthongAE = "\u00E6";
 
    public const String UpperCaseEszett = "\u1E9E";
    public const String LowerCaseEszett = "\u00DF";
+
+   public const String UpperCaseH = "H";
+   public const String LowerCaseH = "h";
 
    public const String UpperCaseI = "I";
    public const String LowerCaseI = "i";
@@ -30,11 +44,18 @@ public class StringData : ComparableValue<String>
    public const String UpperCaseJ = "J";
    public const String LowerCaseJ = "j";
 
+   // Dot-less I sorts between H and dotted I in tr-TR culture (Turkish/Turkey)
    public const String UpperCaseDottedI = "\u0130";
    public const String LowerCaseDotlessI = "\u0131";
 
+   // O with slash sorts between diphthong AE and a(overring) in da-DK culture (Danish/Denmark)
    public const String UpperCaseSlashedO = "\u00D8";
    public const String LowerCaseSlashedO = "\u00F8";
+
+   // O with diaeresis (or umlaut) sorts after Z, A(overring), A(diaeresis) in sv-SE culture (Swedish/Sweden)
+   // and between o and p in tr-TR culture (Turkish)
+   public const String UpperCaseOWithDiaeresis = "\u00D6";
+   public const String LowerCaseOWithDiaeresis = "\u00F6";
 
    public const String UpperCaseSs = "SS";
    public const String LowerCaseSs = "ss";

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 	ProjectSection(SolutionItems) = preProject
 		Documentation\ApproximatelyEqual.md = Documentation\ApproximatelyEqual.md
 		Documentation\Equal.md = Documentation\Equal.md
+		Documentation\GreaterThan.md = Documentation\GreaterThan.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md

--- a/DbC.Net/EqualExtensions.cs
+++ b/DbC.Net/EqualExtensions.cs
@@ -366,9 +366,7 @@ public static class EqualExtensions
             || (value is null && target is null)))
       {
          messageTemplate ??= MessageTemplates.EqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value!,
@@ -393,9 +391,7 @@ public static class EqualExtensions
       if (!comparer.Equals(value, target))
       {
          messageTemplate ??= MessageTemplates.EqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value,
@@ -421,9 +417,7 @@ public static class EqualExtensions
             || (value is null && target is null)))
       {
          messageTemplate ??= MessageTemplates.EqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value,
@@ -451,4 +445,9 @@ public static class EqualExtensions
          {  DataNames.Target, target! },
          {  DataNames.TargetExpression, targetExpression }
       };
+
+   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
+      => requirementType == RequirementType.Precondition
+         ? StandardExceptionFactories.ArgumentExceptionFactory
+         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/EqualExtensions.cs
+++ b/DbC.Net/EqualExtensions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   Extension methods that implement Equal requirement for types that
 ///   implement <see cref="IEquatable{T}"/> or that use 
-///   <see cref="IEqualityComparer{T}"/>
+///   <see cref="IEqualityComparer{T}"/>.
 /// </summary>
 public static class EqualExtensions
 {

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -45,12 +45,74 @@ public static class GreaterThanExtensions
       T target,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression("value")] String valueExpression = null!,
-      [CallerArgumentExpression("target")] String targetExpression = null!) where T : IComparable<T>
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(target))] String targetExpression = null!) where T : IComparable<T>
    {
       CheckGreaterThan(
          value,
          target,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value GreaterThan postcondition. Confirm that <paramref name="value"/>
+   ///   is greater than <paramref name="target"/> and throw an exception if it 
+   ///   is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be greater than.
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IComparer{T}"/> used to compare <paramref name="value"/> 
+   ///   and <paramref name="target"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T EnsuresGreaterThan<T>(
+      this T value,
+      T target,
+      IComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(target))] String targetExpression = null!)
+   {
+      CheckGreaterThan(
+         value,
+         target,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
          RequirementType.Postcondition,
          messageTemplate,
          exceptionFactory,
@@ -98,12 +160,74 @@ public static class GreaterThanExtensions
       T target,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression("value")] String valueExpression = null!,
-      [CallerArgumentExpression("target")] String targetExpression = null!) where T : IComparable<T>
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(target))] String targetExpression = null!) where T : IComparable<T>
    {
       CheckGreaterThan(
          value,
          target,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value GreaterThan precondition. Confirm that <paramref name="value"/>
+   ///   is greater than <paramref name="target"/> and throw an exception if it 
+   ///   is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be greater than.
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IComparer{T}"/> used to compare <paramref name="value"/> 
+   ///   and <paramref name="target"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T RequiresGreaterThan<T>(
+      this T value,
+      T target,
+      IComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(target))] String targetExpression = null!)
+   {
+      CheckGreaterThan(
+         value,
+         target,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull),
          RequirementType.Precondition,
          messageTemplate,
          exceptionFactory,
@@ -123,6 +247,33 @@ public static class GreaterThanExtensions
       String targetExpression) where T : IComparable<T>
    {
       if (value is null || value!.CompareTo(target) <= 0)
+      {
+         messageTemplate ??= MessageTemplates.GreaterThanTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = GetDataDictionary(
+            requirementType,
+            value!,
+            valueExpression,
+            target!,
+            targetExpression);
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static void CheckGreaterThan<T>(
+      T value,
+      T target,
+      IComparer<T> comparer,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression)
+   {
+      if (comparer.Compare(value, target) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanTemplate;
          exceptionFactory ??= requirementType == RequirementType.Precondition

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -1,0 +1,104 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement GreaterThan requirement for types that
+///   implement <see cref="IComparable{T}"/> or that use 
+///   <see cref="IComparer{T}"/>.
+/// </summary>
+public static class GreaterThanExtensions
+{
+   /// <summary>
+   ///   Value GreaterThan precondition. Confirm that <paramref name="value"/>
+   ///   is greater than <paramref name="target"/> and throw an exception if it 
+   ///   is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be greater than.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresGreaterThan<T>(
+      this T value,
+      T target,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!) where T : IComparable<T>
+   {
+      CheckGreaterThan(
+         value,
+         target,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   private static void CheckGreaterThan<T>(
+      T value,
+      T target,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression) where T : IComparable<T>
+   {
+      if (value is null || value!.CompareTo(target) <= 0)
+      {
+         messageTemplate ??= MessageTemplates.GreaterThanTemplate;
+         exceptionFactory ??= requirementType == RequirementType.Precondition
+            ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         var data = GetDataDictionary(
+            requirementType,
+            value!,
+            valueExpression,
+            target!,
+            targetExpression);
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static Dictionary<String, Object> GetDataDictionary<T>(
+      RequirementType requirementType,
+      T value,
+      String valueExpression,
+      T target,
+      String targetExpression)
+      => new()
+      {
+         {  DataNames.RequirementType, requirementType },
+         {  DataNames.RequirementName, RequirementNames.GreaterThan },
+         {  DataNames.Value, value! },
+         {  DataNames.ValueExpression, valueExpression },
+         {  DataNames.Target, target! },
+         {  DataNames.TargetExpression, targetExpression }
+      };
+}

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -123,6 +123,66 @@ public static class GreaterThanExtensions
    }
 
    /// <summary>
+   ///   Value GreaterThan postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is greater than the <see cref="String"/> 
+   ///   <paramref name="target"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be greater than.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String EnsuresGreaterThan(
+      this String value,
+      String target,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(target))] String targetExpression = null!)
+   {
+      CheckGreaterThan(
+         value,
+         target,
+         comparisonType,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   Value GreaterThan precondition. Confirm that <paramref name="value"/>
    ///   is greater than <paramref name="target"/> and throw an exception if it 
    ///   is not.
@@ -237,6 +297,66 @@ public static class GreaterThanExtensions
       return value;
    }
 
+   /// <summary>
+   ///   Value GreaterThan precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is greater than the <see cref="String"/> 
+   ///   <paramref name="target"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be greater than.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String RequiresGreaterThan(
+      this String value,
+      String target,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(target))] String targetExpression = null!)
+   {
+      CheckGreaterThan(
+         value,
+         target,
+         comparisonType,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
    private static void CheckGreaterThan<T>(
       T value,
       T target,
@@ -249,9 +369,7 @@ public static class GreaterThanExtensions
       if (value is null || value!.CompareTo(target) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value!,
@@ -276,15 +394,39 @@ public static class GreaterThanExtensions
       if (comparer.Compare(value, target) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value!,
             valueExpression,
             target!,
             targetExpression);
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static void CheckGreaterThan(
+      String value,
+      String target,
+      StringComparison comparisonType,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression)
+   {
+      if (String.Compare(value, target, comparisonType) <= 0)
+      {
+         messageTemplate ??= MessageTemplates.GreaterThanTemplate;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
+         var data = GetDataDictionary(
+            requirementType,
+            value!,
+            valueExpression,
+            target!,
+            targetExpression);
+         data[DataNames.StringComparison] = comparisonType;
 
          throw exceptionFactory.CreateException(data, messageTemplate);
       }
@@ -305,4 +447,9 @@ public static class GreaterThanExtensions
          {  DataNames.Target, target! },
          {  DataNames.TargetExpression, targetExpression }
       };
+
+   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
+      => requirementType == RequirementType.Precondition
+         ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -8,6 +8,59 @@
 public static class GreaterThanExtensions
 {
    /// <summary>
+   ///   Value GreaterThan postcondition. Confirm that <paramref name="value"/>
+   ///   is greater than <paramref name="target"/> and throw an exception if it 
+   ///   is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target that <paramref name="value"/> should be greater than.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresGreaterThan<T>(
+      this T value,
+      T target,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!) where T : IComparable<T>
+   {
+      CheckGreaterThan(
+         value,
+         target,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   Value GreaterThan precondition. Confirm that <paramref name="value"/>
    ///   is greater than <paramref name="target"/> and throw an exception if it 
    ///   is not.

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -79,6 +79,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}.
+        /// </summary>
+        internal static string GreaterThanTemplate {
+            get {
+                return ResourceManager.GetString("GreaterThanTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype}).
         /// </summary>
         internal static string NotDefaultTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -123,6 +123,9 @@
   <data name="EqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}</value>
   </data>
+  <data name="GreaterThanTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}</value>
+  </data>
   <data name="NotDefaultTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
   </data>

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -365,9 +365,7 @@ public static class NotEqualExtensions
       if ((value is null && target is null) || (value is not null && value.Equals(target)))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value!,
@@ -392,9 +390,7 @@ public static class NotEqualExtensions
       if (comparer.Equals(value, target))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value,
@@ -419,9 +415,7 @@ public static class NotEqualExtensions
       if ((value is null && target is null) || (value is not null && value.Equals(target, comparisonType)))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= GetExceptionFactory(requirementType);
          var data = GetDataDictionary(
             requirementType,
             value,
@@ -449,4 +443,9 @@ public static class NotEqualExtensions
          {  DataNames.Target, target! },
          {  DataNames.TargetExpression, targetExpression }
       };
+
+   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
+      => requirementType == RequirementType.Precondition
+         ? StandardExceptionFactories.ArgumentExceptionFactory
+         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   Extension methods that implement NotEqual requirement for types that
 ///   implement <see cref="IEquatable{T}"/> or that use 
-///   <see cref="IEqualityComparer{T}"/>
+///   <see cref="IEqualityComparer{T}"/>.
 /// </summary>
 public static class NotEqualExtensions
 {

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -7,6 +7,7 @@ public static class RequirementNames
 {
    public static String ApproximatelyEqual = nameof(ApproximatelyEqual);
    public static String Equal = nameof(Equal);
+   public static String GreaterThan = nameof(GreaterThan);
    public static String NotDefault = nameof(NotDefault);
    public static String NotEqual = nameof(NotEqual);
    public static String NotNull = nameof(NotNull);

--- a/Documentation/Equal.md
+++ b/Documentation/Equal.md
@@ -11,13 +11,13 @@ T RequiresEqual<T>(this T value, T target, [String? messageTemplate = null], [IE
 
 T RequiresEqual<T>(this T value, T target, IEqualityComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 
-String RequiresEqual<T>(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresEqual(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 
 T EnsuresEqual<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IEquatable<T>
 
 T EnsuresEqual<T>(this T value, T target, IEqualityComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 
-String EnsuresEqual<T>(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresEqual(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 ```
 
 The default message template for Equal is "{RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}".

--- a/Documentation/GreaterThan.md
+++ b/Documentation/GreaterThan.md
@@ -5,3 +5,127 @@ RequiresGreaterThan and EnsuresGreaterThan have several overloads that support
 IComparable<T> and IComparer<T> as well as an overload for String that accepts a 
 StringComparison value that specifies how the comparison is performed.
 
+**Method signatures:**
+```C#
+T RequiresGreaterThan<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+
+T RequiresGreaterThan<T>(this T value, T target, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String RequiresGreaterThan(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+T EnsuresGreaterThan<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+
+T EnsuresGreaterThan<T>(this T value, T target, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String EnsuresGreaterThan(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+```
+
+The default message template for GreaterThan is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {Target}".
+The default exception factory for RequiresGreaterThan is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresGreaterThan.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, Target and TargetExpression. The data
+dictionary for the String overloads will contain an additional entry for 
+StringComparison.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be greater than to {Target}";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var changeDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
+var targetDate = new DateTime(2023, 1, 1);
+
+// Precondition with default message template/default exception factory.
+changeDate.RequiresGreaterThan(targetDate);
+
+// Precondition with custom message template/default exception factory.
+changeDate.RequiresGreaterThan(targetDate, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+changeDate.RequiresGreaterThan(targetDate, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+changeDate.RequiresGreaterThan(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+changeDate.EnsuresGreaterThan(targetDate);
+
+// Postcondition with custom message template/default exception factory.
+changeDate.EnsuresGreaterThan(targetDate, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+changeDate.EnsuresGreaterThan(targetDate, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+changeDate.EnsuresGreaterThan(targetDate, customMessageTemplate, customExceptionFactory);
+
+
+var point = new Point { X = 10, Y = 10 };
+var targetPoint = new Point { X = 1, Y = 12 };
+var comparer = new PointDistanceFromOriginComparer();
+
+// Precondition with default message template/default exception factory.
+point.RequiresGreaterThan(targetPoint, comparer);
+
+// Precondition with custom message template/default exception factory.
+point.RequiresGreaterThan(targetPoint, comparer, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+point.RequiresGreaterThan(targetPoint, comparer, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+point.RequiresGreaterThan(targetPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+point.EnsuresGreaterThan(targetPoint, comparer);
+
+// Postcondition with custom message template/default exception factory.
+point.EnsuresGreaterThan(targetPoint, comparer, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+point.EnsuresGreaterThan(targetPoint, comparer, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+point.EnsuresGreaterThan(targetPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+var str = "asdf";
+var targetStr = "QWERTY";
+var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+// Precondition with default message template/default exception factory.
+str.RequiresGreaterThan(targetStr, comparisonType);
+
+// Precondition with custom message template/default exception factory.
+str.RequiresGreaterThan(targetStr, comparisonType, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+str.RequiresGreaterThan(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+str.RequiresGreaterThan(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+str.EnsuresGreaterThan(targetStr, comparisonType);
+
+// Postcondition with custom message template/default exception factory.
+str.EnsuresGreaterThan(targetStr, comparisonType, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+str.EnsuresGreaterThan(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+str.EnsuresGreaterThan(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
+```
+
+Implementation details for the Point examples:
+
+[Point struct](/DbC.Net.TestAndExampleResources/Point.cs)
+
+[PointDistanceFromOriginComparer](/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs)

--- a/Documentation/GreaterThan.md
+++ b/Documentation/GreaterThan.md
@@ -1,0 +1,7 @@
+### GreaterThan
+
+GreaterThan requires that the value being checked be greater than a target value. 
+RequiresGreaterThan and EnsuresGreaterThan have several overloads that support 
+IComparable<T> and IComparer<T> as well as an overload for String that accepts a 
+StringComparison value that specifies how the comparison is performed.
+

--- a/Documentation/NotEqual.md
+++ b/Documentation/NotEqual.md
@@ -11,13 +11,13 @@ T RequiresNotEqual<T>(this T value, T target, [String? messageTemplate = null], 
 
 T RequiresNotEqual<T>(this T value, T target, IEqualityComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 
-String RequiresNotEqual<T>(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresNotEqual(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 
 T EnsuresNotEqual<T>(this T value, T target, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IEquatable<T>
 
 T EnsuresNotEqual<T>(this T value, T target, IEqualityComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 
-String EnsuresNotEqual<T>(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresNotEqual(this String value, String target, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
 ```
 
 The default message template for NotEqual is "{RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}".

--- a/README.md
+++ b/README.md
@@ -29,17 +29,21 @@
 
     - [StandardTransforms](#standardtransforms)
 
-  - [Initialization Requirements](#initialization-requirements)
+  - Initialization Requirements
 
     - [NotNull](/Documentation/NotNull.md)
     - [NotDefault](/Documentation/NotDefault.md)
 
-  - [Equality Requirements](#equality-requirements)
+  - Equality Requirements
 
     - [Equal](/Documentation/Equal.md)
     - [NotEqual](/Documentation/NotEqual.md)
 
     - [ApproximatelyEqual](/Documentation/ApproximatelyEqual.md)
+
+  - Range Requirements
+
+    - [GreaterThan](/Documentation/GreaterThan.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a value is greater than a target value.

Requirements:

  RequiresGreaterThan (precondition), default ArgumentOutOfRangeException
  EnsuresGreaterThan (postcondition), default PostconditionFailedException
  Support supplying IComparer<T> object to perform the comparison

DEFINITION OF DONE:

1. Implement RequiresGreaterThan
2. Implement EnsuresGreaterThan
3. Unit tests for Requires/Ensures GreaterThan
4. Performance tests
5. Readme updates
6. Examples