### PR TITLE
S0012 between

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -14,13 +14,16 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 
   - [NotNull Benchmarks](#notnull-benchmarks)
   - [NotDefault Benchmarks](#notdefault-benchmarks)
+
   - [Equal Benchmarks](#equal-benchmarks)
   - [NotEqual Benchmarks](#notequal-benchmarks)
+
   - [ApproximatelyEqual Benchmarks](#approximatelyequal-benchmarks)
   - [GreaterThan Benchmarks](#greaterthan-benchmarks)
   - [GreaterThanOrEqual Benchmarks](#greaterthanorequal-benchmarks)
   - [LessThan Benchmarks](#lessthan-benchmarks)
   - [LessThanOrEqual Benchmarks](#lessthanorequal-benchmarks)
+  - [Between Benchmarks](#between-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -348,3 +351,44 @@ parameter was omitted.
 | RequiresLessThanOrEqual | Class       | IComparer<T>     | X                |                   |  5.6048 ns | 0.0365 ns | 0.0342 ns |         - |
 | RequiresLessThanOrEqual | Class       | IComparer<T>     |                  | X                 |  5.7207 ns | 0.0546 ns | 0.0511 ns |         - |
 | RequiresLessThanOrEqual | Class       | IComparer<T>     | X                | X                 |  5.5950 ns | 0.0395 ns | 0.0350 ns |         - |
+
+### Between Benchmarks
+
+| Method          | Value Type  | Comparer         | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
+|---------------- |:------------|:----------------:|:----------------:|:-----------------:|-----------:|----------:|----------:|----------:|
+| RequiresBetween | Int32       |                  |                  |                   |   2.491 ns | 0.0443 ns | 0.0392 ns |         - |
+| RequiresBetween | Int32       |                  | X                |                   |   2.467 ns | 0.0346 ns | 0.0307 ns |         - |
+| RequiresBetween | Int32       |                  |                  | X                 |   3.918 ns | 0.0432 ns | 0.0383 ns |         - |
+| RequiresBetween | Int32       |                  | X                | X                 |   2.472 ns | 0.0280 ns | 0.0219 ns |         - |
+| RequiresBetween | Int32       | IComparer<T>     |                  |                   |   3.272 ns | 0.0427 ns | 0.0379 ns |         - |
+| RequiresBetween | Int32       | IComparer<T>     | X                |                   |   3.266 ns | 0.0212 ns | 0.0177 ns |         - |
+| RequiresBetween | Int32       | IComparer<T>     |                  | X                 |   3.069 ns | 0.0661 ns | 0.0586 ns |         - |
+| RequiresBetween | Int32       | IComparer<T>     | X                | X                 |   3.055 ns | 0.0454 ns | 0.0425 ns |         - |
+| RequiresBetween | String      |                  |                  |                   | 128.068 ns | 1.4173 ns | 1.2564 ns |         - |
+| RequiresBetween | String      |                  | X                |                   | 121.275 ns | 1.8087 ns | 1.6918 ns |         - |
+| RequiresBetween | String      |                  |                  | X                 | 124.305 ns | 2.2006 ns | 1.9508 ns |         - |
+| RequiresBetween | String      |                  | X                | X                 | 124.494 ns | 0.9860 ns | 0.8741 ns |         - |
+| RequiresBetween | String      | IComparer<T>     |                  |                   |  17.865 ns | 0.3836 ns | 0.3940 ns |         - |
+| RequiresBetween | String      | IComparer<T>     | X                |                   |  18.473 ns | 0.3983 ns | 0.5037 ns |         - |
+| RequiresBetween | String      | IComparer<T>     |                  | X                 |  18.568 ns | 0.3336 ns | 0.3276 ns |         - |
+| RequiresBetween | String      | IComparer<T>     | X                | X                 |  18.770 ns | 0.3832 ns | 0.5496 ns |         - |
+| RequiresBetween | String      | StringComparison |                  |                   |  16.232 ns | 0.2028 ns | 0.1897 ns |         - |
+| RequiresBetween | String      | StringComparison | X                |                   |  16.067 ns | 0.2067 ns | 0.1933 ns |         - |
+| RequiresBetween | String      | StringComparison |                  | X                 |  16.931 ns | 0.3585 ns | 0.3521 ns |         - |
+| RequiresBetween | String      | StringComparison | X                | X                 |  16.729 ns | 0.3632 ns | 0.3033 ns |         - |
+| RequiresBetween | Record      |                  |                  |                   |  17.307 ns | 0.3741 ns | 0.5600 ns |         - |
+| RequiresBetween | Record      |                  | X                |                   |  18.629 ns | 0.3954 ns | 0.6038 ns |         - |
+| RequiresBetween | Record      |                  |                  | X                 |  18.928 ns | 0.4022 ns | 0.4131 ns |         - |
+| RequiresBetween | Record      |                  | X                | X                 |  18.108 ns | 0.3135 ns | 0.2932 ns |         - |
+| RequiresBetween | Record      | IComparer<T>     |                  |                   |  14.815 ns | 0.1416 ns | 0.1255 ns |         - |
+| RequiresBetween | Record      | IComparer<T>     | X                |                   |  13.376 ns | 0.2883 ns | 0.2697 ns |         - |
+| RequiresBetween | Record      | IComparer<T>     |                  | X                 |  13.866 ns | 0.1943 ns | 0.1622 ns |         - |
+| RequiresBetween | Record      | IComparer<T>     | X                | X                 |  13.559 ns | 0.2487 ns | 0.2204 ns |         - |
+| RequiresBetween | Class       |                  |                  |                   |  17.053 ns | 0.2911 ns | 0.3465 ns |         - |
+| RequiresBetween | Class       |                  | X                |                   |  17.399 ns | 0.3774 ns | 0.4194 ns |         - |
+| RequiresBetween | Class       |                  |                  | X                 |  17.603 ns | 0.3686 ns | 0.3620 ns |         - |
+| RequiresBetween | Class       |                  | X                | X                 |  17.180 ns | 0.3736 ns | 0.3119 ns |         - |
+| RequiresBetween | Class       | IComparer<T>     |                  |                   |  14.042 ns | 0.2933 ns | 0.4206 ns |         - |
+| RequiresBetween | Class       | IComparer<T>     | X                |                   |  13.202 ns | 0.1368 ns | 0.1213 ns |         - |
+| RequiresBetween | Class       | IComparer<T>     |                  | X                 |  13.560 ns | 0.2960 ns | 0.5106 ns |         - |
+| RequiresBetween | Class       | IComparer<T>     | X                | X                 |  13.211 ns | 0.1913 ns | 0.1696 ns |         - |

--- a/DbC.Net.Examples/ApproximatelyEqualExamples.cs
+++ b/DbC.Net.Examples/ApproximatelyEqualExamples.cs
@@ -13,29 +13,29 @@ public sealed class ApproximatelyEqualExamples
       var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
 
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/BetweenExamples.cs
+++ b/DbC.Net.Examples/BetweenExamples.cs
@@ -1,0 +1,101 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class BetweenExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be greater than (or equal to) {LowerBound} and less than (or equal to) {UpperBound}";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var number = 42;
+      var intLowerBound = 0;
+      var intUpperBound = 100;
+
+      // Precondition with default message template and default exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound);
+
+      // Precondition with custom message template and default exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound);
+
+      // Postcondition with custom message template and default exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate, customExceptionFactory);
+
+
+      var point = new Point { X = 1, Y = 12 };
+      var pointLowerBound = new Point { X = 0, Y = 0 };
+      var pointUpperBound = new Point { X = 10, Y = 10 };
+      var comparer = new PointDistanceFromOriginComparer();
+
+      // Precondition with default message template and default exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer);
+
+      // Precondition with custom message template and default exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer);
+
+      // Postcondition with custom message template and default exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate, customExceptionFactory);
+
+
+      var str = "ELEPHANT";
+      var strLowerBound = "Aardvark";
+      var strUpperBound = "Zebra";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+      // Precondition with default message template and default exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType);
+
+      // Precondition with custom message template and default exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType);
+
+      // Postcondition with custom message template and default exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Examples/EqualExamples.cs
+++ b/DbC.Net.Examples/EqualExamples.cs
@@ -10,29 +10,29 @@ public sealed class EqualExamples
       var totalCount = 99;
       var targetCount = 100;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       totalCount.RequiresEqual(targetCount);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       totalCount.RequiresEqual(targetCount, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       totalCount.RequiresEqual(targetCount, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       totalCount.RequiresEqual(targetCount, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       totalCount.EnsuresEqual(targetCount);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       totalCount.EnsuresEqual(targetCount, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       totalCount.EnsuresEqual(targetCount, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       totalCount.EnsuresEqual(targetCount, customMessageTemplate, customExceptionFactory);
 
 
@@ -40,29 +40,29 @@ public sealed class EqualExamples
       var targetBox = new Box(2, 2, 2, "Blue");
       var comparer = new BoxVolumeComparer();
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       box.RequiresEqual(targetBox, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       box.RequiresEqual(targetBox, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       box.RequiresEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       box.RequiresEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       box.EnsuresEqual(targetBox, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       box.EnsuresEqual(targetBox, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       box.EnsuresEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       box.EnsuresEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -70,29 +70,29 @@ public sealed class EqualExamples
       var targetStr = "QWERTY";
       var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       str.RequiresEqual(targetStr, comparisonType);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       str.RequiresEqual(targetStr, comparisonType, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       str.RequiresEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       str.RequiresEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       str.EnsuresEqual(targetStr, comparisonType);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       str.EnsuresEqual(targetStr, comparisonType, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       str.EnsuresEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       str.EnsuresEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/GreaterThanExamples.cs
+++ b/DbC.Net.Examples/GreaterThanExamples.cs
@@ -10,29 +10,29 @@ public sealed class GreaterThanExamples
       var changeDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
       var lowerBoundDate = new DateTime(2023, 1, 1);
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       changeDate.RequiresGreaterThan(lowerBoundDate);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       changeDate.RequiresGreaterThan(lowerBoundDate, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       changeDate.RequiresGreaterThan(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       changeDate.RequiresGreaterThan(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       changeDate.EnsuresGreaterThan(lowerBoundDate);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       changeDate.EnsuresGreaterThan(lowerBoundDate, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       changeDate.EnsuresGreaterThan(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       changeDate.EnsuresGreaterThan(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -40,29 +40,29 @@ public sealed class GreaterThanExamples
       var lowerBoundPoint = new Point { X = 1, Y = 12 };
       var comparer = new PointDistanceFromOriginComparer();
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       point.RequiresGreaterThan(lowerBoundPoint, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       point.RequiresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       point.RequiresGreaterThan(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       point.RequiresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       point.EnsuresGreaterThan(lowerBoundPoint, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       point.EnsuresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       point.EnsuresGreaterThan(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       point.EnsuresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -70,29 +70,29 @@ public sealed class GreaterThanExamples
       var lowerBoundStr = "QWERTY";
       var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       str.RequiresGreaterThan(lowerBoundStr, comparisonType);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       str.RequiresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       str.RequiresGreaterThan(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       str.RequiresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       str.EnsuresGreaterThan(lowerBoundStr, comparisonType);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       str.EnsuresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       str.EnsuresGreaterThan(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       str.EnsuresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/GreaterThanOrEqualExamples.cs
+++ b/DbC.Net.Examples/GreaterThanOrEqualExamples.cs
@@ -10,29 +10,29 @@ public sealed class GreaterThanOrEqualExamples
       var changeDate = new DateTime(2023, 1, 1);
       var lowerBoundDate = new DateTime(2023, 1, 1);
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       changeDate.RequiresGreaterThanOrEqual(lowerBoundDate);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       changeDate.RequiresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       changeDate.RequiresGreaterThanOrEqual(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       changeDate.RequiresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -40,29 +40,29 @@ public sealed class GreaterThanOrEqualExamples
       var lowerBoundPoint = new Point { X = 1, Y = 12 };
       var comparer = new PointDistanceFromOriginComparer();
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -70,29 +70,29 @@ public sealed class GreaterThanOrEqualExamples
       var lowerBoundStr = "asdf";
       var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/LessThanExamples.cs
+++ b/DbC.Net.Examples/LessThanExamples.cs
@@ -10,29 +10,29 @@ public sealed class LessThanExamples
       var changeDate = new DateTime(2023, 1, 1);
       var upperBoundDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       changeDate.RequiresLessThan(upperBoundDate);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       changeDate.RequiresLessThan(upperBoundDate, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       changeDate.RequiresLessThan(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       changeDate.RequiresLessThan(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       changeDate.EnsuresLessThan(upperBoundDate);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       changeDate.EnsuresLessThan(upperBoundDate, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       changeDate.EnsuresLessThan(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       changeDate.EnsuresLessThan(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -40,29 +40,29 @@ public sealed class LessThanExamples
       var upperBoundPoint = new Point { X = 10, Y = 10 };
       var comparer = new PointDistanceFromOriginComparer();
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       point.RequiresLessThan(upperBoundPoint, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       point.RequiresLessThan(upperBoundPoint, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       point.RequiresLessThan(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       point.RequiresLessThan(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       point.EnsuresLessThan(upperBoundPoint, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       point.EnsuresLessThan(upperBoundPoint, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       point.EnsuresLessThan(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       point.EnsuresLessThan(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -70,29 +70,29 @@ public sealed class LessThanExamples
       var upperBoundStr = "asdf";
       var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       str.RequiresLessThan(upperBoundStr, comparisonType);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       str.RequiresLessThan(upperBoundStr, comparisonType, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       str.RequiresLessThan(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       str.RequiresLessThan(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       str.EnsuresLessThan(upperBoundStr, comparisonType);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       str.EnsuresLessThan(upperBoundStr, comparisonType, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       str.EnsuresLessThan(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       str.EnsuresLessThan(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/LessThanOrEqualExamples.cs
+++ b/DbC.Net.Examples/LessThanOrEqualExamples.cs
@@ -10,29 +10,29 @@ public sealed class LessThanOrEqualExamples
       var changeDate = new DateTime(2023, 1, 1);
       var upperBoundDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       changeDate.RequiresLessThanOrEqual(upperBoundDate);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       changeDate.RequiresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       changeDate.EnsuresLessThanOrEqual(upperBoundDate);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       changeDate.EnsuresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -40,29 +40,29 @@ public sealed class LessThanOrEqualExamples
       var upperBoundPoint = new Point { X = 10, Y = 10 };
       var comparer = new PointDistanceFromOriginComparer();
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       point.RequiresLessThanOrEqual(upperBoundPoint, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       point.RequiresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       point.EnsuresLessThanOrEqual(upperBoundPoint, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -70,29 +70,29 @@ public sealed class LessThanOrEqualExamples
       var upperBoundStr = "asdf";
       var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       str.RequiresLessThanOrEqual(upperBoundStr, comparisonType);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/NotDefaultExamples.cs
+++ b/DbC.Net.Examples/NotDefaultExamples.cs
@@ -11,29 +11,29 @@ public sealed class NotDefaultExamples
 
       List<Guid> identifiers = default!;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       id.RequiresNotDefault();
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       id.RequiresNotDefault(customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       id.RequiresNotDefault(exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       id.RequiresNotDefault(customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       identifiers.EnsuresNotDefault();
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       identifiers.EnsuresNotDefault(customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       identifiers.EnsuresNotDefault(exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       identifiers.EnsuresNotDefault(customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/NotEqualExamples.cs
+++ b/DbC.Net.Examples/NotEqualExamples.cs
@@ -10,29 +10,29 @@ public sealed class NotEqualExamples
       var currentDate = new DateOnly(2021, 12, 25);
       var targetDate = new DateOnly(2021, 12, 25);
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       currentDate.RequiresNotEqual(targetDate);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       currentDate.RequiresNotEqual(targetDate, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       currentDate.RequiresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       currentDate.RequiresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       currentDate.EnsuresNotEqual(targetDate);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       currentDate.EnsuresNotEqual(targetDate, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       currentDate.EnsuresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       currentDate.EnsuresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -40,29 +40,29 @@ public sealed class NotEqualExamples
       var targetBox = new Box(2, 2, 2, "Blue");
       var comparer = new BoxVolumeComparer();
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       box.RequiresNotEqual(targetBox, comparer);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       box.RequiresNotEqual(targetBox, comparer, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       box.RequiresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       box.RequiresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       box.EnsuresNotEqual(targetBox, comparer);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       box.EnsuresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -70,29 +70,29 @@ public sealed class NotEqualExamples
       var targetStr = "QWERTY";
       var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       str.RequiresNotEqual(targetStr, comparisonType);
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       str.RequiresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       str.EnsuresNotEqual(targetStr, comparisonType);
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       str.EnsuresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/NotNullExamples.cs
+++ b/DbC.Net.Examples/NotNullExamples.cs
@@ -11,29 +11,29 @@ public sealed class NotNullExamples
 
       List<Guid> identifiers = null!;
 
-      // Precondition with default message template/default exception factory.
+      // Precondition with default message template and default exception factory.
       lastName.RequiresNotNull();
 
-      // Precondition with custom message template/default exception factory.
+      // Precondition with custom message template and default exception factory.
       lastName.RequiresNotNull(customMessageTemplate);
 
-      // Precondition with default message template/custom exception factory.
+      // Precondition with default message template and custom exception factory.
       lastName.RequiresNotNull(exceptionFactory: customExceptionFactory);
 
-      // Precondition with custom message template/custom exception factory.
+      // Precondition with custom message template and custom exception factory.
       lastName.RequiresNotNull(customMessageTemplate, customExceptionFactory);
 
 
-      // Postcondition with default message template/default exception factory.
+      // Postcondition with default message template and default exception factory.
       identifiers.EnsuresNotNull();
 
-      // Postcondition with custom message template/default exception factory.
+      // Postcondition with custom message template and default exception factory.
       identifiers.EnsuresNotNull(customMessageTemplate);
 
-      // Postcondition with default message template/custom exception factory.
+      // Postcondition with default message template and custom exception factory.
       identifiers.EnsuresNotNull(exceptionFactory: customExceptionFactory);
 
-      // Postcondition with custom message template/custom exception factory.
+      // Postcondition with custom message template and custom exception factory.
       identifiers.EnsuresNotNull(customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.TestAndExampleResources/ReverseComparer.cs
+++ b/DbC.Net.TestAndExampleResources/ReverseComparer.cs
@@ -11,4 +11,6 @@ public sealed class ReverseComparer<T> : IComparer<T>, IEqualityComparer<T>
    public Boolean Equals(T? x, T? y) => !EqualityComparer<T>.Default.Equals(x, y);
 
    public Int32 GetHashCode([DisallowNull] T obj) => throw new NotImplementedException();
+
+   public (T, T) ReverseValues(T lower, T upper) => (upper, lower);
 }

--- a/DbC.Net.Tests.Benchmarks/BetweenBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/BetweenBenchmarks.cs
@@ -1,0 +1,272 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class BetweenBenchmarks
+{
+   private const Int32 _intValue = 99;
+   private const Int32 _intLowerBound = 0;
+   private const Int32 _intUpperBound = 100;
+   private static readonly IComparer<Int32> _intComparer = Comparer<Int32>.Default;
+
+   private const String _strValue = "ELEPHANT";
+   private const String _strLowerBound = "Aardvark";
+   private const String _strUpperBound = "Zebra";
+   private static readonly IComparer<String> _stringComparer = StringComparer.OrdinalIgnoreCase;
+   private const StringComparison _comparisonType = StringComparison.OrdinalIgnoreCase;
+
+   private static readonly Box _boxValue = new(2, 4, 8, "Green");
+   private static readonly Box _boxLowerBound = new(1, 1, 1, "Red");
+   private static readonly Box _boxUpperBound = new(4, 16, 36, "Purple");
+   private static readonly IComparer<Box> _boxComparer = BoxComparers.AllFieldsComparer;
+
+   private static readonly Observation _observationValue = new()
+   {
+      ObservationId = new Guid("f77d70bc-6eea-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2022, 11, 22, 9, 37, 46, 789),
+      ObservationType = ObservationType.Temperature,
+      Value = 6.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly Observation _observationLowerBound = new()
+   {
+      ObservationId = new Guid("f77a70aa-6aaa-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2021, 10, 21, 8, 36, 45, 689),
+      ObservationType = ObservationType.Temperature,
+      Value = 4.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly Observation _observationUpperBound = new()
+   {
+      ObservationId = new Guid("f77e70ee-6fff-45f4-96e5-5bbb02f7ee08"),
+      ObservationTimestamp = new DateTime(2023, 12, 23, 10, 38, 47, 889),
+      ObservationType = ObservationType.Temperature,
+      Value = 16.278,
+      Units = Units.DegreesCelsius
+   };
+   private static readonly IComparer<Observation> _observationComparer = ObservationComparers.AllFieldsComparer;
+
+   private const String _messageTemplate = "{ValueExpression} must be greater than (or equal to) {LowerBound} and less than (or equal to) {UpperBound}";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P000()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P100()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P010()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P110()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P001()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, _intComparer);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P101()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, _intComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P011()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, _intComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Int32_P111()
+   {
+      var result = _intValue.RequiresBetween(_intLowerBound, _intUpperBound, _intComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P000()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P100()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P010()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P110()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P001()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _stringComparer);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P101()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _stringComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P011()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _stringComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P111()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _stringComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P002()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _comparisonType);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P102()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _comparisonType, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P012()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _comparisonType, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_String_P112()
+   {
+      var result = _strValue.RequiresBetween(_strLowerBound, _strUpperBound, _comparisonType, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P000()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P100()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P010()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P110()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P001()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, _boxComparer);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P101()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, _boxComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P011()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, _boxComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Record_P111()
+   {
+      var result = _boxValue.RequiresBetween(_boxLowerBound, _boxUpperBound, _boxComparer, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P000()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P100()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P010()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P110()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P001()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, _observationComparer);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P101()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, _observationComparer, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P011()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, _observationComparer, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresBetween_Class_P111()
+   {
+      var result = _observationValue.RequiresBetween(_observationLowerBound, _observationUpperBound, _observationComparer, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -6,4 +6,5 @@
 //BenchmarkRunner.Run<GreaterThanBenchmarks>();
 //BenchmarkRunner.Run<GreaterThanOrEqualBenchmarks>();
 //BenchmarkRunner.Run<LessThanBenchmarks>();
-BenchmarkRunner.Run<LessThanOrEqualBenchmarks>();
+//BenchmarkRunner.Run<LessThanOrEqualBenchmarks>();
+BenchmarkRunner.Run<BetweenBenchmarks>();

--- a/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
@@ -320,7 +320,7 @@ public class BetweenExtensionsTests
       // Arrange.
       var value = data.WithinBoundsValue;
       T lowerBound = default!;
-      var upperBound = data.WithinBoundsValue;
+      var upperBound = data.UpperBound;
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
 
       // Act/assert.
@@ -329,7 +329,7 @@ public class BetweenExtensionsTests
 
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
-   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndUpperBoundIsNotAndValueIsNull<T>(
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndValueIsNull<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -366,9 +366,384 @@ public class BetweenExtensionsTests
    {
       // Arrange.
       var value = data.WithinBoundsValue;
-      var lowerBound = data.UpperBound;
+      var lowerBound = data.LowerBound;
       T upperBound = default!;
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region EnsuresBetween (IComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = lowerBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = upperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+      var value = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = upperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = lowerBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldReturnOriginalValue_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      T lowerBound = default!;
+      T upperBound = default!;
+      T value = default!;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrow_WhenValueIsBelowLowerBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (value, _) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (_, value) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrow_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      T value = default!;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new Int32Data();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (value, _) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Between);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.LowerBound].Should().Be(lowerBound);
+      ex.Data[DataNames.LowerBoundExpression].Should().Be(nameof(lowerBound));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenThanIComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (_, value) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+      var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new HalfData();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (value, _) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer, messageTemplate);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new UInt128Data();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (_, value) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new StringData();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldNotThrow_WhenBoundsAreNormalizedAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldNotThrow_WhenBoundsAreEqualAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldNotThrow_WhenReferenceTypeLowerBoundIsNullAndUpperBoundIsNotAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      T lowerBound = default!;
+      T upperBound = default!;
+      T value = default!;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrowInvalidOperationException_WhenLowerBoundIsGreaterThanUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.UpperBound, data.LowerBound);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparer_ShouldThrowInvalidOperationException_WhenReferenceTypeLowerBoundIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, default!);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
@@ -696,7 +1071,7 @@ public class BetweenExtensionsTests
       // Arrange.
       var value = data.WithinBoundsValue;
       T lowerBound = default!;
-      var upperBound = data.WithinBoundsValue;
+      var upperBound = data.UpperBound;
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
 
       // Act/assert.
@@ -705,7 +1080,7 @@ public class BetweenExtensionsTests
 
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
-   public void BetweenExtensions_RequiresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndUpperBoundIsNotAndValueIsNull<T>(
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndValueIsNull<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
       // Arrange.
@@ -742,9 +1117,390 @@ public class BetweenExtensionsTests
    {
       // Arrange.
       var value = data.WithinBoundsValue;
-      var lowerBound = data.UpperBound;
+      var lowerBound = data.LowerBound;
       T upperBound = default!;
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresBetween (IComparer) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = lowerBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = upperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+      var value = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = upperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = lowerBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldReturnOriginalValue_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      T lowerBound = default!;
+      T upperBound = default!;
+      T value = default!;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrow_WhenValueIsBelowLowerBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (value, _) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (_, value) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrow_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      T value = default!;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new Int32Data();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (value, _) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Between);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.LowerBound].Should().Be(lowerBound);
+      ex.Data[DataNames.LowerBoundExpression].Should().Be(nameof(lowerBound));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenThanIComparer_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (_, value) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new HalfData();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (value, _) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new UInt128Data();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var (_, value) = comparer.ReverseValues(data.BelowLowerBoundValue, data.AboveUpperBoundValue);
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new StringData();
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldNotThrow_WhenBoundsAreNormalizedAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, data.UpperBound);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldNotThrow_WhenBoundsAreEqualAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldNotThrow_WhenReferenceTypeLowerBoundIsNullAndUpperBoundIsNotAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(default!, data.UpperBound);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      T lowerBound = default!;
+      T upperBound = default!;
+      T value = default!;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrowInvalidOperationException_WhenLowerBoundIsGreaterThanUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.UpperBound, data.LowerBound);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparer_ShouldThrowInvalidOperationException_WhenReferenceTypeLowerBoundIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var comparer = data.ReverseComparer;
+      var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, default!);
+      var value = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
@@ -753,6 +753,613 @@ public class BetweenExtensionsTests
 
    #endregion
 
+   #region EnsuresBetween (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   // For ordinal comparison, caret(^) sorts between uppercase Z and lowercase A
+   // For ordinal ignore case comparison, caret(^) sorts above Z
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseO, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.UpperCaseO, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseZ, StringData.LowerCaseA, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
+   [UseCulture(CultureData.LatinAzerbaijan)]
+   [Theory]
+   [InlineData(StringData.LowerCaseX, StringData.UpperCaseH, StringData.UpperCaseI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseX, StringData.LowerCaseH, StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseO, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.UpperCaseO, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseZ, StringData.LowerCaseA, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBoundAndCurrentCultureIs_azLatnAZ(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // sv-SE culture (Swedish/Sweden) sorts Z, A(overring), A(diaeresis), O(diaeresis)
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAWithOverring, StringData.LowerCaseZ, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAWithOverring, StringData.UpperCaseZ, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseO, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.UpperCaseO, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBoundAndCurrentCultureIs_svSE(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseA, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAPlusDiaeresisCombiningCharacter, StringData.UpperCaseAWithDiaeresis, StringData.LowerCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAWithDiaeresis, StringData.UpperCaseAWithDiaeresis, StringData.UpperCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // da-DK culture (Danish/Denmark) sorts Z, AE(diphthong), O(slashed), A(overring)
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringData.LowerCaseAWithOverring, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringData.LowerCaseAWithOverring, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusSlashCombiningCharacter, StringData.UpperCaseSlashedO, StringData.LowerCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseOPlusSlashCombiningCharacter, StringData.UpperCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBoundAndCurrentCultureIs_daDK(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // sv-SE culture (Swedish/Sweden) sorts Z, A(overring), A(diaeresis), O(diaeresis)
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAPlusOverringCombiningCharacter, StringData.UpperCaseZ, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, StringData.LowerCaseZ, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBoundAndCurrentCultureIs_svSE(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueEqualToLowerBoundAndToUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueEqualToLowerBoundAndToUpperBoundAndCurrentCultureIs_trTR(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, null, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, null, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseSlashedO, null, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, null, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, null, StringData.LowerCaseA, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, null, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndValueIsNotNullAndBelowUpperBound(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(StringData.UpperCaseH, null, StringData.UpperCaseH, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseH, null, StringData.UpperCaseH, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, null, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, null, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndValueIsNotNullAndEqualToUpperBound(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null, null, StringData.UpperCaseH, StringComparison.CurrentCulture)]
+   [InlineData(null, null, StringData.UpperCaseH, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(null, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, null, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(null, null, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndValueIsNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null, null, null, StringComparison.CurrentCulture)]
+   [InlineData(null, null, null, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.InvariantCulture)]
+   [InlineData(null, null, null, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.Ordinal)]
+   [InlineData(null, null, null, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldReturnOriginalValue_WhenValueIsNullAndLowerAndUpperBoundsAreNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseH, StringData.LowerCaseI, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseP, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseX, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrow_WhenValueIsBelowLowerBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
+   [UseCulture(CultureData.LatinAzerbaijan)]
+   [Theory]
+   [InlineData(StringData.LowerCaseX, StringData.UpperCaseX, StringData.UpperCaseJ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseX, StringData.LowerCaseDotlessI, StringData.LowerCaseJ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseP, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseX, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrow_WhenValueIsBelowLowerBoundAndCurrentCultureIs_azLatnAZ(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseP, StringData.UpperCaseA, StringData.UpperCaseO, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseP, StringData.LowerCaseA, StringData.LowerCaseO, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseO, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseA, StringData.LowerCaseO, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseZ, StringData.LowerCaseA, StringData.LowerCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   // da-DK culture (Danish/Denmark) sorts Z, AE(diphthong), O(slashed), A(overring)
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseA, StringData.UpperCaseDiphthongAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseO, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseA, StringData.LowerCaseO, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseZ, StringData.LowerCaseA, StringData.LowerCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_daDK(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+   [Theory]
+   [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(null, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(null, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(null, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrow_WhenValueIsNullAndLowerAndUpperBoundsAreNotNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.Ordinal;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseZ;
+      var value = StringData.UpperCaseA;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Between);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.LowerBound].Should().Be(lowerBound);
+      ex.Data[DataNames.LowerBoundExpression].Should().Be(nameof(lowerBound));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseZ;
+      var value = StringData.Caret;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+      var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.InvariantCulture;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseJ;
+      var value = StringData.UpperCaseSlashedO;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType, messageTemplate);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseJ;
+      var value = StringData.UpperCaseSlashedO;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.Ordinal;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseJ;
+      var value = StringData.UpperCaseAPlusDiaeresisCombiningCharacter;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldNotThrow_WhenBoundsAreNormalizedAndValueIsInRange(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldNotThrow_WhenBoundsAreEqualAndValueIsInRange(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // sv-SE culture (Swedish/Sweden) sorts Z, A(overring), A(diaeresis), O(diaeresis)
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAPlusOverringCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, null, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, null, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, null, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldNotThrow_WhenLowerBoundIsNullAndUpperBoundIsNotAndValueIsInRange(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData(null, null, null, StringComparison.CurrentCulture)]
+   [InlineData(null, null, null, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.InvariantCulture)]
+   [InlineData(null, null, null, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.Ordinal)]
+   [InlineData(null, null, null, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldNotThrow_WhenBoundsAreNullAndValueIsNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
+   [UseCulture(CultureData.LatinAzerbaijan)]
+   [Theory]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseJ, StringData.UpperCaseX, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseJ, StringData.LowerCaseX, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseSlashedO, StringData.UpperCaseP, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.LowerCaseP, StringData.LowerCaseO, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.LowerCaseZ, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseZ, StringData.LowerCaseA, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowInvalidOperationException_WhenLowerBoundIsGreaterThanUpperBound(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_EnsuresBetweenString_ShouldThrowInvalidOperationException_WhenLowerBoundIsNotNullAndUpperBoundIsNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
    #region RequiresBetween (IComparable) Tests
    // ==========================================================================
    // ==========================================================================
@@ -1501,6 +2108,619 @@ public class BetweenExtensionsTests
       var (lowerBound, upperBound) = comparer.ReverseValues(data.LowerBound, default!);
       var value = data.WithinBoundsValue;
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresBetween (String) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   // For ordinal comparison, caret(^) sorts between uppercase Z and lowercase A
+   // For ordinal ignore case comparison, caret(^) sorts above Z
+   [UseCulture(CultureData.EnglishUS)]  
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseO, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.UpperCaseO, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseZ, StringData.LowerCaseA, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
+   [UseCulture(CultureData.LatinAzerbaijan)] 
+   [Theory]
+   [InlineData(StringData.LowerCaseX, StringData.UpperCaseH, StringData.UpperCaseI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseX, StringData.LowerCaseH, StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseO, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.UpperCaseO, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseZ, StringData.LowerCaseA, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBoundAndCurrentCultureIs_azLatnAZ(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // sv-SE culture (Swedish/Sweden) sorts Z, A(overring), A(diaeresis), O(diaeresis)
+   [UseCulture(CultureData.SwedishSweden)]  
+   [Theory]
+   [InlineData(StringData.LowerCaseAWithOverring, StringData.LowerCaseZ, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAWithOverring, StringData.UpperCaseZ, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseO, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.UpperCaseO, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseAE, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBoundAndCurrentCultureIs_svSE(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseA, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseAPlusDiaeresisCombiningCharacter, StringData.UpperCaseAWithDiaeresis, StringData.LowerCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseAWithDiaeresis, StringData.UpperCaseAWithDiaeresis, StringData.UpperCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // da-DK culture (Danish/Denmark) sorts Z, AE(diphthong), O(slashed), A(overring)
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringData.LowerCaseAWithOverring, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseDiphthongAE, StringData.UpperCaseDiphthongAE, StringData.LowerCaseAWithOverring, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusSlashCombiningCharacter, StringData.UpperCaseSlashedO, StringData.LowerCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseOPlusSlashCombiningCharacter, StringData.UpperCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseA, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBoundAndCurrentCultureIs_daDK(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   // sv-SE culture (Swedish/Sweden) sorts Z, A(overring), A(diaeresis), O(diaeresis)
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAPlusOverringCombiningCharacter, StringData.UpperCaseZ, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, StringData.LowerCaseZ, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBoundAndCurrentCultureIs_svSE(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.UpperCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueEqualToLowerBoundAndToUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueEqualToLowerBoundAndToUpperBoundAndCurrentCultureIs_trTR(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(StringData.UpperCaseAE, null, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseAE, null, StringData.UpperCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseSlashedO, null, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, null, StringData.UpperCaseP, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, null, StringData.LowerCaseA, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, null, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndValueIsNotNullAndBelowUpperBound(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+         // Act.
+         var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+         // Assert.
+         result.Should().Be(value);
+      }
+
+   [Theory]
+   [InlineData(StringData.UpperCaseH, null, StringData.UpperCaseH, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseH, null, StringData.UpperCaseH, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, null, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, null, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndValueIsNotNullAndEqualToUpperBound(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null, null, StringData.UpperCaseH, StringComparison.CurrentCulture)]
+   [InlineData(null, null, StringData.UpperCaseH, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(null, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, null, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(null, null, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndValueIsNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null, null, null, StringComparison.CurrentCulture)]
+   [InlineData(null, null, null, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.InvariantCulture)]
+   [InlineData(null, null, null, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.Ordinal)]
+   [InlineData(null, null, null, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldReturnOriginalValue_WhenValueIsNullAndLowerAndUpperBoundsAreNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseH, StringData.LowerCaseI, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseP, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseX, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrow_WhenValueIsBelowLowerBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
+   [UseCulture(CultureData.LatinAzerbaijan)]
+   [Theory]
+   [InlineData(StringData.LowerCaseX, StringData.UpperCaseX, StringData.UpperCaseJ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseX, StringData.LowerCaseDotlessI, StringData.LowerCaseJ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseP, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseA, StringData.LowerCaseX, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrow_WhenValueIsBelowLowerBoundAndCurrentCultureIs_azLatnAZ(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseP, StringData.UpperCaseA, StringData.UpperCaseO, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseP, StringData.LowerCaseA, StringData.LowerCaseO, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseO, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseA, StringData.LowerCaseO, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseZ, StringData.LowerCaseA, StringData.LowerCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_enUS(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   // da-DK culture (Danish/Denmark) sorts Z, AE(diphthong), O(slashed), A(overring)
+   [UseCulture(CultureData.DanishDenmark)]
+   [Theory]
+   [InlineData(StringData.LowerCaseSlashedO, StringData.UpperCaseA, StringData.UpperCaseDiphthongAE, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseDiphthongAE, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseO, StringComparison.InvariantCulture)]
+   [InlineData(StringData.UpperCaseSlashedO, StringData.LowerCaseA, StringData.LowerCaseO, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.UpperCaseZ, StringData.LowerCaseA, StringData.LowerCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrow_WhenValueIsAboveUpperBoundAndCurrentCultureIs_daDK(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+   [Theory]
+   [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(null, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.InvariantCulture)]
+   [InlineData(null, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(null, StringData.LowerCaseA, StringData.LowerCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrow_WhenValueIsNullAndLowerAndUpperBoundsAreNotNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.Ordinal;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseZ;
+      var value = StringData.UpperCaseA;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_stringDataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Between);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.LowerBound].Should().Be(lowerBound);
+      ex.Data[DataNames.LowerBoundExpression].Should().Be(nameof(lowerBound));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseZ;
+      var value = StringData.Caret;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.InvariantCulture;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseJ;
+      var value = StringData.UpperCaseSlashedO;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseJ;
+      var value = StringData.UpperCaseSlashedO;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var comparisonType = StringComparison.Ordinal;
+      var lowerBound = StringData.LowerCaseA;
+      var upperBound = StringData.LowerCaseJ;
+      var value = StringData.UpperCaseAPlusDiaeresisCombiningCharacter;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseZ, StringData.UpperCaseA, StringData.LowerCaseZ, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, StringData.UpperCaseA, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, StringData.Caret, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldNotThrow_WhenBoundsAreNormalizedAndValueIsInRange(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData(StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.UpperCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, StringData.UpperCaseOWithDiaeresis, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.Caret, StringData.Caret, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseH, StringData.UpperCaseH, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldNotThrow_WhenBoundsAreEqualAndValueIsInRange(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // sv-SE culture (Swedish/Sweden) sorts Z, A(overring), A(diaeresis), O(diaeresis)
+   [UseCulture(CultureData.SwedishSweden)]
+   [Theory]
+   [InlineData(StringData.LowerCaseAPlusOverringCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseOWithDiaeresis, null, StringData.LowerCaseOWithDiaeresis, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseOPlusDiaeresisCombiningCharacter, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOWithDiaeresis, null, StringData.UpperCaseOWithDiaeresis, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseZ, null, StringData.LowerCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseZ, null, StringData.UpperCaseZ, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldNotThrow_WhenLowerBoundIsNullAndUpperBoundIsNotAndValueIsInRange(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData(null, null, null, StringComparison.CurrentCulture)]
+   [InlineData(null, null, null, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.InvariantCulture)]
+   [InlineData(null, null, null, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(null, null, null, StringComparison.Ordinal)]
+   [InlineData(null, null, null, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldNotThrow_WhenBoundsAreNullAndValueIsNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
+   [UseCulture(CultureData.LatinAzerbaijan)]
+   [Theory]
+   [InlineData(StringData.LowerCaseI, StringData.UpperCaseJ, StringData.UpperCaseX, StringComparison.CurrentCulture)]
+   [InlineData(StringData.UpperCaseI, StringData.LowerCaseJ, StringData.LowerCaseX, StringComparison.CurrentCultureIgnoreCase)] // I without dot sorts before I with dot in tr-TR culture
+   [InlineData(StringData.UpperCaseSlashedO, StringData.UpperCaseP, StringData.LowerCaseP, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseOPlusSlashCombiningCharacter, StringData.LowerCaseP, StringData.LowerCaseO, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.Caret, StringData.LowerCaseZ, StringData.UpperCaseZ, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.UpperCaseZ, StringData.LowerCaseA, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowInvalidOperationException_WhenLowerBoundIsGreaterThanUpperBound(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.CurrentCulture)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.InvariantCulture)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.Ordinal)]
+   [InlineData(StringData.LowerCaseH, StringData.LowerCaseA, null, StringComparison.OrdinalIgnoreCase)]
+   public void BetweenExtensions_RequiresBetweenString_ShouldThrowInvalidOperationException_WhenLowerBoundIsNotNullAndUpperBoundIsNull(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
@@ -1,0 +1,756 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class BetweenExtensionsTests
+{
+   private const Int32 _dataCount = 8;
+   private const Int32 _stringDataCount = 9;
+
+   #region EnsuresBetween (IComparable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.LowerBound;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.UpperBound;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      T lowerBound = default!;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.UpperBound;
+      T lowerBound = default!;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T lowerBound = default!;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldReturnOriginalValue_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T lowerBound = default!;
+      T upperBound = default!;
+
+      // Act.
+      var result = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrow_WhenValueIsBelowLowerBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.BelowLowerBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrow_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new Int32Data();
+      var value = data.BelowLowerBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Between);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.LowerBound].Should().Be(lowerBound);
+      ex.Data[DataNames.LowerBoundExpression].Should().Be(nameof(lowerBound));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenThanIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+      var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new HalfData();
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, messageTemplate);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new UInt128Data();
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var lowerBound = "ABC";
+      var upperBound = "xyz";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldNotThrow_WhenBoundsAreNormalizedAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldNotThrow_WhenBoundsAreEqualAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeLowerBoundIsNullAndUpperBoundIsNotAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      T lowerBound = default!;
+      var upperBound = data.WithinBoundsValue;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndUpperBoundIsNotAndValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T lowerBound = default!;
+      T upperBound = default!;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrowInvalidOperationException_WhenLowerBoundIsGreaterThanUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.UpperBound;
+      var upperBound = data.LowerBound;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_EnsuresBetweenIComparable_ShouldThrowInvalidOperationException_WhenReferenceTypeLowerBoundIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.UpperBound;
+      T upperBound = default!;
+      var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresBetween (IComparable) Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.LowerBound;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsAboveLowerBoundAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.UpperBound;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenValueIsEqualToLowerBoundAndUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndBelowUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      T lowerBound = default!;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNotNullAndEqualToUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.UpperBound;
+      T lowerBound = default!;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenLowerBoundIsNullAndReferenceTypeValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T lowerBound = default!;
+      var upperBound = data.UpperBound;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldReturnOriginalValue_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T lowerBound = default!;
+      T upperBound = default!;
+
+      // Act.
+      var result = value.RequiresBetween(lowerBound, upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrow_WhenValueIsBelowLowerBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.BelowLowerBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrow_WhenValueIsAboveUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrow_WhenReferenceTypeValueIsNullAndLowerAndUpperBoundsAreNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var data = new Int32Data();
+      var value = data.BelowLowerBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Between);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.LowerBound].Should().Be(lowerBound);
+      ex.Data[DataNames.LowerBoundExpression].Should().Be(nameof(lowerBound));
+      ex.Data[DataNames.UpperBound].Should().Be(upperBound);
+      ex.Data[DataNames.UpperBoundExpression].Should().Be(nameof(upperBound));
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenThanIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var data = new PointStructData();
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var data = new HalfData();
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var data = new UInt128Data();
+      var value = data.AboveUpperBoundValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var lowerBound = "ABC";
+      var upperBound = "xyz";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Between failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldNotThrow_WhenBoundsAreNormalizedAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.LowerBound;
+      var upperBound = data.UpperBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldNotThrow_WhenBoundsAreEqualAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.WithinBoundsValue;
+      var upperBound = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeLowerBoundIsNullAndUpperBoundIsNotAndValueIsInRange<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      T lowerBound = default!;
+      var upperBound = data.WithinBoundsValue;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldNotThrow_WhenReferenceTypeBoundsAreNullAndUpperBoundIsNotAndValueIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      T lowerBound = default!;
+      T upperBound = default!;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(BoundedTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrowInvalidOperationException_WhenLowerBoundIsGreaterThanUpperBound<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.UpperBound;
+      var upperBound = data.LowerBound;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
+   public void BetweenExtensions_RequiresBetweenIComparable_ShouldThrowInvalidOperationException_WhenReferenceTypeLowerBoundIsNotNullAndUpperBoundIsNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      var value = data.WithinBoundsValue;
+      var lowerBound = data.UpperBound;
+      T upperBound = default!;
+      var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
+      var expectedMessage = Messages.BetweenBoundsNotNormalized;
+
+      // Act/assert.
+      act.Should().Throw<InvalidOperationException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
@@ -46,6 +46,22 @@ public class LessThanOrEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var upperBound = data.MinValue;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
    public void LessThanOrEqualExtensions_EnsuresLessOrEqualThanIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNull<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
@@ -82,20 +98,6 @@ public class LessThanOrEqualExtensionsTests
       // Arrange.
       var value = data.MaxValue;
       T upperBound = default!;
-      var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
-
-      // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
-   }
-
-   [Theory]
-   [ClassData(typeof(ReferenceTypesTestData))]
-   public void LessThanOrEqualExtensions_EnsuresLessThanOrEqualIComparable_ShouldThrow_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
-      IComparableTestData<T> data) where T : IComparable<T>
-   {
-      // Arrange.
-      T value = default!;
-      var upperBound = data.MinValue;
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
 
       // Act/assert.
@@ -706,6 +708,22 @@ public class LessThanOrEqualExtensionsTests
 
    [Theory]
    [ClassData(typeof(ReferenceTypesTestData))]
+   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
+      IComparableTestData<T> data) where T : IComparable<T>
+   {
+      // Arrange.
+      T value = default!;
+      var upperBound = data.MinValue;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqual(upperBound);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(ReferenceTypesTestData))]
    public void LessThanOrEqualExtensions_RequiresLessOrEqualThanIComparable_ShouldReturnOriginalValue_WhenReferenceValueIsNullAndUpperBoundIsNull<T>(
       IComparableTestData<T> data) where T : IComparable<T>
    {
@@ -742,20 +760,6 @@ public class LessThanOrEqualExtensionsTests
       // Arrange.
       var value = data.MaxValue;
       T upperBound = default!;
-      var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
-
-      // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
-   }
-
-   [Theory]
-   [ClassData(typeof(ReferenceTypesTestData))]
-   public void LessThanOrEqualExtensions_RequiresLessThanOrEqualIComparable_ShouldThrow_WhenReferenceValueIsNullAndUpperBoundIsNotNull<T>(
-      IComparableTestData<T> data) where T : IComparable<T>
-   {
-      // Arrange.
-      T value = default!;
-      var upperBound = data.MinValue;
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
 
       // Act/assert.

--- a/DbC.Net.Tests.Unit/TestData/BigIntegerData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BigIntegerData.cs
@@ -7,6 +7,11 @@ public class BigIntegerData : ComparableValue<BigInteger>
       -100,
       new ReverseComparer<BigInteger>(),
       BigInteger.Multiply(Int64.MinValue, 2),
+      BigInteger.Multiply(Int64.MaxValue, 2),
+      Int64.MinValue,
+      Int64.MaxValue,
+      BigInteger.Multiply(Int64.MinValue, 2),
+      0,
       BigInteger.Multiply(Int64.MaxValue, 2))
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/BigIntegerData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BigIntegerData.cs
@@ -5,6 +5,7 @@ public class BigIntegerData : ComparableValue<BigInteger>
    public BigIntegerData() : base(
       100,
       -100,
+      Comparer<BigInteger>.Default,
       new ReverseComparer<BigInteger>(),
       BigInteger.Multiply(Int64.MinValue, 2),
       BigInteger.Multiply(Int64.MaxValue, 2),

--- a/DbC.Net.Tests.Unit/TestData/BooleanData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BooleanData.cs
@@ -4,7 +4,8 @@ public class BooleanData : ComparableValue<Boolean>
 {
    public BooleanData() : base(
       true, 
-      false, 
+      false,
+      Comparer<Boolean>.Default,
       new ReverseComparer<Boolean>(), 
       false, 
       true,
@@ -25,4 +26,12 @@ public class BooleanData : ComparableValue<Boolean>
    public override Boolean WithinBoundsValue => throw new NotImplementedException();
 
    public override Boolean AboveUpperBoundValue => throw new NotImplementedException();
+
+   public override Boolean ReverseLowerBound => throw new NotImplementedException();
+
+   public override Boolean ReverseUpperBound => throw new NotImplementedException();
+
+   public override Boolean ReverseBelowLowerBoundValue => throw new NotImplementedException();
+
+   public override Boolean ReverseAboveUpperBoundValue => throw new NotImplementedException();
 }

--- a/DbC.Net.Tests.Unit/TestData/BooleanData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BooleanData.cs
@@ -2,7 +2,27 @@
 
 public class BooleanData : ComparableValue<Boolean>
 {
-   public BooleanData() : base(true, false, new ReverseComparer<Boolean>(), false, true) { }
+   public BooleanData() : base(
+      true, 
+      false, 
+      new ReverseComparer<Boolean>(), 
+      false, 
+      true,
+      false,
+      false,
+      false,
+      false,
+      false) { }
 
-    public override Boolean NonDefaultNotEqualValue => true;
+   public override Boolean NonDefaultNotEqualValue => true;
+
+   public override Boolean LowerBound => throw new NotImplementedException();
+
+   public override Boolean UpperBound => throw new NotImplementedException();
+
+   public override Boolean BelowLowerBoundValue => throw new NotImplementedException();
+
+   public override Boolean WithinBoundsValue => throw new NotImplementedException();
+
+   public override Boolean AboveUpperBoundValue => throw new NotImplementedException();
 }

--- a/DbC.Net.Tests.Unit/TestData/BoundedTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BoundedTypesTestData.cs
@@ -1,0 +1,39 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public class BoundedTypesTestData : IEnumerable<Object[]>
+{
+   public IEnumerator<Object[]> GetEnumerator()
+   {
+      yield return new Object[] { new BigIntegerData() };
+      yield return new Object[] { new ByteData() };
+      yield return new Object[] { new CharData() };
+      yield return new Object[] { new DateOnlyData() };
+      yield return new Object[] { new DateTimeData() };
+      yield return new Object[] { new DateTimeOffsetData() };
+      yield return new Object[] { new DecimalData() };
+      yield return new Object[] { new DoubleData() };
+      yield return new Object[] { new GuidData() };
+      yield return new Object[] { new HalfData() };
+      yield return new Object[] { new Int128Data() };
+      yield return new Object[] { new Int16Data() };
+      yield return new Object[] { new Int32Data() };
+      yield return new Object[] { new Int64Data() };
+      yield return new Object[] { new SByteData() };
+      yield return new Object[] { new SingleData() };
+      yield return new Object[] { new TimeOnlyData() };
+      yield return new Object[] { new UInt128Data() };
+      yield return new Object[] { new UInt16Data() };
+      yield return new Object[] { new UInt32Data() };
+      yield return new Object[] { new UInt64Data() };
+      yield return new Object[] { new nintData() };
+      yield return new Object[] { new nuintData() };
+
+      yield return new Object[] { new StringData() };
+
+      yield return new Object[] { new PointStructData() };
+      yield return new Object[] { new BoxRecordData() };
+      yield return new Object[] { new ObservationClassData() };
+   }
+
+   IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/DbC.Net.Tests.Unit/TestData/BoundedTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BoundedTypesTestData.cs
@@ -21,6 +21,7 @@ public class BoundedTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new SByteData() };
       yield return new Object[] { new SingleData() };
       yield return new Object[] { new TimeOnlyData() };
+      yield return new Object[] { new TimeSpanData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };
       yield return new Object[] { new UInt32Data() };

--- a/DbC.Net.Tests.Unit/TestData/BoxRecordData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BoxRecordData.cs
@@ -5,6 +5,7 @@ public class BoxRecordData : ComparableValue<Box>
    public BoxRecordData() : base(
       new Box(1, 2, 3, "Blue"),
       new Box(2, 2, 2, "Red"),
+      BoxComparers.AllFieldsComparer,
       new ReverseComparer<Box>(),
       new Box(1, 1, 1, "Green"),
       new Box(100, 100, 100, "Blue"),

--- a/DbC.Net.Tests.Unit/TestData/BoxRecordData.cs
+++ b/DbC.Net.Tests.Unit/TestData/BoxRecordData.cs
@@ -7,6 +7,11 @@ public class BoxRecordData : ComparableValue<Box>
       new Box(2, 2, 2, "Red"),
       new ReverseComparer<Box>(),
       new Box(1, 1, 1, "Green"),
+      new Box(100, 100, 100, "Blue"),
+      new Box(3, 3, 3, "Orange"),
+      new Box(9, 9, 9, "Yellow"),
+      new Box(1, 1, 1, "Green"),
+      new Box(5, 5, 5, "Red"),
       new Box(100, 100, 100, "Blue"))
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/ByteData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ByteData.cs
@@ -7,6 +7,11 @@ public class ByteData : ComparableValue<Byte>
       101,
       new ReverseComparer<Byte>(),
       Byte.MinValue,
-      Byte.MaxValue)
+      Byte.MaxValue,
+      10,
+      100,
+      5,
+      45,
+      105)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/ByteData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ByteData.cs
@@ -5,6 +5,7 @@ public class ByteData : ComparableValue<Byte>
    public ByteData() : base(
       100,
       101,
+      Comparer<Byte>.Default,
       new ReverseComparer<Byte>(),
       Byte.MinValue,
       Byte.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/CharData.cs
+++ b/DbC.Net.Tests.Unit/TestData/CharData.cs
@@ -5,6 +5,7 @@ public class CharData : ComparableValue<Char>
    public CharData() : base(
       'A',
       'z',
+      Comparer<Char>.Default,
       new ReverseComparer<Char>(),
       Char.MinValue,
       Char.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/CharData.cs
+++ b/DbC.Net.Tests.Unit/TestData/CharData.cs
@@ -7,6 +7,11 @@ public class CharData : ComparableValue<Char>
       'z',
       new ReverseComparer<Char>(),
       Char.MinValue,
-      Char.MaxValue)
+      Char.MaxValue,
+      'A',
+      'Z',
+      '*',
+      'M',
+      '~')
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/ComparableTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableTypesTestData.cs
@@ -22,6 +22,7 @@ public sealed class ComparableTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new SByteData() };
       yield return new Object[] { new SingleData() };
       yield return new Object[] { new TimeOnlyData() };
+      yield return new Object[] { new TimeSpanData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };
       yield return new Object[] { new UInt32Data() };

--- a/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
@@ -6,6 +6,7 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
    public ComparableValue(
       T equalValue,
       T notEqualValue,
+      IComparer<T> comparer,
       ReverseComparer<T> reverseComparer,
       T minValue,
       T maxValue,
@@ -13,7 +14,7 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
       T upperBound,
       T belowLowerBoundValue,
       T withinBoundsValue,
-      T aboveUpperBoundValue) : base(equalValue, notEqualValue, reverseComparer)
+      T aboveUpperBoundValue) : base(equalValue, notEqualValue, comparer, reverseComparer)
    {
       MinValue = minValue;
       MaxValue = maxValue;
@@ -25,6 +26,10 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
       BelowLowerBoundValue = belowLowerBoundValue;
       WithinBoundsValue = withinBoundsValue;
       AboveUpperBoundValue = aboveUpperBoundValue;
+      ReverseLowerBound = upperBound;
+      ReverseUpperBound = lowerBound;
+      ReverseBelowLowerBoundValue = aboveUpperBoundValue;
+      ReverseAboveUpperBoundValue = belowLowerBoundValue;
    }
 
    public T MaxValue { get; }
@@ -44,4 +49,12 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
    public virtual T WithinBoundsValue { get; }
 
    public virtual T AboveUpperBoundValue { get; }
+
+   public virtual T ReverseLowerBound { get; }
+
+   public virtual T ReverseUpperBound { get; }
+
+   public virtual T ReverseBelowLowerBoundValue { get; }
+
+   public virtual T ReverseAboveUpperBoundValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/ComparableValue.cs
@@ -8,12 +8,23 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
       T notEqualValue,
       ReverseComparer<T> reverseComparer,
       T minValue,
-      T maxValue) : base(equalValue, notEqualValue, reverseComparer)
+      T maxValue,
+      T lowerBound,
+      T upperBound,
+      T belowLowerBoundValue,
+      T withinBoundsValue,
+      T aboveUpperBoundValue) : base(equalValue, notEqualValue, reverseComparer)
    {
       MinValue = minValue;
       MaxValue = maxValue;
       ReverseMaxValue = minValue;
       ReverseMinValue = maxValue;
+
+      LowerBound = lowerBound;
+      UpperBound = upperBound;
+      BelowLowerBoundValue = belowLowerBoundValue;
+      WithinBoundsValue = withinBoundsValue;
+      AboveUpperBoundValue = aboveUpperBoundValue;
    }
 
    public T MaxValue { get; }
@@ -23,4 +34,14 @@ public abstract class ComparableValue<T> : EquatableValue<T>, IComparableTestDat
    public T ReverseMaxValue { get; }
 
    public T ReverseMinValue { get; }
+
+   public virtual T LowerBound { get; }
+
+   public virtual T UpperBound { get; }
+
+   public virtual T BelowLowerBoundValue { get; }
+
+   public virtual T WithinBoundsValue { get; }
+
+   public virtual T AboveUpperBoundValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/CultureData.cs
+++ b/DbC.Net.Tests.Unit/TestData/CultureData.cs
@@ -6,6 +6,8 @@ public static class CultureData
 
    public const String EnglishUS = "en-US";
 
+   public const String LatinAzerbaijan = "az-Latn-AZ";
+
    public const String SwedishSweden = "sv-SE";
 
    public const String ThaiThailand = "th-TH";

--- a/DbC.Net.Tests.Unit/TestData/DateOnlyData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DateOnlyData.cs
@@ -5,6 +5,7 @@ public class DateOnlyData : ComparableValue<DateOnly>
    public DateOnlyData() : base(
       new(2000, 1, 1),
       new(1970, 1, 1),
+      Comparer<DateOnly>.Default,
       new ReverseComparer<DateOnly>(),
       DateOnly.MinValue,
       DateOnly.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/DateOnlyData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DateOnlyData.cs
@@ -7,6 +7,11 @@ public class DateOnlyData : ComparableValue<DateOnly>
       new(1970, 1, 1),
       new ReverseComparer<DateOnly>(),
       DateOnly.MinValue,
-      DateOnly.MaxValue)
+      DateOnly.MaxValue,
+      new(1966, 9, 8),  // TOS first episode aired
+      new(1969, 6, 3),  // TOS last episode aired
+      new(1965, 9, 15), // Lost in Space first episode aired
+      new(1967, 9, 15), // TOS Amok Time first aired
+      new(1979, 4, 29)) // Battlestar Galactica last episode aired
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DateTimeData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DateTimeData.cs
@@ -5,6 +5,7 @@ public class DateTimeData : ComparableValue<DateTime>
    public DateTimeData() : base(
       new(2000, 1, 1),
       new(1970, 1, 1),
+      Comparer<DateTime>.Default,
       new ReverseComparer<DateTime>(),
       DateTime.MinValue,
       DateTime.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/DateTimeData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DateTimeData.cs
@@ -7,6 +7,11 @@ public class DateTimeData : ComparableValue<DateTime>
       new(1970, 1, 1),
       new ReverseComparer<DateTime>(),
       DateTime.MinValue,
-      DateTime.MaxValue)
+      DateTime.MaxValue,
+      new(1966, 9, 8, 18, 30, 0),  // TOS first episode aired
+      new(1969, 6, 3, 20, 0, 0),  // TOS last episode aired
+      new(1965, 9, 15, 17, 30, 0), // Lost in Space first episode aired
+      new(1967, 9, 15, 18, 30, 0), // TOS Amok Time first aired
+      new(1979, 4, 29, 18, 0, 0)) // Battlestar Galactica last episode aired
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DateTimeOffsetData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DateTimeOffsetData.cs
@@ -5,6 +5,7 @@ public class DateTimeOffsetData : ComparableValue<DateTimeOffset>
    public DateTimeOffsetData() : base(
       new DateTimeOffset(new DateTime(DateTimeOffset.MaxValue.Ticks / 4)),
       new DateTimeOffset(new DateTime(DateTimeOffset.MaxValue.Ticks / 2)),
+      Comparer<DateTimeOffset>.Default,
       new ReverseComparer<DateTimeOffset>(),
       DateTimeOffset.MinValue,
       DateTimeOffset.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/DateTimeOffsetData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DateTimeOffsetData.cs
@@ -7,6 +7,11 @@ public class DateTimeOffsetData : ComparableValue<DateTimeOffset>
       new DateTimeOffset(new DateTime(DateTimeOffset.MaxValue.Ticks / 2)),
       new ReverseComparer<DateTimeOffset>(),
       DateTimeOffset.MinValue,
-      DateTimeOffset.MaxValue)
+      DateTimeOffset.MaxValue,
+      new(new DateTime(1966, 9, 8, 18, 30, 0)),  // TOS first episode aired
+      new(new DateTime(1969, 6, 3, 20, 0, 0)),  // TOS last episode aired
+      new(new DateTime(1965, 9, 15, 17, 30, 0)), // Lost in Space first episode aired
+      new(new DateTime(1967, 9, 15, 18, 30, 0)), // TOS Amok Time first aired
+      new(new DateTime(1979, 4, 29, 18, 0, 0))) // Battlestar Galactica last episode aired
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DecimalData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DecimalData.cs
@@ -12,6 +12,7 @@ public class DecimalData : FloatingPointValue<Decimal>
       default!,
       Decimal.MaxValue,
       Decimal.MinValue,
+      Comparer<Decimal>.Default,
       new ReverseComparer<Decimal>(),
       Decimal.MinValue / 2,
       Decimal.MaxValue / 2,

--- a/DbC.Net.Tests.Unit/TestData/DecimalData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DecimalData.cs
@@ -12,6 +12,11 @@ public class DecimalData : FloatingPointValue<Decimal>
       default!,
       Decimal.MaxValue,
       Decimal.MinValue,
-      new ReverseComparer<Decimal>())
+      new ReverseComparer<Decimal>(),
+      Decimal.MinValue / 2,
+      Decimal.MaxValue / 2,
+      Decimal.MaxValue,
+      0,
+      Decimal.MinValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/DoubleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DoubleData.cs
@@ -12,6 +12,7 @@ public class DoubleData : FloatingPointValue<Double>
       StandardFloatingPointComparers.DoubleRelativeErrorComparer,
       Double.MaxValue,
       Double.MinValue,
+      Comparer<Double>.Default,
       new ReverseComparer<Double>(),
       Double.MinValue / 2,
       Double.MaxValue / 2,

--- a/DbC.Net.Tests.Unit/TestData/DoubleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/DoubleData.cs
@@ -12,6 +12,11 @@ public class DoubleData : FloatingPointValue<Double>
       StandardFloatingPointComparers.DoubleRelativeErrorComparer,
       Double.MaxValue,
       Double.MinValue,
-      new ReverseComparer<Double>())
+      new ReverseComparer<Double>(),
+      Double.MinValue / 2,
+      Double.MaxValue / 2,
+      Double.MaxValue,
+      0,
+      Double.MinValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/EquatableTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/EquatableTypesTestData.cs
@@ -18,6 +18,7 @@ public sealed class EquatableTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new Int64Data() };
       yield return new Object[] { new SByteData() };
       yield return new Object[] { new TimeOnlyData() };
+      yield return new Object[] { new TimeSpanData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };
       yield return new Object[] { new UInt32Data() };

--- a/DbC.Net.Tests.Unit/TestData/EquatableValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/EquatableValue.cs
@@ -5,11 +5,13 @@ public abstract class EquatableValue<T> : IEquatableTestData<T> where T : IEquat
     public EquatableValue(
        T equalValue,
        T notEqualValue,
+       IComparer<T> comparer,
        ReverseComparer<T> reverseComparer)
    {
       EqualValue = equalValue;
       NotEqualValue = notEqualValue;
       NonDefaultNotEqualValue = notEqualValue;
+      Comparer = comparer;
       ReverseComparer = reverseComparer;
    }
 
@@ -21,6 +23,8 @@ public abstract class EquatableValue<T> : IEquatableTestData<T> where T : IEquat
    ///   Special case for <see cref="Boolean"/> when performing equality tests against default.
    /// </summary>
    public virtual T NonDefaultNotEqualValue { get; }
+
+   public IComparer<T> Comparer { get; }
 
    public ReverseComparer<T> ReverseComparer { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -12,7 +12,12 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
       IApproximateEqualityComparer<T> relativeErrorComparer,
       T maxValue,
       T minValue,
-      ReverseComparer<T> reverseComparer)
+      ReverseComparer<T> reverseComparer,
+      T lowerBound,
+      T upperBound,
+      T belowLowerBoundValue,
+      T withinBoundsValue,
+      T aboveUpperBoundValue)
    {
       Value = value;
       WithinToleranceDelta = withinToleranceDelta;
@@ -26,6 +31,12 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
       ReverseComparer = reverseComparer;
       ReverseMaxValue = minValue;
       ReverseMinValue = maxValue;
+
+      LowerBound = lowerBound;
+      UpperBound = upperBound;
+      BelowLowerBoundValue = belowLowerBoundValue;
+      WithinBoundsValue = withinBoundsValue;
+      AboveUpperBoundValue = aboveUpperBoundValue;
    }
 
    public virtual T Value { get; }
@@ -51,4 +62,14 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
    public T ReverseMaxValue { get; }
 
    public T ReverseMinValue { get; }
+
+   public T LowerBound { get; }
+
+   public T UpperBound { get; }
+
+   public T BelowLowerBoundValue { get; }
+
+   public T WithinBoundsValue { get; }
+
+   public T AboveUpperBoundValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
+++ b/DbC.Net.Tests.Unit/TestData/FloatingPointValue.cs
@@ -12,6 +12,7 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
       IApproximateEqualityComparer<T> relativeErrorComparer,
       T maxValue,
       T minValue,
+      IComparer<T> comparer,
       ReverseComparer<T> reverseComparer,
       T lowerBound,
       T upperBound,
@@ -28,6 +29,7 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
       RelativeErrorComparer = relativeErrorComparer;
       MaxValue = maxValue;
       MinValue = minValue;
+      Comparer = comparer;
       ReverseComparer = reverseComparer;
       ReverseMaxValue = minValue;
       ReverseMinValue = maxValue;
@@ -37,6 +39,10 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
       BelowLowerBoundValue = belowLowerBoundValue;
       WithinBoundsValue = withinBoundsValue;
       AboveUpperBoundValue = aboveUpperBoundValue;
+      ReverseLowerBound = upperBound;
+      ReverseUpperBound = lowerBound;
+      ReverseBelowLowerBoundValue = aboveUpperBoundValue;
+      ReverseAboveUpperBoundValue = belowLowerBoundValue;
    }
 
    public virtual T Value { get; }
@@ -57,6 +63,8 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
 
    public T MinValue { get; }
 
+   public IComparer<T> Comparer { get; }
+
    public ReverseComparer<T> ReverseComparer { get; }
 
    public T ReverseMaxValue { get; }
@@ -72,4 +80,12 @@ public abstract class FloatingPointValue<T> : IComparableTestData<T> where T : I
    public T WithinBoundsValue { get; }
 
    public T AboveUpperBoundValue { get; }
+
+   public virtual T ReverseLowerBound { get; }
+
+   public virtual T ReverseUpperBound { get; }
+
+   public virtual T ReverseBelowLowerBoundValue { get; }
+
+   public virtual T ReverseAboveUpperBoundValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/GuidData.cs
+++ b/DbC.Net.Tests.Unit/TestData/GuidData.cs
@@ -5,6 +5,7 @@ public class GuidData : ComparableValue<Guid>
    public GuidData() : base(
       new Guid("44444444-4444-4444-4444-444444444444"),
       new Guid("88888888-8888-8888-8888-888888888888"),
+      Comparer<Guid>.Default,
       new ReverseComparer<Guid>(),
       new Guid("11111111-1111-1111-1111-111111111111"),
       new Guid("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"),

--- a/DbC.Net.Tests.Unit/TestData/GuidData.cs
+++ b/DbC.Net.Tests.Unit/TestData/GuidData.cs
@@ -7,6 +7,11 @@ public class GuidData : ComparableValue<Guid>
       new Guid("88888888-8888-8888-8888-888888888888"),
       new ReverseComparer<Guid>(),
       new Guid("11111111-1111-1111-1111-111111111111"),
+      new Guid("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"),
+      new Guid("33333333-3333-3333-3333-333333333333"),
+      new Guid("CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC"),
+      new Guid("11111111-1111-1111-1111-111111111111"),
+      new Guid("88888888-8888-8888-8888-888888888888"),
       new Guid("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"))
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/HalfData.cs
+++ b/DbC.Net.Tests.Unit/TestData/HalfData.cs
@@ -12,7 +12,12 @@ public class HalfData : FloatingPointValue<Half>
       StandardFloatingPointComparers.HalfRelativeErrorComparer,
       Half.MaxValue,
       Half.MinValue,
-      new ReverseComparer<Half>())
+      new ReverseComparer<Half>(),
+      Half.MinValue / (Half)2,
+      Half.MaxValue / (Half)2,
+      Half.MaxValue,
+      (Half)0,
+      Half.MinValue)
    { }
 }
 

--- a/DbC.Net.Tests.Unit/TestData/HalfData.cs
+++ b/DbC.Net.Tests.Unit/TestData/HalfData.cs
@@ -12,6 +12,7 @@ public class HalfData : FloatingPointValue<Half>
       StandardFloatingPointComparers.HalfRelativeErrorComparer,
       Half.MaxValue,
       Half.MinValue,
+      Comparer<Half>.Default,
       new ReverseComparer<Half>(),
       Half.MinValue / (Half)2,
       Half.MaxValue / (Half)2,

--- a/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
@@ -6,6 +6,8 @@ public interface IComparableTestData<T> where T : IComparable<T>
 
    T MinValue { get; }
 
+   IComparer<T> Comparer { get; }
+
    ReverseComparer<T> ReverseComparer { get; }
 
    T ReverseMaxValue { get; }
@@ -21,4 +23,12 @@ public interface IComparableTestData<T> where T : IComparable<T>
    T WithinBoundsValue { get; }
 
    T AboveUpperBoundValue { get; }
+
+   T ReverseLowerBound { get; }
+
+   T ReverseUpperBound { get; }
+
+   T ReverseBelowLowerBoundValue { get; }
+
+   T ReverseAboveUpperBoundValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/IComparableTestData.cs
@@ -11,4 +11,14 @@ public interface IComparableTestData<T> where T : IComparable<T>
    T ReverseMaxValue { get; }
 
    T ReverseMinValue { get; }
+
+   T LowerBound { get; }
+
+   T UpperBound { get; }
+
+   T BelowLowerBoundValue { get; }
+
+   T WithinBoundsValue { get; }
+
+   T AboveUpperBoundValue { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/IEquatableTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/IEquatableTestData.cs
@@ -8,5 +8,7 @@ public interface IEquatableTestData<T> where T : IEquatable<T>
 
    T NonDefaultNotEqualValue { get; }
 
+   IComparer<T> Comparer { get; }
+
    ReverseComparer<T> ReverseComparer { get; }
 }

--- a/DbC.Net.Tests.Unit/TestData/Int128Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int128Data.cs
@@ -5,6 +5,7 @@ public class Int128Data : ComparableValue<Int128>
    public Int128Data() : base(
       100,
       101,
+      Comparer<Int128>.Default,
       new ReverseComparer<Int128>(),
       Int128.MinValue,
       Int128.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/Int128Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int128Data.cs
@@ -7,6 +7,11 @@ public class Int128Data : ComparableValue<Int128>
       101,
       new ReverseComparer<Int128>(),
       Int128.MinValue,
+      Int128.MaxValue,
+      Int128.MinValue / 2,
+      Int128.MaxValue / 2,
+      Int128.MinValue,
+      0,
       Int128.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/Int16Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int16Data.cs
@@ -7,6 +7,11 @@ public class Int16Data : ComparableValue<Int16>
       -1,
       new ReverseComparer<Int16>(),
       Int16.MinValue,
+      Int16.MaxValue,
+      Int16.MinValue / 2,
+      Int16.MaxValue / 2,
+      Int16.MinValue,
+      0,
       Int16.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/Int16Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int16Data.cs
@@ -5,6 +5,7 @@ public class Int16Data : ComparableValue<Int16>
    public Int16Data() : base(
       1,
       -1,
+      Comparer<Int16>.Default,
       new ReverseComparer<Int16>(),
       Int16.MinValue,
       Int16.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/Int32Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int32Data.cs
@@ -5,6 +5,7 @@ public class Int32Data : ComparableValue<Int32>
    public Int32Data() : base(
       100,
       101,
+      Comparer<Int32>.Default,
       new ReverseComparer<Int32>(),
       Int32.MinValue,
       Int32.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/Int32Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int32Data.cs
@@ -7,6 +7,11 @@ public class Int32Data : ComparableValue<Int32>
       101,
       new ReverseComparer<Int32>(),
       Int32.MinValue,
+      Int32.MaxValue,
+      Int32.MinValue / 2,
+      Int32.MaxValue / 2,
+      Int32.MinValue,
+      0,
       Int32.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/Int64Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int64Data.cs
@@ -7,6 +7,11 @@ public class Int64Data : ComparableValue<Int64>
       101,
       new ReverseComparer<Int64>(),
       Int64.MinValue,
+      Int64.MaxValue,
+      Int64.MinValue / 2,
+      Int64.MaxValue / 2,
+      Int64.MinValue,
+      0,
       Int64.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/Int64Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/Int64Data.cs
@@ -5,6 +5,7 @@ public class Int64Data : ComparableValue<Int64>
    public Int64Data() : base(
       100,
       101,
+      Comparer<Int64>.Default,
       new ReverseComparer<Int64>(),
       Int64.MinValue,
       Int64.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/ObservationClassData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ObservationClassData.cs
@@ -17,6 +17,7 @@ public class ObservationClassData : ComparableValue<Observation>
          Value = 3.056,
          Units = Units.DegreesCelsius
       },
+      ObservationComparers.AllFieldsComparer,
       new ReverseComparer<Observation>(),
       new Observation
       {

--- a/DbC.Net.Tests.Unit/TestData/ObservationClassData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ObservationClassData.cs
@@ -33,6 +33,46 @@ public class ObservationClassData : ComparableValue<Observation>
          ObservationType = ObservationType.Mass,
          Value = 99.9,
          Units = Units.Kilogram
+      },
+      new Observation
+      {
+         ObservationId = new Guid("33333333-3333-3333-3333-333333333333"),
+         ObservationTimestamp = new DateTime(1980, 3, 3, 3, 3, 3, 3),
+         ObservationType = ObservationType.Concentration,
+         Value = 0.3,
+         Units = Units.GramsPerLiter
+      },
+      new Observation
+      {
+         ObservationId = new Guid("CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC"),
+         ObservationTimestamp = new DateTime(1990, 9, 9, 9, 9, 9, 9),
+         ObservationType = ObservationType.Concentration,
+         Value = 0.9,
+         Units = Units.KilogramsPerMeterCubed
+      },
+      new Observation
+      {
+         ObservationId = new Guid("11111111-1111-1111-1111-111111111111"),
+         ObservationTimestamp = new DateTime(1970, 1, 1, 1, 1, 1, 1),
+         ObservationType = ObservationType.Concentration,
+         Value = 0.1,
+         Units = Units.GramsPerLiter
+      },
+      new Observation
+      {
+         ObservationId = new Guid("88888888-8888-8888-8888-888888888888"),
+         ObservationTimestamp = new DateTime(1985, 8, 8, 8, 8, 8, 8),
+         ObservationType = ObservationType.Concentration,
+         Value = 0.6,
+         Units = Units.GramsPerLiter
+      },
+      new Observation
+      {
+         ObservationId = new Guid("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"),
+         ObservationTimestamp = new DateTime(2099, 12, 31, 23, 59, 59, 999),
+         ObservationType = ObservationType.Concentration,
+         Value = 99.9,
+         Units = Units.KilogramsPerMeterCubed
       })
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/PointStructData.cs
+++ b/DbC.Net.Tests.Unit/TestData/PointStructData.cs
@@ -7,6 +7,11 @@ public class PointStructData : ComparableValue<Point>
       new Point { X = -1, Y = -1 },
       new ReverseComparer<Point>(),
       new Point { X = 0, Y = 0 },
-      new Point { X = 10, Y = 10 })
+      new Point { X = 10, Y = 10 },
+      new Point { X = 3, Y = 3 },
+      new Point { X = 7, Y = 7 },
+      new Point { X = 0, Y = 0 },
+      new Point { X = 5, Y = 5 },
+      new Point { X = 9, Y = 9 })
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/PointStructData.cs
+++ b/DbC.Net.Tests.Unit/TestData/PointStructData.cs
@@ -5,6 +5,7 @@ public class PointStructData : ComparableValue<Point>
    public PointStructData() : base(
       new Point { X = 1, Y = 1 },
       new Point { X = -1, Y = -1 },
+      new PointDistanceFromOriginComparer(),
       new ReverseComparer<Point>(),
       new Point { X = 0, Y = 0 },
       new Point { X = 10, Y = 10 },

--- a/DbC.Net.Tests.Unit/TestData/SByteData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SByteData.cs
@@ -5,6 +5,7 @@ public class SByteData : ComparableValue<SByte>
    public SByteData() : base(
       1,
       (SByte)(-1),
+      Comparer<SByte>.Default,
       new ReverseComparer<SByte>(),
       SByte.MinValue,
       SByte.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/SByteData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SByteData.cs
@@ -7,6 +7,11 @@ public class SByteData : ComparableValue<SByte>
       (SByte)(-1),
       new ReverseComparer<SByte>(),
       SByte.MinValue,
+      SByte.MaxValue,
+      -64,
+      64,
+      SByte.MinValue,
+      0,
       SByte.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/SingleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SingleData.cs
@@ -12,6 +12,7 @@ public class SingleData : FloatingPointValue<Single>
       StandardFloatingPointComparers.SingleRelativeErrorComparer,
       Single.MaxValue,
       Single.MinValue,
+      Comparer<Single>.Default,
       new ReverseComparer<Single>(),
       Single.MinValue / 2,
       Single.MaxValue / 2,

--- a/DbC.Net.Tests.Unit/TestData/SingleData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SingleData.cs
@@ -12,6 +12,11 @@ public class SingleData : FloatingPointValue<Single>
       StandardFloatingPointComparers.SingleRelativeErrorComparer,
       Single.MaxValue,
       Single.MinValue,
-      new ReverseComparer<Single>())
+      new ReverseComparer<Single>(),
+      Single.MinValue / 2,
+      Single.MaxValue / 2,
+      Single.MaxValue,
+      0,
+      Single.MinValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/StringData.cs
+++ b/DbC.Net.Tests.Unit/TestData/StringData.cs
@@ -7,6 +7,11 @@ public class StringData : ComparableValue<String>
       "qwerty",
       new ReverseComparer<String>(),
       "AA",
+      "zz",
+      "BB",
+      "ww",
+      "AA",
+      "Mm",
       "zz")
    { }
 

--- a/DbC.Net.Tests.Unit/TestData/StringData.cs
+++ b/DbC.Net.Tests.Unit/TestData/StringData.cs
@@ -5,6 +5,7 @@ public class StringData : ComparableValue<String>
    public StringData() : base(
       "asdf",
       "qwerty",
+      StringComparer.OrdinalIgnoreCase,
       new ReverseComparer<String>(),
       "AA",
       "zz",

--- a/DbC.Net.Tests.Unit/TestData/StringData.cs
+++ b/DbC.Net.Tests.Unit/TestData/StringData.cs
@@ -16,6 +16,10 @@ public class StringData : ComparableValue<String>
       "zz")
    { }
 
+   public const String DiaeresisCombiningCharacter = "\u0308";
+   public const String OverringCombiningCharacter = "\u030A";
+   public const String SlashCombiningCharacter = "\u0338";
+
    public const String UpperCaseA = "A";
    public const String LowerCaseA = "a";
 
@@ -23,10 +27,16 @@ public class StringData : ComparableValue<String>
    public const String UpperCaseAWithDiaeresis = "\u00C4";
    public const String LowerCaseAWithDiaeresis = "\u00E4";
 
+   public const String UpperCaseAPlusDiaeresisCombiningCharacter = UpperCaseA + DiaeresisCombiningCharacter;
+   public const String LowerCaseAPlusDiaeresisCombiningCharacter = LowerCaseA + DiaeresisCombiningCharacter;
+
    // A with overring sorts as the last character, after O with slash, in da-DK culture (Danish/Denmark)
    // and between Z and A(diaeresis) in sv-SE culture (Swedish/Sweden)
    public const String UpperCaseAWithOverring = "\u00C5";
    public const String LowerCaseAWithOverring = "\u00E5";
+
+   public const String UpperCaseAPlusOverringCombiningCharacter = UpperCaseA + OverringCombiningCharacter;
+   public const String LowerCaseAPlusOverringCombiningCharacter = LowerCaseA + OverringCombiningCharacter;
 
    public const String UpperCaseAE = "AE";
    public const String LowerCaseAE = "ae";
@@ -50,6 +60,12 @@ public class StringData : ComparableValue<String>
    public const String UpperCaseJ = "J";
    public const String LowerCaseJ = "j";
 
+   public const String UpperCaseO = "O";
+   public const String LowerCaseO = "o";
+
+   public const String UpperCaseP = "P";
+   public const String LowerCaseP = "p";
+
    // Dot-less I sorts between H and dotted I in tr-TR culture (Turkish/Turkey)
    public const String UpperCaseDottedI = "\u0130";
    public const String LowerCaseDotlessI = "\u0131";
@@ -58,14 +74,25 @@ public class StringData : ComparableValue<String>
    public const String UpperCaseSlashedO = "\u00D8";
    public const String LowerCaseSlashedO = "\u00F8";
 
+   public const String UpperCaseOPlusSlashCombiningCharacter = UpperCaseO + SlashCombiningCharacter;
+   public const String LowerCaseOPlusSlashCombiningCharacter = LowerCaseO + SlashCombiningCharacter;
+
    // O with diaeresis (or umlaut) sorts after Z, A(overring), A(diaeresis) in sv-SE culture (Swedish/Sweden)
    // and between o and p in tr-TR culture (Turkish)
    public const String UpperCaseOWithDiaeresis = "\u00D6";
    public const String LowerCaseOWithDiaeresis = "\u00F6";
 
+   public const String UpperCaseOPlusDiaeresisCombiningCharacter = UpperCaseO + DiaeresisCombiningCharacter;
+   public const String LowerCaseOPlusDiaeresisCombiningCharacter = LowerCaseO + DiaeresisCombiningCharacter;
+
    public const String UpperCaseSs = "SS";
    public const String LowerCaseSs = "ss";
 
+   public const String UpperCaseX = "X";
+   public const String LowerCaseX = "x";
+
    public const String UpperCaseZ = "Z";
    public const String LowerCaseZ = "z";
+
+   public const String Caret = "^";
 }

--- a/DbC.Net.Tests.Unit/TestData/TimeOnlyData.cs
+++ b/DbC.Net.Tests.Unit/TestData/TimeOnlyData.cs
@@ -7,6 +7,11 @@ public class TimeOnlyData : ComparableValue<TimeOnly>
       new(20, 1, 1),
       new ReverseComparer<TimeOnly>(),
       TimeOnly.MinValue,
+      TimeOnly.MaxValue,
+      new(4, 0, 0),
+      new(20, 0, 0),
+      TimeOnly.MinValue,
+      new(12, 0, 0),
       TimeOnly.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/TimeOnlyData.cs
+++ b/DbC.Net.Tests.Unit/TestData/TimeOnlyData.cs
@@ -5,6 +5,7 @@ public class TimeOnlyData : ComparableValue<TimeOnly>
    public TimeOnlyData() : base(
       new(12, 1, 1),
       new(20, 1, 1),
+      Comparer<TimeOnly>.Default,
       new ReverseComparer<TimeOnly>(),
       TimeOnly.MinValue,
       TimeOnly.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/TimeSpanData.cs
+++ b/DbC.Net.Tests.Unit/TestData/TimeSpanData.cs
@@ -1,0 +1,18 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public class TimeSpanData : ComparableValue<TimeSpan>
+{
+   public TimeSpanData() : base(
+      new(4096),
+      new(2048),
+      Comparer<TimeSpan>.Default,
+      new ReverseComparer<TimeSpan>(),
+      TimeSpan.MinValue,
+      TimeSpan.MaxValue,
+      new(2048),
+      new(4096),
+      TimeSpan.MinValue,
+      new(3064),
+      TimeSpan.MaxValue)
+   { }
+}

--- a/DbC.Net.Tests.Unit/TestData/UInt128Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt128Data.cs
@@ -5,6 +5,7 @@ public class UInt128Data : ComparableValue<UInt128>
    public UInt128Data() : base(
       100,
       101,
+      Comparer<UInt128>.Default,
       new ReverseComparer<UInt128>(),
       UInt128.MinValue,
       UInt128.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/UInt128Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt128Data.cs
@@ -7,6 +7,11 @@ public class UInt128Data : ComparableValue<UInt128>
       101,
       new ReverseComparer<UInt128>(),
       UInt128.MinValue,
+      UInt128.MaxValue,
+      UInt128.MaxValue / 4,
+      UInt128.MaxValue / 4 * 3,
+      UInt128.MinValue,
+      UInt128.MaxValue / 2,
       UInt128.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/UInt16Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt16Data.cs
@@ -7,6 +7,11 @@ public class UInt16Data : ComparableValue<UInt16>
       101,
       new ReverseComparer<UInt16>(),
       UInt16.MinValue,
+      UInt16.MaxValue,
+      UInt16.MaxValue / 4,
+      UInt16.MaxValue / 4 * 3,
+      UInt16.MinValue,
+      UInt16.MaxValue / 2,
       UInt16.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/UInt16Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt16Data.cs
@@ -5,6 +5,7 @@ public class UInt16Data : ComparableValue<UInt16>
    public UInt16Data() : base(
       100,
       101,
+      Comparer<UInt16>.Default,
       new ReverseComparer<UInt16>(),
       UInt16.MinValue,
       UInt16.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/UInt32Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt32Data.cs
@@ -5,6 +5,7 @@ public class UInt32Data : ComparableValue<UInt32>
    public UInt32Data() : base(
       100,
       101,
+      Comparer<UInt32>.Default,
       new ReverseComparer<UInt32>(),
       UInt32.MinValue,
       UInt32.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/UInt32Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt32Data.cs
@@ -7,6 +7,11 @@ public class UInt32Data : ComparableValue<UInt32>
       101,
       new ReverseComparer<UInt32>(),
       UInt32.MinValue,
+      UInt32.MaxValue,
+      UInt32.MaxValue / 4,
+      UInt32.MaxValue / 4 * 3,
+      UInt32.MinValue,
+      UInt32.MaxValue / 2,
       UInt32.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/UInt64Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt64Data.cs
@@ -7,6 +7,11 @@ public class UInt64Data : ComparableValue<UInt64>
       101,
       new ReverseComparer<UInt64>(),
       UInt64.MinValue,
+      UInt64.MaxValue,
+      UInt64.MaxValue / 4,
+      UInt64.MaxValue / 4 * 3,
+      UInt64.MinValue,
+      UInt64.MaxValue / 2,
       UInt64.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/UInt64Data.cs
+++ b/DbC.Net.Tests.Unit/TestData/UInt64Data.cs
@@ -5,6 +5,7 @@ public class UInt64Data : ComparableValue<UInt64>
    public UInt64Data() : base(
       100,
       101,
+      Comparer<UInt64>.Default,
       new ReverseComparer<UInt64>(),
       UInt64.MinValue,
       UInt64.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/ValueTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/ValueTypesTestData.cs
@@ -18,6 +18,7 @@ public class ValueTypesTestData : IEnumerable<Object[]>
       yield return new Object[] { new Int64Data() };
       yield return new Object[] { new SByteData() };
       yield return new Object[] { new TimeOnlyData() };
+      yield return new Object[] { new TimeSpanData() };
       yield return new Object[] { new UInt128Data() };
       yield return new Object[] { new UInt16Data() };
       yield return new Object[] { new UInt32Data() };

--- a/DbC.Net.Tests.Unit/TestData/nintData.cs
+++ b/DbC.Net.Tests.Unit/TestData/nintData.cs
@@ -7,6 +7,7 @@ public class nintData : ComparableValue<nint>
    public nintData() : base(
       100,
       101,
+      Comparer<nint>.Default,
       new ReverseComparer<nint>(),
       nint.MinValue,
       nint.MaxValue,

--- a/DbC.Net.Tests.Unit/TestData/nintData.cs
+++ b/DbC.Net.Tests.Unit/TestData/nintData.cs
@@ -9,6 +9,11 @@ public class nintData : ComparableValue<nint>
       101,
       new ReverseComparer<nint>(),
       nint.MinValue,
+      nint.MaxValue,
+      nint.MinValue / 2,
+      nint.MaxValue / 2,
+      nint.MinValue,
+      0,
       nint.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/nuintData.cs
+++ b/DbC.Net.Tests.Unit/TestData/nuintData.cs
@@ -9,6 +9,11 @@ public class nuintData : ComparableValue<nuint>
       101,
       new ReverseComparer<nuint>(),
       nuint.MinValue,
+      nuint.MaxValue,
+      nuint.MaxValue / 4,
+      nuint.MaxValue / 4 * 3,
+      nuint.MinValue,
+      nuint.MaxValue / 2,
       nuint.MaxValue)
    { }
 }

--- a/DbC.Net.Tests.Unit/TestData/nuintData.cs
+++ b/DbC.Net.Tests.Unit/TestData/nuintData.cs
@@ -7,6 +7,7 @@ public class nuintData : ComparableValue<nuint>
    public nuintData() : base(
       100,
       101,
+      Comparer<nuint>.Default,
       new ReverseComparer<nuint>(),
       nuint.MinValue,
       nuint.MaxValue,

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -24,6 +24,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{72254BA1-52A7-4B81-A595-76580B77647E}"
 	ProjectSection(SolutionItems) = preProject
 		Documentation\ApproximatelyEqual.md = Documentation\ApproximatelyEqual.md
+		Documentation\Between.md = Documentation\Between.md
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\GreaterThan.md = Documentation\GreaterThan.md
 		Documentation\GreaterThanOrEqual.md = Documentation\GreaterThanOrEqual.md

--- a/DbC.Net/ApproximatelyEqualExtensions.cs
+++ b/DbC.Net/ApproximatelyEqualExtensions.cs
@@ -172,9 +172,7 @@ public static class ApproximatelyEqualExtensions
       if (!comparer.ApproximatelyEquals(value, target, epsilon))
       {
          messageTemplate ??= MessageTemplates.ApproximatelyEqualTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)

--- a/DbC.Net/BetweenExtensions.cs
+++ b/DbC.Net/BetweenExtensions.cs
@@ -1,0 +1,185 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement Between requirement for types that
+///   implement <see cref="IComparable{T}"/> or that use 
+///   <see cref="IComparer{T}"/>.
+/// </summary>
+public static class BetweenExtensions
+{
+   private const String _requirementName = RequirementNames.Between;
+
+   /// <summary>
+   ///   Value Between postcondition. Confirm that <paramref name="value"/>
+   ///   is greater than or equal to <paramref name="lowerBound"/> and less than 
+   ///   or equal to <paramref name="upperBound"/> and throw an exception if
+   ///   it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="lowerBound">
+   ///   The lower bound that <paramref name="value"/> should be fall below.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="lowerBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="lowerBound"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="InvalidOperationException">
+   ///   Lower bound is greater than upper bound.
+   /// </exception>
+   public static T EnsuresBetween<T>(
+      this T value,
+      T lowerBound,
+      T upperBound,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(lowerBound))] String lowerBoundExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!) where T : IComparable<T>
+   {
+      CheckNormalizedBounds(lowerBound, upperBound);
+      CheckBetween(
+         value,
+         lowerBound,
+         upperBound,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         lowerBoundExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value Between precondition. Confirm that <paramref name="value"/>
+   ///   is greater than or equal to <paramref name="lowerBound"/> and less than 
+   ///   or equal to <paramref name="upperBound"/> and throw an exception if
+   ///   it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="lowerBound">
+   ///   The lower bound that <paramref name="value"/> should be fall below.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="lowerBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="lowerBound"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="InvalidOperationException">
+   ///   Lower bound is greater than upper bound.
+   /// </exception>
+   public static T RequiresBetween<T>(
+      this T value,
+      T lowerBound,
+      T upperBound,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(lowerBound))] String lowerBoundExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!) where T : IComparable<T>
+   {
+      CheckNormalizedBounds(lowerBound, upperBound);
+      CheckBetween(
+         value,
+         lowerBound,
+         upperBound,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         lowerBoundExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   private static void CheckBetween<T>(
+      T value,
+      T lowerBound,
+      T upperBound,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String lowerBoundExpression,
+      String upperBoundExpression) where T : IComparable<T>
+   {
+      if ((value is null && lowerBound is not null)
+         ||(value is not null && (value!.CompareTo(lowerBound) < 0 || value.CompareTo(upperBound) > 0))) 
+      {
+         messageTemplate ??= MessageTemplates.BetweenTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithLowerBound(lowerBound!, lowerBoundExpression)
+            .WithUpperBound(upperBound!, upperBoundExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
+   private static void CheckNormalizedBounds<T>(T lowerBound, T upperBound) where T : IComparable<T>
+   {
+      // Lower bound must be less than or equal to upper bound.
+      if (lowerBound is not null && lowerBound.CompareTo(upperBound) > 0)
+      {
+         throw new InvalidOperationException(Messages.BetweenBoundsNotNormalized);
+      }
+   }
+}

--- a/DbC.Net/BetweenExtensions.cs
+++ b/DbC.Net/BetweenExtensions.cs
@@ -160,6 +160,82 @@ public static class BetweenExtensions
    }
 
    /// <summary>
+   ///   Value Between postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is greater than or equal to 
+   ///   <paramref name="lowerBound"/> and less than or equal to 
+   ///   <paramref name="upperBound"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="lowerBound">
+   ///   The lower bound that <paramref name="value"/> should be fall below.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and the <paramref name="lowerBound"/> and
+   ///   <paramref name="upperBound"/> strings are compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="lowerBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="lowerBound"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="InvalidOperationException">
+   ///   Lower bound is greater than upper bound.
+   /// </exception>
+   public static String EnsuresBetween(
+      this String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(lowerBound))] String lowerBoundExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!)
+   {
+      CheckNormalizedBounds(lowerBound, upperBound, comparisonType);
+      CheckBetween(
+         value,
+         lowerBound,
+         upperBound,
+         comparisonType,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         lowerBoundExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   Value Between precondition. Confirm that <paramref name="value"/>
    ///   is greater than or equal to <paramref name="lowerBound"/> and less than 
    ///   or equal to <paramref name="upperBound"/> and throw an exception if
@@ -309,6 +385,82 @@ public static class BetweenExtensions
       return value;
    }
 
+   /// <summary>
+   ///   Value Between precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is greater than or equal to 
+   ///   <paramref name="lowerBound"/> and less than or equal to 
+   ///   <paramref name="upperBound"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="lowerBound">
+   ///   The lower bound that <paramref name="value"/> should be fall below.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and the <paramref name="lowerBound"/> and
+   ///   <paramref name="upperBound"/> strings are compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="lowerBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="lowerBound"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="InvalidOperationException">
+   ///   Lower bound is greater than upper bound.
+   /// </exception>
+   public static String RequiresBetween(
+      this String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(lowerBound))] String lowerBoundExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!)
+   {
+      CheckNormalizedBounds(lowerBound, upperBound, comparisonType);
+      CheckBetween(
+         value,
+         lowerBound,
+         upperBound,
+         comparisonType,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         lowerBoundExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
    private static void CheckBetween<T>(
       T value,
       T lowerBound,
@@ -363,6 +515,35 @@ public static class BetweenExtensions
       }
    }
 
+   private static void CheckBetween(
+      String value,
+      String lowerBound,
+      String upperBound,
+      StringComparison comparisonType,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String lowerBoundExpression,
+      String upperBoundExpression)
+   {
+      if (String.Compare(value, lowerBound, comparisonType) < 0 
+         || String.Compare(value, upperBound, comparisonType) > 0)
+      {
+         messageTemplate ??= MessageTemplates.BetweenTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithLowerBound(lowerBound, lowerBoundExpression)
+            .WithUpperBound(upperBound!, upperBoundExpression)
+            .WithItem(DataNames.StringComparison, comparisonType)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
    private static void CheckNormalizedBounds<T>(T lowerBound, T upperBound) where T : IComparable<T>
    {
       // Lower bound must be less than or equal to upper bound.
@@ -376,6 +557,15 @@ public static class BetweenExtensions
    {
       // Lower bound must be less than or equal to upper bound.
       if (comparer.Compare(lowerBound, upperBound) > 0)
+      {
+         throw new InvalidOperationException(Messages.BetweenBoundsNotNormalized);
+      }
+   }
+
+   private static void CheckNormalizedBounds(String lowerBound, String upperBound, StringComparison comparisonType)
+   {
+      // Lower bound must be less than or equal to upper bound.
+      if (String.Compare(lowerBound, upperBound, comparisonType) > 0)
       {
          throw new InvalidOperationException(Messages.BetweenBoundsNotNormalized);
       }

--- a/DbC.Net/BetweenExtensions.cs
+++ b/DbC.Net/BetweenExtensions.cs
@@ -79,6 +79,87 @@ public static class BetweenExtensions
    }
 
    /// <summary>
+   ///   Value Between postcondition. Confirm that <paramref name="value"/>
+   ///   is greater than or equal to <paramref name="lowerBound"/> and less than 
+   ///   or equal to <paramref name="upperBound"/> and throw an exception if
+   ///   it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="lowerBound">
+   ///   The lower bound that <paramref name="value"/> should be fall below.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IComparer{T}"/> used to compare <paramref name="value"/> 
+   ///   and <paramref name="lowerBound"/> and <paramref name="upperBound"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="lowerBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="lowerBound"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="InvalidOperationException">
+   ///   Lower bound is greater than upper bound.
+   /// </exception>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T EnsuresBetween<T>(
+      this T value,
+      T lowerBound,
+      T upperBound,
+      IComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(lowerBound))] String lowerBoundExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!)
+   {
+      CheckNormalizedBounds(
+         lowerBound,
+         upperBound,
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull));
+      CheckBetween(
+         value,
+         lowerBound,
+         upperBound,
+         comparer,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         lowerBoundExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   Value Between precondition. Confirm that <paramref name="value"/>
    ///   is greater than or equal to <paramref name="lowerBound"/> and less than 
    ///   or equal to <paramref name="upperBound"/> and throw an exception if
@@ -147,6 +228,87 @@ public static class BetweenExtensions
       return value;
    }
 
+   /// <summary>
+   ///   Value Between precondition. Confirm that <paramref name="value"/>
+   ///   is greater than or equal to <paramref name="lowerBound"/> and less than 
+   ///   or equal to <paramref name="upperBound"/> and throw an exception if
+   ///   it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="lowerBound">
+   ///   The lower bound that <paramref name="value"/> should be fall below.
+   /// </param>
+   /// <param name="upperBound">
+   ///   The upper bound that <paramref name="value"/> should not exceed.
+   /// </param>
+   /// <param name="comparer">
+   ///   An <see cref="IComparer{T}"/> used to compare <paramref name="value"/> 
+   ///   and <paramref name="lowerBound"/> and <paramref name="upperBound"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="lowerBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="lowerBound"/>. 
+   /// </param>
+   /// <param name="upperBoundExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="upperBound"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="InvalidOperationException">
+   ///   Lower bound is greater than upper bound.
+   /// </exception>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="comparer"/> is <see langword="null"/>.
+   /// </exception>
+   public static T RequiresBetween<T>(
+      this T value,
+      T lowerBound,
+      T upperBound,
+      IComparer<T> comparer,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(lowerBound))] String lowerBoundExpression = null!,
+      [CallerArgumentExpression(nameof(upperBound))] String upperBoundExpression = null!)
+   {
+      CheckNormalizedBounds(
+         lowerBound, 
+         upperBound, 
+         comparer ?? throw new ArgumentNullException(nameof(comparer), Messages.ComparerIsNull));
+      CheckBetween(
+         value,
+         lowerBound,
+         upperBound,
+         comparer,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         lowerBoundExpression,
+         upperBoundExpression);
+
+      return value;
+   }
+
    private static void CheckBetween<T>(
       T value,
       T lowerBound,
@@ -174,10 +336,46 @@ public static class BetweenExtensions
       }
    }
 
+   private static void CheckBetween<T>(
+      T value,
+      T lowerBound,
+      T upperBound,
+      IComparer<T> comparer,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String lowerBoundExpression,
+      String upperBoundExpression)
+   {
+      if (comparer.Compare(value, lowerBound) < 0 || comparer.Compare(value, upperBound) > 0)
+      {
+         messageTemplate ??= MessageTemplates.BetweenTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithLowerBound(lowerBound!, lowerBoundExpression)
+            .WithUpperBound(upperBound!, upperBoundExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+
    private static void CheckNormalizedBounds<T>(T lowerBound, T upperBound) where T : IComparable<T>
    {
       // Lower bound must be less than or equal to upper bound.
       if (lowerBound is not null && lowerBound.CompareTo(upperBound) > 0)
+      {
+         throw new InvalidOperationException(Messages.BetweenBoundsNotNormalized);
+      }
+   }
+
+   private static void CheckNormalizedBounds<T>(T lowerBound, T upperBound, IComparer<T> comparer)
+   {
+      // Lower bound must be less than or equal to upper bound.
+      if (comparer.Compare(lowerBound, upperBound) > 0)
       {
          throw new InvalidOperationException(Messages.BetweenBoundsNotNormalized);
       }

--- a/DbC.Net/EqualExtensions.cs
+++ b/DbC.Net/EqualExtensions.cs
@@ -27,7 +27,7 @@ public static class EqualExtensions
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
    ///   exception that is thrown if the <paramref name="value"/> is 
    ///   <see langword="null"/>. Defaults to 
-   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
    ///   Optional. Defaults to the caller expression for
@@ -368,7 +368,7 @@ public static class EqualExtensions
             || (value is null && target is null)))
       {
          messageTemplate ??= MessageTemplates.EqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -392,7 +392,7 @@ public static class EqualExtensions
       if (!comparer.Equals(value, target))
       {
          messageTemplate ??= MessageTemplates.EqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -417,7 +417,7 @@ public static class EqualExtensions
             || (value is null && target is null)))
       {
          messageTemplate ??= MessageTemplates.EqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -428,9 +428,4 @@ public static class EqualExtensions
          throw exceptionFactory.CreateException(data, messageTemplate);
       }
    }
-
-   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
-      => requirementType == RequirementType.Precondition
-         ? StandardExceptionFactories.ArgumentExceptionFactory
-         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/Exceptions/StandardExceptionFactories.cs
+++ b/DbC.Net/Exceptions/StandardExceptionFactories.cs
@@ -132,6 +132,28 @@ public class StandardExceptionFactories
 
    /// <summary>
    ///   Internal helper method for obtaining either
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>
+   ///   or <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>,
+   ///   depending on the <paramref name="requirementType"/>.
+   /// </summary>
+   internal static IExceptionFactory ResolveArgumentExceptionFactory(RequirementType requirementType)
+      => requirementType == RequirementType.Precondition
+         ? ArgumentExceptionFactory
+         : PostconditionFailedExceptionFactory;
+
+   /// <summary>
+   ///   Internal helper method for obtaining either
+   ///   <see cref="StandardExceptionFactories.ArgumentNullExceptionFactory"/>
+   ///   or <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>,
+   ///   depending on the <paramref name="requirementType"/>.
+   /// </summary>
+   internal static IExceptionFactory ResolveArgumentNullExceptionFactory(RequirementType requirementType)
+      => requirementType == RequirementType.Precondition
+         ? ArgumentNullExceptionFactory
+         : PostconditionFailedExceptionFactory;
+
+   /// <summary>
+   ///   Internal helper method for obtaining either
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>
    ///   or <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>,
    ///   depending on the <paramref name="requirementType"/>.

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -371,7 +371,7 @@ public static class GreaterThanExtensions
       if (value is null || value!.CompareTo(lowerBound) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -395,7 +395,7 @@ public static class GreaterThanExtensions
       if (comparer.Compare(value, lowerBound) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -419,7 +419,7 @@ public static class GreaterThanExtensions
       if (String.Compare(value, lowerBound, comparisonType) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -430,9 +430,4 @@ public static class GreaterThanExtensions
          throw exceptionFactory.CreateException(data, messageTemplate);
       }
    }
-
-   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
-      => requirementType == RequirementType.Precondition
-         ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
-         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/GreaterThanOrEqualExtensions.cs
+++ b/DbC.Net/GreaterThanOrEqualExtensions.cs
@@ -380,7 +380,7 @@ public static class GreaterThanOrEqualToExtensions
          || (value is not null && value.CompareTo(lowerBound) < 0))
       {
          messageTemplate ??= MessageTemplates.GreaterThanOrEqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -404,7 +404,7 @@ public static class GreaterThanOrEqualToExtensions
       if (comparer.Compare(value, lowerBound) < 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanOrEqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -428,7 +428,7 @@ public static class GreaterThanOrEqualToExtensions
       if (String.Compare(value, lowerBound, comparisonType) < 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanOrEqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -439,9 +439,4 @@ public static class GreaterThanOrEqualToExtensions
          throw exceptionFactory.CreateException(data, messageTemplate);
       }
    }
-
-   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
-      => requirementType == RequirementType.Precondition
-         ? StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
-         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/LessThanExtensions.cs
+++ b/DbC.Net/LessThanExtensions.cs
@@ -374,8 +374,7 @@ public static class LessThanExtensions
       String valueExpression,
       String upperBoundExpression) where T : IComparable<T>
    {
-      if ((value is null && upperBound is null)
-         || (value is not null && value.CompareTo(upperBound) >= 0))
+      if (upperBound is null || (value is not null && value.CompareTo(upperBound) >= 0))
       {
          messageTemplate ??= MessageTemplates.LessThanTemplate;
          exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);

--- a/DbC.Net/LessThanOrEqualExtensions.cs
+++ b/DbC.Net/LessThanOrEqualExtensions.cs
@@ -370,8 +370,7 @@ public static class LessThanOrEqualExtensions
       String valueExpression,
       String upperBoundExpression) where T : IComparable<T>
    {
-      if ((value is null && upperBound is not null)
-         || (value is not null && value.CompareTo(upperBound) > 0))
+      if (value is not null && value.CompareTo(upperBound) > 0)
       {
          messageTemplate ??= MessageTemplates.LessThanOrEqualTemplate;
          exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -70,6 +70,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive).
+        /// </summary>
+        internal static string BetweenTemplate {
+            get {
+                return ResourceManager.GetString("BetweenTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}.
         /// </summary>
         internal static string EqualTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -120,6 +120,9 @@
   <data name="ApproximatelyEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}</value>
   </data>
+  <data name="BetweenTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)</value>
+  </data>
   <data name="EqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}</value>
   </data>

--- a/DbC.Net/Messages.Designer.cs
+++ b/DbC.Net/Messages.Designer.cs
@@ -70,6 +70,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lower bound may not be greater than upper bound.
+        /// </summary>
+        internal static string BetweenBoundsNotNormalized {
+            get {
+                return ResourceManager.GetString("BetweenBoundsNotNormalized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comparer may not be null.
         /// </summary>
         internal static string ComparerIsNull {

--- a/DbC.Net/Messages.resx
+++ b/DbC.Net/Messages.resx
@@ -120,6 +120,9 @@
   <data name="BaseTransformIsNull" xml:space="preserve">
     <value>Decorator base transform may not be null</value>
   </data>
+  <data name="BetweenBoundsNotNormalized" xml:space="preserve">
+    <value>Lower bound may not be greater than upper bound</value>
+  </data>
   <data name="ComparerIsNull" xml:space="preserve">
     <value>Comparer may not be null</value>
   </data>

--- a/DbC.Net/NotDefaultExtensions.cs
+++ b/DbC.Net/NotDefaultExtensions.cs
@@ -23,7 +23,7 @@ public static class NotDefaultExtensions
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
    ///   exception that is thrown if the <paramref name="value"/> is 
    ///   <see langword="null"/>. Defaults to 
-   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
    ///   Optional. Defaults to the caller expression for
@@ -101,9 +101,7 @@ public static class NotDefaultExtensions
       if (EqualityComparer<T>.Default.Equals(value, default))
       {
          messageTemplate ??= MessageTemplates.NotDefaultTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithItem(DataNames.ValueExpression, valueExpression)

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -27,7 +27,7 @@ public static class NotEqualExtensions
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
    ///   exception that is thrown if the <paramref name="value"/> is 
    ///   <see langword="null"/>. Defaults to 
-   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
    ///   Optional. Defaults to the caller expression for
@@ -367,7 +367,7 @@ public static class NotEqualExtensions
       if ((value is null && target is null) || (value is not null && value.Equals(target)))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -391,7 +391,7 @@ public static class NotEqualExtensions
       if (comparer.Equals(value, target))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -415,7 +415,7 @@ public static class NotEqualExtensions
       if ((value is null && target is null) || (value is not null && value.Equals(target, comparisonType)))
       {
          messageTemplate ??= MessageTemplates.NotEqualTemplate;
-         exceptionFactory ??= GetExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)
@@ -426,9 +426,4 @@ public static class NotEqualExtensions
          throw exceptionFactory.CreateException(data, messageTemplate);
       }
    }
-
-   private static IExceptionFactory GetExceptionFactory(RequirementType requirementType)
-      => requirementType == RequirementType.Precondition
-         ? StandardExceptionFactories.ArgumentExceptionFactory
-         : StandardExceptionFactories.PostconditionFailedExceptionFactory;
 }

--- a/DbC.Net/NotNullExtensions.cs
+++ b/DbC.Net/NotNullExtensions.cs
@@ -101,9 +101,7 @@ public static class NotNullExtensions
       if (value is null)
       {
          messageTemplate ??= MessageTemplates.NotNullTemplate;
-         exceptionFactory ??= requirementType == RequirementType.Precondition
-            ? StandardExceptionFactories.ArgumentNullExceptionFactory
-            : StandardExceptionFactories.PostconditionFailedExceptionFactory;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentNullExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithItem(DataNames.ValueExpression, valueExpression)

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -6,6 +6,7 @@
 public static class RequirementNames
 {
    public const String ApproximatelyEqual = nameof(ApproximatelyEqual);
+   public const String Between = nameof(Between);
    public const String Equal = nameof(Equal);
    public const String GreaterThan = nameof(GreaterThan);
    public const String GreaterThanOrEqual = nameof(GreaterThanOrEqual);

--- a/Documentation/ApproximatelyEqual.md
+++ b/Documentation/ApproximatelyEqual.md
@@ -21,7 +21,7 @@ object to the Requires/EnsuresApproximatelyEqual methods.
 **Fixed Error and Relative Error**
 
 A common approach for checking approximate equality is to check 
-ABS(value - target) < epsilon. This is known as an fixed error. The issue
+ABS(value - target) < epsilon. This is known as a fixed error. The issue
 with using an fixed error is that it can produce incorrect results for very
 large or very small values. For example, an epsilon of 0.0001 may seem like a 
 good choice, but when the target is 1,000,000,000 (1 billion), a value of 
@@ -79,29 +79,29 @@ var epsilon = 0.0001;
 var comparer = StandardFloatingPointComparers.DoubleRelativeErrorComparer;
 
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 value.RequiresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 value.RequiresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 value.EnsuresApproximatelyEqual(target, epsilon, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 value.EnsuresApproximatelyEqual(target, epsilon, comparer, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/Between.md
+++ b/Documentation/Between.md
@@ -17,17 +17,17 @@ ArgumentNullException if the comparer parameter is null.
 
 **Method signatures:**
 ```C#
-T RequiresBetween<T>(this T value, T lowerBound, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T RequiresBetween<T>(this T value, T lowerBound, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null], [String? upperBoundExpression = null]) where T : IComparable<T>
 
-T RequiresBetween<T>(this T value, T lowerBound, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T RequiresBetween<T>(this T value, T lowerBound, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null], [String? upperBoundExpression = null])
 
-String RequiresBetween(this String value, String lowerBound, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresBetween(this String value, String lowerBound, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null], [String? upperBoundExpression = null])
 
-T EnsuresBetween<T>(this T value, T lowerBound, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T EnsuresBetween<T>(this T value, T lowerBound, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null], [String? upperBoundExpression = null]) where T : IComparable<T>
 
-T EnsuresBetween<T>(this T value, T lowerBound, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T EnsuresBetween<T>(this T value, T lowerBound, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null], [String? upperBoundExpression = null])
 
-String EnsuresBetween(this String value, String lowerBound, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresBetween(this String value, String lowerBound, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null], [String? upperBoundExpression = null])
 ```
 
 The default message template for Between is "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".

--- a/Documentation/Between.md
+++ b/Documentation/Between.md
@@ -40,3 +40,105 @@ RequirementName, Value, ValueExpression, LowerBound, LowerBoundExpression, Upper
 and UpperBoundExpression. The data dictionary for the String overloads will 
 contain an additional entry for StringComparison.
 
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be greater than (or equal to) {LowerBound} and less than (or equal to) {UpperBound}";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var number = 42;
+var intLowerBound = 0;
+var intUpperBound = 100;
+
+// Precondition with default message template and default exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound);
+
+// Precondition with custom message template and default exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound);
+
+// Postcondition with custom message template and default exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+number.RequiresBetween(intLowerBound, intUpperBound, customMessageTemplate, customExceptionFactory);
+
+
+var point = new Point { X = 1, Y = 12 };
+var pointLowerBound = new Point { X = 0, Y = 0 };
+var pointUpperBound = new Point { X = 10, Y = 10 };
+var comparer = new PointDistanceFromOriginComparer();
+
+// Precondition with default message template and default exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer);
+
+// Precondition with custom message template and default exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer);
+
+// Postcondition with custom message template and default exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+point.RequiresBetween(pointLowerBound, pointUpperBound, comparer, customMessageTemplate, customExceptionFactory);
+
+
+var str = "ELEPHANT";
+var strLowerBound = "Aardvark";
+var strUpperBound = "Zebra";
+var comparisonType = StringComparison.OrdinalIgnoreCase;
+
+// Precondition with default message template and default exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType);
+
+// Precondition with custom message template and default exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType);
+
+// Postcondition with custom message template and default exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+str.RequiresBetween(strLowerBound, strUpperBound, comparisonType, customMessageTemplate, customExceptionFactory);
+```
+
+Implementation details for the Point examples:
+
+[Point struct](/DbC.Net.TestAndExampleResources/Point.cs)
+
+[PointDistanceFromOriginComparer](/DbC.Net.TestAndExampleResources/PointDistanceFromOriginComparer.cs)

--- a/Documentation/Between.md
+++ b/Documentation/Between.md
@@ -1,0 +1,42 @@
+### Between
+
+Between requires that the value being checked be greater than or
+equal to a lower bound and less than or equal to an upper bound. RequiresBetween 
+and EnsuresBetween have several overloads that support IComparable<T> and IComparer<T> 
+as well as an overload for String that accepts a StringComparison value that 
+specifies how the comparison is performed.
+
+Note that the allowed values are inclusive of the lower an upper bounds (similar
+to a SQL BETWEEN clause).
+
+All RequiresBetween and EnsuresBetween overloads will throw an InvalidOperationException 
+if the supplied lower bound is greater than the upper bound.
+
+The IComparer<T> overload of RequiresBetween and EnsuresBetween will throw an
+ArgumentNullException if the comparer parameter is null.
+
+**Method signatures:**
+```C#
+T RequiresBetween<T>(this T value, T lowerBound, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+
+T RequiresBetween<T>(this T value, T lowerBound, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String RequiresBetween(this String value, String lowerBound, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+T EnsuresBetween<T>(this T value, T lowerBound, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+
+T EnsuresBetween<T>(this T value, T lowerBound, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String EnsuresBetween(this String value, String lowerBound, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+```
+
+The default message template for Between is "{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)".
+The default exception factory for RequiresBetween is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresBetween.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, LowerBound, LowerBoundExpression, UpperBound
+and UpperBoundExpression. The data dictionary for the String overloads will 
+contain an additional entry for StringComparison.
+

--- a/Documentation/Equal.md
+++ b/Documentation/Equal.md
@@ -38,29 +38,29 @@ var customExceptionFactory = new CustomExceptionFactory();
 var totalCount = 99;
 var targetCount = 100;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 totalCount.RequiresEqual(targetCount);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 totalCount.RequiresEqual(targetCount, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 totalCount.RequiresEqual(targetCount, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 totalCount.RequiresEqual(targetCount, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 totalCount.EnsuresEqual(targetCount);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 totalCount.EnsuresEqual(targetCount, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 totalCount.EnsuresEqual(targetCount, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 totalCount.EnsuresEqual(targetCount, customMessageTemplate, customExceptionFactory);
 
 
@@ -68,29 +68,29 @@ var box = new Box(1, 2, 3, "Red");
 var targetBox = new Box(2, 2, 2, "Blue");
 var comparer = new BoxVolumeComparer();
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 box.RequiresEqual(targetBox, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 box.RequiresEqual(targetBox, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 box.RequiresEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 box.RequiresEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 box.EnsuresEqual(targetBox, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 box.EnsuresEqual(targetBox, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 box.EnsuresEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 box.EnsuresEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -98,29 +98,29 @@ var str = "asdf";
 var targetStr = "QWERTY";
 var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 str.RequiresEqual(targetStr, comparisonType);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 str.RequiresEqual(targetStr, comparisonType, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 str.RequiresEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 str.RequiresEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 str.EnsuresEqual(targetStr, comparisonType);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 str.EnsuresEqual(targetStr, comparisonType, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 str.EnsuresEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 str.EnsuresEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/GreaterThan.md
+++ b/Documentation/GreaterThan.md
@@ -38,29 +38,29 @@ var customExceptionFactory = new CustomExceptionFactory();
 var changeDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
 var lowerBoundDate = new DateTime(2023, 1, 1);
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 changeDate.RequiresGreaterThan(lowerBoundDate);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 changeDate.RequiresGreaterThan(lowerBoundDate, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 changeDate.RequiresGreaterThan(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 changeDate.RequiresGreaterThan(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 changeDate.EnsuresGreaterThan(lowerBoundDate);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 changeDate.EnsuresGreaterThan(lowerBoundDate, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 changeDate.EnsuresGreaterThan(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 changeDate.EnsuresGreaterThan(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -68,29 +68,29 @@ var point = new Point { X = 10, Y = 10 };
 var lowerBoundPoint = new Point { X = 1, Y = 12 };
 var comparer = new PointDistanceFromOriginComparer();
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 point.RequiresGreaterThan(lowerBoundPoint, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 point.RequiresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 point.RequiresGreaterThan(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 point.RequiresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 point.EnsuresGreaterThan(lowerBoundPoint, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 point.EnsuresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 point.EnsuresGreaterThan(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 point.EnsuresGreaterThan(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -98,29 +98,29 @@ var str = "asdf";
 var lowerBoundStr = "QWERTY";
 var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 str.RequiresGreaterThan(lowerBoundStr, comparisonType);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 str.RequiresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 str.RequiresGreaterThan(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 str.RequiresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 str.EnsuresGreaterThan(lowerBoundStr, comparisonType);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 str.EnsuresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 str.EnsuresGreaterThan(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 str.EnsuresGreaterThan(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/GreaterThanOrEqual.md
+++ b/Documentation/GreaterThanOrEqual.md
@@ -39,29 +39,29 @@ var customExceptionFactory = new CustomExceptionFactory();
 var changeDate = new DateTime(2023, 1, 1);
 var lowerBoundDate = new DateTime(2023, 1, 1);
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 changeDate.RequiresGreaterThanOrEqual(lowerBoundDate);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 changeDate.RequiresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 changeDate.RequiresGreaterThanOrEqual(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 changeDate.RequiresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 changeDate.EnsuresGreaterThanOrEqual(lowerBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -69,29 +69,29 @@ var point = new Point { X = 10, Y = 10 };
 var lowerBoundPoint = new Point { X = 1, Y = 12 };
 var comparer = new PointDistanceFromOriginComparer();
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 point.RequiresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 point.EnsuresGreaterThanOrEqual(lowerBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -99,29 +99,29 @@ var str = "asdf";
 var lowerBoundStr = "asdf";
 var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 str.RequiresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 str.EnsuresGreaterThanOrEqual(lowerBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/LessThan.md
+++ b/Documentation/LessThan.md
@@ -38,29 +38,29 @@ var customExceptionFactory = new CustomExceptionFactory();
 var changeDate = new DateTime(2023, 1, 1);
 var upperBoundDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 changeDate.RequiresLessThan(upperBoundDate);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 changeDate.RequiresLessThan(upperBoundDate, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 changeDate.RequiresLessThan(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 changeDate.RequiresLessThan(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 changeDate.EnsuresLessThan(upperBoundDate);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 changeDate.EnsuresLessThan(upperBoundDate, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 changeDate.EnsuresLessThan(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 changeDate.EnsuresLessThan(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -68,29 +68,29 @@ var point = new Point { X = 1, Y = 12 };
 var upperBoundPoint = new Point { X = 10, Y = 10 };
 var comparer = new PointDistanceFromOriginComparer();
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 point.RequiresLessThan(upperBoundPoint, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 point.RequiresLessThan(upperBoundPoint, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 point.RequiresLessThan(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 point.RequiresLessThan(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 point.EnsuresLessThan(upperBoundPoint, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 point.EnsuresLessThan(upperBoundPoint, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 point.EnsuresLessThan(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 point.EnsuresLessThan(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -98,29 +98,29 @@ var str = "QWERTY";
 var upperBoundStr = "asdf";
 var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 str.RequiresLessThan(upperBoundStr, comparisonType);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 str.RequiresLessThan(upperBoundStr, comparisonType, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 str.RequiresLessThan(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 str.RequiresLessThan(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 str.EnsuresLessThan(upperBoundStr, comparisonType);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 str.EnsuresLessThan(upperBoundStr, comparisonType, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 str.EnsuresLessThan(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 str.EnsuresLessThan(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/LessThanOrEqual.md
+++ b/Documentation/LessThanOrEqual.md
@@ -39,29 +39,29 @@ var customExceptionFactory = new CustomExceptionFactory();
 var changeDate = new DateTime(2023, 1, 1);
 var upperBoundDate = new DateTime(2023, 3, 12, 11, 17, 38, 1234);
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 changeDate.RequiresLessThanOrEqual(upperBoundDate);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 changeDate.RequiresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 changeDate.RequiresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 changeDate.EnsuresLessThanOrEqual(upperBoundDate);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 changeDate.EnsuresLessThanOrEqual(upperBoundDate, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 changeDate.EnsuresLessThanOrEqual(upperBoundDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -69,29 +69,29 @@ var point = new Point { X = 1, Y = 12 };
 var upperBoundPoint = new Point { X = 10, Y = 10 };
 var comparer = new PointDistanceFromOriginComparer();
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 point.RequiresLessThanOrEqual(upperBoundPoint, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 point.RequiresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 point.RequiresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 point.EnsuresLessThanOrEqual(upperBoundPoint, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 point.EnsuresLessThanOrEqual(upperBoundPoint, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -99,29 +99,29 @@ var str = "QWERTY";
 var upperBoundStr = "asdf";
 var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 str.RequiresLessThanOrEqual(upperBoundStr, comparisonType);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 str.RequiresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 str.EnsuresLessThanOrEqual(upperBoundStr, comparisonType, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/NotDefault.md
+++ b/Documentation/NotDefault.md
@@ -29,28 +29,28 @@ Int64 id = default;
 
 List<Guid> identifiers = default!;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 id.RequiresNotDefault();
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 id.RequiresNotDefault(customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 id.RequiresNotDefault(exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 id.RequiresNotDefault(customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 identifiers.EnsuresNotDefault();
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 identifiers.EnsuresNotDefault(customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 identifiers.EnsuresNotDefault(exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 identifiers.EnsuresNotDefault(customMessageTemplate, customExceptionFactory);
 ```

--- a/Documentation/NotEqual.md
+++ b/Documentation/NotEqual.md
@@ -38,29 +38,29 @@ var customExceptionFactory = new CustomExceptionFactory();
 var currentDate = new DateOnly(2021, 12, 25);
 var targetDate = new DateOnly(2021, 12, 25);
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 currentDate.RequiresNotEqual(targetDate);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 currentDate.RequiresNotEqual(targetDate, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 currentDate.RequiresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 currentDate.RequiresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 currentDate.EnsuresNotEqual(targetDate);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 currentDate.EnsuresNotEqual(targetDate, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 currentDate.EnsuresNotEqual(targetDate, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 currentDate.EnsuresNotEqual(targetDate, customMessageTemplate, customExceptionFactory);
 
 
@@ -68,29 +68,29 @@ var box = new Box(1, 1, 8, "Red");
 var targetBox = new Box(2, 2, 2, "Blue");
 var comparer = new BoxVolumeComparer();
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 box.RequiresNotEqual(targetBox, comparer);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 box.RequiresNotEqual(targetBox, comparer, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 box.RequiresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 box.RequiresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 box.EnsuresNotEqual(targetBox, comparer);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 box.EnsuresNotEqual(targetBox, comparer, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 box.EnsuresNotEqual(targetBox, comparer, customMessageTemplate, customExceptionFactory);
 
 
@@ -98,29 +98,29 @@ var str = "qwerty";
 var targetStr = "QWERTY";
 var comparisonType = StringComparison.OrdinalIgnoreCase;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 str.RequiresNotEqual(targetStr, comparisonType);
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 str.RequiresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 str.RequiresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 str.EnsuresNotEqual(targetStr, comparisonType);
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 str.EnsuresNotEqual(targetStr, comparisonType, exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 str.EnsuresNotEqual(targetStr, comparisonType, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/NotNull.md
+++ b/Documentation/NotNull.md
@@ -27,28 +27,28 @@ String lastName = null!;
 
 List<Guid> identifiers = null!;
 
-// Precondition with default message template/default exception factory.
+// Precondition with default message template and default exception factory.
 lastName.RequiresNotNull();
 
-// Precondition with custom message template/default exception factory.
+// Precondition with custom message template and default exception factory.
 lastName.RequiresNotNull(customMessageTemplate);
 
-// Precondition with default message template/custom exception factory.
+// Precondition with default message template and custom exception factory.
 lastName.RequiresNotNull(exceptionFactory: customExceptionFactory);
 
-// Precondition with custom message template/custom exception factory.
+// Precondition with custom message template and custom exception factory.
 lastName.RequiresNotNull(customMessageTemplate, customExceptionFactory);
 
 
-// Postcondition with default message template/default exception factory.
+// Postcondition with default message template and default exception factory.
 identifiers.EnsuresNotNull();
 
-// Postcondition with custom message template/default exception factory.
+// Postcondition with custom message template and default exception factory.
 identifiers.EnsuresNotNull(customMessageTemplate);
 
-// Postcondition with default message template/custom exception factory.
+// Postcondition with default message template and custom exception factory.
 identifiers.EnsuresNotNull(exceptionFactory: customExceptionFactory);
 
-// Postcondition with custom message template/custom exception factory.
+// Postcondition with custom message template and custom exception factory.
 identifiers.EnsuresNotNull(customMessageTemplate, customExceptionFactory);
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
     - [GreaterThanOrEqual](/Documentation/GreaterThanOrEqual.md)
     - [LessThan](/Documentation/LessThan.md)
     - [LessThanOrEqual](/Documentation/LessThanOrEqual.md)
+    - [Between](/Documentation/Between.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a value is between a minimum and maximum value.

Requirements:

  RequiresBetween (precondition), default ArgumentOutOfRangeException
  EnsuresBetween (postcondition), default PostconditionFailedException
  Support supplying IComparer<T> object to perform the comparison

DEFINITION OF DONE:

1. Implement RequiresBetween
2. Implement EnsuresBetween
3. Unit tests for Requires/Ensures Between
4. Performance tests
5. Readme updates
6. Examples