### PR TITLE
S0011 less than or equal to

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -20,6 +20,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [GreaterThan Benchmarks](#greaterthan-benchmarks)
   - [GreaterThanOrEqual Benchmarks](#greaterthanorequal-benchmarks)
   - [LessThan Benchmarks](#lessthan-benchmarks)
+  - [LessThanOrEqual Benchmarks](#lessthanorequal-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -266,7 +267,6 @@ parameter was omitted.
 | RequiresGreaterThanOrEqual | Class       | IComparer<T>     |                  | X                 |  6.1544 ns | 0.0711 ns | 0.0665 ns |         - |
 | RequiresGreaterThanOrEqual | Class       | IComparer<T>     | X                | X                 |  5.7887 ns | 0.0562 ns | 0.0526 ns |         - |
 
-
 ### LessThan Benchmarks
 
 | Method           | Value Type  | Comparer         | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
@@ -307,3 +307,44 @@ parameter was omitted.
 | RequiresLessThan | Class       | IComparer<T>     | X                |                   |  5.6437 ns | 0.0316 ns | 0.0280 ns |         - |
 | RequiresLessThan | Class       | IComparer<T>     |                  | X                 |  5.7431 ns | 0.0508 ns | 0.0475 ns |         - |
 | RequiresLessThan | Class       | IComparer<T>     | X                | X                 |  5.6304 ns | 0.0434 ns | 0.0406 ns |         - |
+
+### LessThanOrEqual Benchmarks
+
+| Method                  | Value Type  | Comparer         | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
+|------------------------ |:------------|:----------------:|:----------------:|:-----------------:|-----------:|----------:|----------:|----------:|
+| RequiresLessThanOrEqual | Int32       |                  |                  |                   |  0.0032 ns | 0.0038 ns | 0.0032 ns |         - |
+| RequiresLessThanOrEqual | Int32       |                  | X                |                   |  0.0046 ns | 0.0060 ns | 0.0056 ns |         - |
+| RequiresLessThanOrEqual | Int32       |                  |                  | X                 |  2.2491 ns | 0.0251 ns | 0.0235 ns |         - |
+| RequiresLessThanOrEqual | Int32       |                  | X                | X                 |  1.9912 ns | 0.0129 ns | 0.0121 ns |         - |
+| RequiresLessThanOrEqual | Int32       | IComparer<T>     |                  |                   |  2.7751 ns | 0.0231 ns | 0.0216 ns |         - |
+| RequiresLessThanOrEqual | Int32       | IComparer<T>     | X                |                   |  2.2859 ns | 0.0153 ns | 0.0135 ns |         - |
+| RequiresLessThanOrEqual | Int32       | IComparer<T>     |                  | X                 |  3.0145 ns | 0.0532 ns | 0.0444 ns |         - |
+| RequiresLessThanOrEqual | Int32       | IComparer<T>     | X                | X                 |  2.7113 ns | 0.0612 ns | 0.0752 ns |         - |
+| RequiresLessThanOrEqual | String      |                  |                  |                   | 40.2086 ns | 0.8267 ns | 1.1316 ns |         - |
+| RequiresLessThanOrEqual | String      |                  | X                |                   | 41.6270 ns | 0.7159 ns | 0.6346 ns |         - |
+| RequiresLessThanOrEqual | String      |                  |                  | X                 | 43.7436 ns | 0.8791 ns | 0.8633 ns |         - |
+| RequiresLessThanOrEqual | String      |                  | X                | X                 | 42.5799 ns | 0.6806 ns | 0.6367 ns |         - |
+| RequiresLessThanOrEqual | String      | IComparer<T>     |                  |                   |  7.1765 ns | 0.1537 ns | 0.1888 ns |         - |
+| RequiresLessThanOrEqual | String      | IComparer<T>     | X                |                   |  7.2017 ns | 0.1673 ns | 0.1790 ns |         - |
+| RequiresLessThanOrEqual | String      | IComparer<T>     |                  | X                 |  8.2092 ns | 0.1942 ns | 0.3024 ns |         - |
+| RequiresLessThanOrEqual | String      | IComparer<T>     | X                | X                 |  7.8686 ns | 0.1794 ns | 0.1762 ns |         - |
+| RequiresLessThanOrEqual | String      | StringComparison |                  |                   |  5.5717 ns | 0.0273 ns | 0.0228 ns |         - |
+| RequiresLessThanOrEqual | String      | StringComparison | X                |                   |  6.0956 ns | 0.1475 ns | 0.1755 ns |         - |
+| RequiresLessThanOrEqual | String      | StringComparison |                  | X                 |  6.3769 ns | 0.1430 ns | 0.1267 ns |         - |
+| RequiresLessThanOrEqual | String      | StringComparison | X                | X                 |  5.9994 ns | 0.0777 ns | 0.0727 ns |         - |
+| RequiresLessThanOrEqual | Record      |                  |                  |                   |  6.5428 ns | 0.1601 ns | 0.1644 ns |         - |
+| RequiresLessThanOrEqual | Record      |                  | X                |                   |  7.2435 ns | 0.0858 ns | 0.0670 ns |         - |
+| RequiresLessThanOrEqual | Record      |                  |                  | X                 |  7.2417 ns | 0.1708 ns | 0.2557 ns |         - |
+| RequiresLessThanOrEqual | Record      |                  | X                | X                 |  7.2571 ns | 0.1708 ns | 0.1598 ns |         - |
+| RequiresLessThanOrEqual | Record      | IComparer<T>     |                  |                   |  5.5694 ns | 0.0846 ns | 0.0750 ns |         - |
+| RequiresLessThanOrEqual | Record      | IComparer<T>     | X                |                   |  5.6697 ns | 0.1401 ns | 0.1376 ns |         - |
+| RequiresLessThanOrEqual | Record      | IComparer<T>     |                  | X                 |  5.8552 ns | 0.0326 ns | 0.0272 ns |         - |
+| RequiresLessThanOrEqual | Record      | IComparer<T>     | X                | X                 |  5.9280 ns | 0.0484 ns | 0.0429 ns |         - |
+| RequiresLessThanOrEqual | Class       |                  |                  |                   |  6.4110 ns | 0.0327 ns | 0.0290 ns |         - |
+| RequiresLessThanOrEqual | Class       |                  | X                |                   |  6.8122 ns | 0.0495 ns | 0.0439 ns |         - |
+| RequiresLessThanOrEqual | Class       |                  |                  | X                 |  6.7991 ns | 0.0440 ns | 0.0412 ns |         - |
+| RequiresLessThanOrEqual | Class       |                  | X                | X                 |  6.9434 ns | 0.0571 ns | 0.0534 ns |         - |
+| RequiresLessThanOrEqual | Class       | IComparer<T>     |                  |                   |  5.5902 ns | 0.0259 ns | 0.0230 ns |         - |
+| RequiresLessThanOrEqual | Class       | IComparer<T>     | X                |                   |  5.6048 ns | 0.0365 ns | 0.0342 ns |         - |
+| RequiresLessThanOrEqual | Class       | IComparer<T>     |                  | X                 |  5.7207 ns | 0.0546 ns | 0.0511 ns |         - |
+| RequiresLessThanOrEqual | Class       | IComparer<T>     | X                | X                 |  5.5950 ns | 0.0395 ns | 0.0350 ns |         - |

--- a/DbC.Net.Examples/LessThanOrEqualExamples.cs
+++ b/DbC.Net.Examples/LessThanOrEqualExamples.cs
@@ -1,0 +1,98 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class LessThanOrEqualExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be less than or equal to {UpperBound}";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var changeDate = new DateTime(2023, 1, 1);
+      var upperBoundDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
+
+      // Precondition with default message template/default exception factory.
+      changeDate.RequiresLessThanOrEqual(upperBoundDate);
+
+      // Precondition with custom message template/default exception factory.
+      changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      changeDate.RequiresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      changeDate.EnsuresLessThanOrEqual(upperBoundDate);
+
+      // Postcondition with custom message template/default exception factory.
+      changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      changeDate.EnsuresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
+
+
+      var point = new Point { X = 1, Y = 12 };
+      var upperBoundPoint = new Point { X = 10, Y = 10 };
+      var comparer = new PointDistanceFromOriginComparer();
+
+      // Precondition with default message template/default exception factory.
+      point.RequiresLessThanOrEqual(upperBoundPoint, comparer);
+
+      // Precondition with custom message template/default exception factory.
+      point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      point.RequiresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      point.EnsuresLessThanOrEqual(upperBoundPoint, comparer);
+
+      // Postcondition with custom message template/default exception factory.
+      point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      var str = "QWERTY";
+      var upperBoundStr = "asdf";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+      // Precondition with default message template/default exception factory.
+      str.RequiresLessThanOrEqual(upperBoundStr, comparisonType);
+
+      // Precondition with custom message template/default exception factory.
+      str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
+
+      // Precondition with default message template/custom exception factory.
+      str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template/custom exception factory.
+      str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template/default exception factory.
+      str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType);
+
+      // Postcondition with custom message template/default exception factory.
+      str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
+
+      // Postcondition with default message template/custom exception factory.
+      str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template/custom exception factory.
+      str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/LessThanOrEqualBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/LessThanOrEqualBenchmarks.cs
@@ -1,0 +1,261 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class LessThanOrEqualBenchmarks
+{
+   private const Int32 _intValue = 99;
+   private const Int32 _intUpperBound = 100;
+   private static readonly IComparer<Int32> _intComparer = Comparer<Int32>.Default;
+
+   private const String _strValue = "ASDF";
+   private const String _strUpperBound = "qwerty";
+   private static readonly IComparer<String> _stringComparer = StringComparer.OrdinalIgnoreCase;
+   private const StringComparison _comparisonType = StringComparison.OrdinalIgnoreCase;
+
+   private static readonly Box _boxValue = new(2, 4, 8, "Green");
+   private static readonly Box _boxUpperBound = new(4, 16, 36, "Purple");
+   private static readonly IComparer<Box> _boxComparer = BoxComparers.AllFieldsComparer;
+
+   private static readonly Observation _observationValue = new()
+   {
+      ObservationId = new Guid("f77d70bc-6eea-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2022, 11, 22, 9, 37, 46, 789),
+      ObservationType = ObservationType.Temperature,
+      Value = 6.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly Observation _observationUpperBound = new()
+   {
+      ObservationId = new Guid("f77e70ee-6fff-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2023, 12, 23, 10, 38, 47, 889),
+      ObservationType = ObservationType.Temperature,
+      Value = 16.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly IComparer<Observation> _observationComparer = ObservationComparers.AllFieldsComparer;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be less than or equal to {UpperBound}";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P000()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P100()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P010()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P110()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P001()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, _intComparer);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P101()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, _intComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P011()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, _intComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Int32_P111()
+   {
+      var result = _intValue.RequiresLessThanOrEqual(_intUpperBound, _intComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P000()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P100()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P010()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P110()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P001()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _stringComparer);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P101()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _stringComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P011()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _stringComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P111()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _stringComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P002()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _comparisonType);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P102()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _comparisonType, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P012()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _comparisonType, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_String_P112()
+   {
+      var result = _strValue.RequiresLessThanOrEqual(_strUpperBound, _comparisonType, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P000()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P100()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P010()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P110()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P001()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, _boxComparer);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P101()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, _boxComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P011()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, _boxComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Record_P111()
+   {
+      var result = _boxValue.RequiresLessThanOrEqual(_boxUpperBound, _boxComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P000()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P100()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P010()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P110()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P001()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, _observationComparer);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P101()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, _observationComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P011()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, _observationComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqual_Class_P111()
+   {
+      var result = _observationValue.RequiresLessThanOrEqual(_observationUpperBound, _observationComparer, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -5,4 +5,5 @@
 //BenchmarkRunner.Run<ApproximatelyEqualBenchmarks>();
 //BenchmarkRunner.Run<GreaterThanBenchmarks>();
 //BenchmarkRunner.Run<GreaterThanOrEqualBenchmarks>();
-BenchmarkRunner.Run<LessThanBenchmarks>();
+//BenchmarkRunner.Run<LessThanBenchmarks>();
+BenchmarkRunner.Run<LessThanOrEqualBenchmarks>();

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualExtensionsTests.cs
@@ -1205,7 +1205,7 @@ public class GreaterThanOrEqualExtensionsTests
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseZ, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
    [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.OrdinalIgnoreCase)]
-   public void GreaterThanOrEqualExtensions_RequiresGreaterThanOrEqualString_ShouldThrow_WhenValueIsLessThanLowerBoundAndCurrentCultureIs_trTR(
+   public void GreaterThanOrEqualExtensions_RequiresGreaterThanOrEqualString_ShouldThrow_WhenValueIsBelowLowerBoundAndCurrentCultureIs_trTR(
       String value,
       String lowerBound,
       StringComparison comparisonType)

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualExtensionsTests.cs
@@ -3,7 +3,7 @@
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
 
-public class GreaterThanOrEqualToExtensionsTests
+public class GreaterThanOrEqualExtensionsTests
 {
    private const Int32 _dataCount = 6;
    private const Int32 _stringDataCount = 7;

--- a/DbC.Net.Tests.Unit/LessThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanExtensionsTests.cs
@@ -479,7 +479,7 @@ public class LessThanExtensionsTests
    [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.Ordinal)]
    [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseI, StringComparison.OrdinalIgnoreCase)]
-   public void LessThanExtensions_EnsuresLessThanString_ShouldThrow_WhenValueExceedsUpperBoundAndCurrentCultureIs_trTR(
+   public void LessThanExtensions_EnsuresLessThanString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_trTR(
       String value,
       String upperBound,
       StringComparison comparisonType)
@@ -1141,7 +1141,7 @@ public class LessThanExtensionsTests
    [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCultureIgnoreCase)]
    [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.Ordinal)]
    [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseI, StringComparison.OrdinalIgnoreCase)]
-   public void LessThanExtensions_RequiresLessThanString_ShouldThrow_WhenValueExceedsUpperBoundAndCurrentCultureIs_trTR(
+   public void LessThanExtensions_RequiresLessThanString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_trTR(
       String value,
       String upperBound,
       StringComparison comparisonType)

--- a/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
@@ -186,6 +186,213 @@ public class LessThanOrEqualExtensionsTests
 
    #endregion
 
+   #region EnsuresLessThanOrEqual (IComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenValueIsBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMinValue;
+      var upperBound = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenValueIsEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMinValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T upperBound = default!;
+      var comparer = Comparer<T>.Default;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var upperBound = data.ReverseMaxValue;
+      var comparer = Comparer<T>.Default;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrow_WhenReferenceValueIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      T upperBound = default!;
+      var comparer = Comparer<T>.Default;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new DateTimeData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new BoxRecordData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
+      var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      ex.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrowPostconditionFailedExceptionExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new ByteData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer, messageTemplate);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      ex.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new DoubleData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = "def";
+      var upperBound = "ABC";
+      var comparer = StringComparer.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessOrEqualThanIComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var data = new TimeOnlyData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      IComparer<TimeOnly> comparer = null!;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
+   }
+
+   #endregion
+
    #region RequiresLessThanOrEqual (IComparable) Tests
    // ==========================================================================
    // ==========================================================================
@@ -366,6 +573,219 @@ public class LessThanOrEqualExtensionsTests
       // Act/assert.
       act.Should().Throw<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresLessThanOrEqual (IComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenValueIsBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMinValue;
+      var upperBound = data.ReverseMaxValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenValueIsEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMinValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T upperBound = default!;
+      var comparer = Comparer<T>.Default;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var upperBound = data.ReverseMaxValue;
+      var comparer = Comparer<T>.Default;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrow_WhenReferenceValueIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.ReverseMaxValue;
+      T upperBound = default!;
+      var comparer = Comparer<T>.Default;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new DateTimeData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new BoxRecordData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new ByteData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new DoubleData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      var comparer = data.ReverseComparer;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = "def";
+      var upperBound = "ABC";
+      var comparer = StringComparer.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessOrEqualThanIComparer_ShouldThrowArgumentNullException_WhenComparerIsNull()
+   {
+      // Arrange.
+      var data = new TimeOnlyData();
+      var value = data.ReverseMaxValue;
+      var upperBound = data.ReverseMinValue;
+      IComparer<TimeOnly> comparer = null!;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(comparer))
+         .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
@@ -393,6 +393,281 @@ public class LessThanOrEqualExtensionsTests
 
    #endregion
 
+   #region EnsuresLessThanOrEqual (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsBelowUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseDottedI, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsBelowLowerBoundAndCurrentCultureIs_trTR(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.LowerCaseDiphthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsBelowUpperBoundAndCurrentCultureIs_svSE(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsEqualToUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueAndUpperBoundAreDefaultAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String upperBound = default!;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueAndUpperBoundAreDefaultAndCurrentCultureIs_daDK(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String upperBound = default!;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.LowerCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseI, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_trTR(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrow_WhenValueIsNotDefaultAndUpperBoundIsDefaultAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = "asdf";
+      String upperBound = default!;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrow_WhenValueIsNotDefaultAndUpperBoundIsDefaultAndCurrentCultureIs_svSE(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = "asdf";
+      String upperBound = default!;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseZ;
+      var upperBound = StringData.UpperCaseA;
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseZ;
+      var upperBound = StringData.UpperCaseA;
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
+      var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      ex.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseJ;
+      var upperBound = StringData.UpperCaseH;
+      var comparisonType = StringComparison.InvariantCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType, messageTemplate);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      ex.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseZ;
+      var upperBound = StringData.UpperCaseJ;
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseZ;
+      var upperBound = StringData.LowerCaseA;
+      var comparisonType = StringComparison.CurrentCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
    #region RequiresLessThanOrEqual (IComparable) Tests
    // ==========================================================================
    // ==========================================================================
@@ -786,6 +1061,287 @@ public class LessThanOrEqualExtensionsTests
       act.Should().Throw<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
+   }
+
+   #endregion
+
+   #region RequiresLessThanOrEqual (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsBelowUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseDottedI, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsBelowLowerBoundAndCurrentCultureIs_trTR(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseI, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.LowerCaseDiphthongAE, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseDiphthongAE, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsBelowUpperBoundAndCurrentCultureIs_svSE(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.LowerCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueIsEqualToUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueAndUpperBoundAreDefaultAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String upperBound = default!;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldReturnOriginalValue_WhenValueAndUpperBoundAreDefaultAndCurrentCultureIs_daDK(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = default!;
+      String upperBound = default!;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseAE, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.LowerCaseAE, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseSlashedO, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseDotlessI, StringData.UpperCaseI, StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_trTR(
+      String value,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrow_WhenValueIsNotDefaultAndUpperBoundIsDefaultAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = "asdf";
+      String upperBound = default!;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrow_WhenValueIsNotDefaultAndUpperBoundIsDefaultAndCurrentCultureIs_svSE(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = "asdf";
+      String upperBound = default!;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseZ;
+      var upperBound = StringData.UpperCaseA;
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseZ;
+      var upperBound = StringData.UpperCaseA;
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseJ;
+      var upperBound = StringData.UpperCaseH;
+      var comparisonType = StringComparison.InvariantCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.LowerCaseZ;
+      var upperBound = StringData.UpperCaseJ;
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualString_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.UpperCaseZ;
+      var upperBound = StringData.LowerCaseA;
+      var comparisonType = StringComparison.CurrentCulture;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
    }
 
    #endregion

--- a/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
@@ -1,0 +1,372 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class LessThanOrEqualExtensionsTests
+{
+   private const Int32 _dataCount = 6;
+   private const Int32 _stringDataCount = 7;
+
+   #region EnsuresLessThanOrEqual (IComparable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldReturnOriginalValue_WhenValueIsBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var upperBound = data.MaxValue;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldReturnOriginalValue_WhenValueIsEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var upperBound = data.MaxValue;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessOrEqualThanIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T upperBound = default!;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessOrEqualThanIComparable_ShouldThrow_WhenReferenceValueIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      T upperBound = default!;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrow_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new Int32Data();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
+      var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      ex.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new HalfData();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, messageTemplate);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      ex.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new UInt128Data();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "ABC";
+      String upperBound = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresLessThanOrEqual (IComparable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldReturnOriginalValue_WhenValueIsBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var upperBound = data.MaxValue;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldReturnOriginalValue_WhenValueIsEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var upperBound = data.MaxValue;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessOrEqualThanIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T upperBound = default!;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ComparableTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessOrEqualThanIComparable_ShouldThrow_WhenReferenceValueIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      T upperBound = default!;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrow_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new Int32Data();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqual);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new HalfData();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      ex.ParamName.Should().Be(expectedParameterName);
+      ex.Message.Should().StartWith(expectedMessage);
+      ex.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new UInt128Data();
+      var value = data.MaxValue;
+      var upperBound = data.MinValue;
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "ABC";
+      String upperBound = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqual(upperBound, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqual failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .And.Message.Should().StartWith(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -26,9 +26,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\ApproximatelyEqual.md = Documentation\ApproximatelyEqual.md
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\GreaterThan.md = Documentation\GreaterThan.md
-		Documentation\LessThan.md = Documentation\LessThan.md
-		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\GreaterThanOrEqual.md = Documentation\GreaterThanOrEqual.md
+		Documentation\LessThan.md = Documentation\LessThan.md
+		Documentation\LessThanOrEqual.md = Documentation\LessThanOrEqual.md
+		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md
 	EndProjectSection

--- a/DbC.Net/LessThanOrEqualExtensions.cs
+++ b/DbC.Net/LessThanOrEqualExtensions.cs
@@ -125,6 +125,67 @@ public static class LessThanOrEqualExtensions
    }
 
    /// <summary>
+   ///   Value LessThanOrEqual postcondition. Confirm that the 
+   ///   <see cref="String"/> <paramref name="value"/> is less than or equal
+   ///   to the <see cref="String"/> <paramref name="upperBound"/> and throw an 
+   ///   exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="upperBound"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String EnsuresLessThanOrEqual(
+      this String value,
+      String upperBound,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!)
+   {
+      CheckLessThanOrEqual(
+         value,
+         upperBound,
+         comparisonType,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   Value LessThanOrEqual precondition. Confirm that <paramref name="value"/>
    ///   is less than or equal to <paramref name="upperBound"/> and throw an 
    ///   exception if it is not.
@@ -239,6 +300,67 @@ public static class LessThanOrEqualExtensions
       return value;
    }
 
+   /// <summary>
+   ///   Value LessThanOrEqual precondition. Confirm that the 
+   ///   <see cref="String"/> <paramref name="value"/> is less than or equal
+   ///   to the <see cref="String"/> <paramref name="upperBound"/> and throw an 
+   ///   exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="upperBound"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String RequiresLessThanOrEqual(
+      this String value,
+      String upperBound,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!)
+   {
+      CheckLessThanOrEqual(
+         value,
+         upperBound,
+         comparisonType,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
    private static void CheckLessThanOrEqual<T>(
       T value,
       T upperBound,
@@ -281,6 +403,31 @@ public static class LessThanOrEqualExtensions
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
             .WithUpperBound(upperBound!, upperBoundExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static void CheckLessThanOrEqual(
+      String value,
+      String upperBound,
+      StringComparison comparisonType,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String upperBoundExpression)
+   {
+      if (String.Compare(value, upperBound, comparisonType) > 0)
+      {
+         messageTemplate ??= MessageTemplates.LessThanOrEqualTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithUpperBound(upperBound!, upperBoundExpression)
+            .WithItem(DataNames.StringComparison, comparisonType)
             .Build();
 
          throw exceptionFactory.CreateException(data, messageTemplate);

--- a/DbC.Net/LessThanOrEqualExtensions.cs
+++ b/DbC.Net/LessThanOrEqualExtensions.cs
@@ -1,0 +1,141 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement LessThanOrEqual requirement for types that
+///   implement <see cref="IComparable{T}"/> or that use 
+///   <see cref="IComparer{T}"/>.
+/// </summary>
+public static class LessThanOrEqualExtensions
+{
+   private const String _requirementName = RequirementNames.LessThanOrEqual;
+
+   /// <summary>
+   ///   Value LessThanOrEqual postcondition. Confirm that <paramref name="value"/>
+   ///   is less than or equal to <paramref name="upperBound"/> and throw an 
+   ///   exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresLessThanOrEqual<T>(
+      this T value,
+      T upperBound,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!) where T : IComparable<T>
+   {
+      CheckLessThanOrEqual(
+         value,
+         upperBound,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value LessThanOrEqual precondition. Confirm that <paramref name="value"/>
+   ///   is less than or equal to <paramref name="upperBound"/> and throw an 
+   ///   exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresLessThanOrEqual<T>(
+      this T value,
+      T upperBound,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!) where T : IComparable<T>
+   {
+      CheckLessThanOrEqual(
+         value,
+         upperBound,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   private static void CheckLessThanOrEqual<T>(
+      T value,
+      T upperBound,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String upperBoundExpression) where T : IComparable<T>
+   {
+      if ((value is null && upperBound is not null)
+         || (value is not null && value.CompareTo(upperBound) > 0))
+      {
+         messageTemplate ??= MessageTemplates.LessThanOrEqualTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithUpperBound(upperBound!, upperBoundExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -97,6 +97,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}.
+        /// </summary>
+        internal static string LessThanOrEqualTemplate {
+            get {
+                return ResourceManager.GetString("LessThanOrEqualTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be less than {UpperBound}.
         /// </summary>
         internal static string LessThanTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -129,6 +129,9 @@
   <data name="GreaterThanTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {LowerBound}</value>
   </data>
+  <data name="LessThanOrEqualTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}</value>
+  </data>
   <data name="LessThanTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than {UpperBound}</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -10,6 +10,7 @@ public static class RequirementNames
    public const String GreaterThan = nameof(GreaterThan);
    public const String GreaterThanOrEqual = nameof(GreaterThanOrEqual);
    public const String LessThan = nameof(LessThan);
+   public const String LessThanOrEqual = nameof(LessThanOrEqual);
    public const String NotDefault = nameof(NotDefault);
    public const String NotEqual = nameof(NotEqual);
    public const String NotNull = nameof(NotNull);

--- a/Documentation/LessThanOrEqual.md
+++ b/Documentation/LessThanOrEqual.md
@@ -5,3 +5,129 @@ equal to an upper bound. RequiresLessThanOrEqual and EnsuresLessThanOrEqual
 have several overloads that support IComparable<T> and IComparer<T> as well as 
 an overload for String that accepts a StringComparison value that specifies how 
 the comparison is performed.
+
+**Method signatures:**
+```C#
+T RequiresLessThanOrEqual<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+
+T RequiresLessThanOrEqual<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String RequiresLessThanOrEqual(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+T EnsuresLessThanOrEqual<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+
+T EnsuresLessThanOrEqual<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String EnsuresLessThanOrEqual(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+```
+
+The default message template for LessThanOrEqual is "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}".
+The default exception factory for RequiresLessThanOrEqual is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresLessThanOrEqual.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, UpperBound and UpperBoundExpression. The 
+data dictionary for the String overloads will contain an additional entry for 
+StringComparison.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be less than or equal to {UpperBound}";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var changeDate = new DateTime(2023, 1, 1);
+var upperBoundDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
+
+// Precondition with default message template/default exception factory.
+changeDate.RequiresLessThanOrEqual(upperBoundDate);
+
+// Precondition with custom message template/default exception factory.
+changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+changeDate.RequiresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+changeDate.EnsuresLessThanOrEqual(upperBoundDate);
+
+// Postcondition with custom message template/default exception factory.
+changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+changeDate.EnsuresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
+
+
+var point = new Point { X = 1, Y = 12 };
+var upperBoundPoint = new Point { X = 10, Y = 10 };
+var comparer = new PointDistanceFromOriginComparer();
+
+// Precondition with default message template/default exception factory.
+point.RequiresLessThanOrEqual(upperBoundPoint, comparer);
+
+// Precondition with custom message template/default exception factory.
+point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+point.RequiresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+point.EnsuresLessThanOrEqual(upperBoundPoint, comparer);
+
+// Postcondition with custom message template/default exception factory.
+point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
+
+
+var str = "QWERTY";
+var upperBoundStr = "asdf";
+var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+// Precondition with default message template/default exception factory.
+str.RequiresLessThanOrEqual(upperBoundStr, comparisonType);
+
+// Precondition with custom message template/default exception factory.
+str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
+
+// Precondition with default message template/custom exception factory.
+str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template/custom exception factory.
+str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template/default exception factory.
+str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType);
+
+// Postcondition with custom message template/default exception factory.
+str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
+
+// Postcondition with default message template/custom exception factory.
+str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template/custom exception factory.
+str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
+```
+
+Implementation details for the Point examples:
+
+[Point struct](/DbC.Net.TestAndExampleResources/Point.cs)
+
+[PointDistanceFromOriginComparer](/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs)
+

--- a/Documentation/LessThanOrEqual.md
+++ b/Documentation/LessThanOrEqual.md
@@ -1,0 +1,7 @@
+### LessThanOrEqual
+
+LessThanOrEqual requires that the value being checked be less than or
+equal to an upper bound. RequiresLessThanOrEqual and EnsuresLessThanOrEqual
+have several overloads that support IComparable<T> and IComparer<T> as well as 
+an overload for String that accepts a StringComparison value that specifies how 
+the comparison is performed.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
     - [GreaterThan](/Documentation/GreaterThan.md)
     - [GreaterThanOrEqual](/Documentation/GreaterThanOrEqual.md)
     - [LessThan](/Documentation/LessThan.md)
+    - [LessThanOrEqual](/Documentation/LessThanOrEqual.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a value is less than or equal to a target value.

Requirements:

  RequiresLessThanOrEqualTo (precondition), default ArgumentOutOfRangeException
  EnsuresLessThanOrEqualTo (postcondition), default PostconditionFailedException
  Support supplying IComparer<T> object to perform the comparison

DEFINITION OF DONE:

1. Implement RequiresLessThanOrEqualTo
2. Implement EnsuresLessThanOrEqualTo
3. Unit tests for Requires/Ensures LessThanOrEqualTo
4. Performance tests
5. Readme updates
6. Examples