### PR TITLE
S0013 greater than zero

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -396,7 +396,7 @@ parameter was omitted.
 
 ### GreaterThanZero Benchmarks
 
-| Method     --------     | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+| Method                  | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
 |:----------------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
 | RequiresGreaterThanZero | Double      |                  |                   | 0.6312 ns | 0.0198 ns | 0.0185 ns |         - |
 | RequiresGreaterThanZero | Double      | X                |                   | 0.9438 ns | 0.0115 ns | 0.0102 ns |         - |

--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -24,6 +24,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [LessThan Benchmarks](#lessthan-benchmarks)
   - [LessThanOrEqual Benchmarks](#lessthanorequal-benchmarks)
   - [Between Benchmarks](#between-benchmarks)
+  - [GreaterThanZero Benchmarks](#greaterthanzero-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -392,3 +393,17 @@ parameter was omitted.
 | RequiresBetween | Class       | IComparer<T>     | X                |                   |  13.202 ns | 0.1368 ns | 0.1213 ns |         - |
 | RequiresBetween | Class       | IComparer<T>     |                  | X                 |  13.560 ns | 0.2960 ns | 0.5106 ns |         - |
 | RequiresBetween | Class       | IComparer<T>     | X                | X                 |  13.211 ns | 0.1913 ns | 0.1696 ns |         - |
+
+### GreaterThanZero Benchmarks
+
+| Method     --------     | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:----------------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresGreaterThanZero | Double      |                  |                   | 0.6312 ns | 0.0198 ns | 0.0185 ns |         - |
+| RequiresGreaterThanZero | Double      | X                |                   | 0.9438 ns | 0.0115 ns | 0.0102 ns |         - |
+| RequiresGreaterThanZero | Double      |                  | X                 | 2.0147 ns | 0.0189 ns | 0.0177 ns |         - |
+| RequiresGreaterThanZero | Double      | X                | X                 | 2.0258 ns | 0.0251 ns | 0.0235 ns |         - |
+| RequiresGreaterThanZero | Decimal     |                  |                   | 2.4109 ns | 0.0531 ns | 0.0471 ns |         - |
+| RequiresGreaterThanZero | Decimal     | X                |                   | 2.1276 ns | 0.0199 ns | 0.0177 ns |         - |
+| RequiresGreaterThanZero | Decimal     |                  | X                 | 3.9250 ns | 0.0179 ns | 0.0158 ns |         - |
+| RequiresGreaterThanZero | Decimal     | X                | X                 | 3.9672 ns | 0.0404 ns | 0.0359 ns |         - |
+

--- a/DbC.Net.Examples/GreaterThanZeroExamples.cs
+++ b/DbC.Net.Examples/GreaterThanZeroExamples.cs
@@ -1,0 +1,37 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class GreaterThanZeroExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be greater than zero";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = Double.Pi;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresGreaterThanZero();
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresGreaterThanZero(customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresGreaterThanZero(exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresGreaterThanZero(customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.EnsuresGreaterThanZero();
+
+      // Postcondition with custom message template and default exception factory.
+      value.EnsuresGreaterThanZero(customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.EnsuresGreaterThanZero(exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.EnsuresGreaterThanZero(customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/GreaterThanZeroBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/GreaterThanZeroBenchmarks.cs
@@ -1,0 +1,66 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class GreaterThanZeroBenchmarks
+{
+   private const Double _doubleValue = Double.Pi;
+
+   private const Decimal _decimalValue = Decimal.MaxValue;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be greater than zero";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _doubleValue.RequiresGreaterThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Double_P000()
+   {
+      var result = _doubleValue.RequiresGreaterThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Double_P100()
+   {
+      var result = _doubleValue.RequiresGreaterThanZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Double_P010()
+   {
+      var result = _doubleValue.RequiresGreaterThanZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Double_P110()
+   {
+      var result = _doubleValue.RequiresGreaterThanZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Decimal_P000()
+   {
+      var result = _decimalValue.RequiresGreaterThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Decimal_P100()
+   {
+      var result = _decimalValue.RequiresGreaterThanZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Decimal_P010()
+   {
+      var result = _decimalValue.RequiresGreaterThanZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Decimal_P110()
+   {
+      var result = _decimalValue.RequiresGreaterThanZero(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -7,4 +7,5 @@
 //BenchmarkRunner.Run<GreaterThanOrEqualBenchmarks>();
 //BenchmarkRunner.Run<LessThanBenchmarks>();
 //BenchmarkRunner.Run<LessThanOrEqualBenchmarks>();
-BenchmarkRunner.Run<BetweenBenchmarks>();
+//BenchmarkRunner.Run<BetweenBenchmarks>();
+BenchmarkRunner.Run<GreaterThanZeroBenchmarks>();

--- a/DbC.Net.Tests.Unit/GreaterThanZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanZeroExtensionsTests.cs
@@ -1,0 +1,277 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class GreaterThanZeroExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresGreaterThanZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThanZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.EnsuresGreaterThanZero();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.EnsuresGreaterThanZero();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+
+      // Act.
+      var result = value.EnsuresGreaterThanZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = 0;
+      var act = () => _ = value.EnsuresGreaterThanZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThanZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = -1.5;
+      var act = () => _ = value.EnsuresGreaterThanZero();
+      var expectedMessage = $"Postcondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = -1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThanZero(messageTemplate);
+      var expectedMessage = $"Requirement GreaterThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Single)0;
+      var act = () => _ = value.EnsuresGreaterThanZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)(-1);
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThanZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresGreaterThanZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThanZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.RequiresGreaterThanZero();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.RequiresGreaterThanZero();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+
+      // Act.
+      var result = value.RequiresGreaterThanZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = 0;
+      var act = () => _ = value.RequiresGreaterThanZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThanZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = -1.5;
+      var act = () => _ = value.RequiresGreaterThanZero();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = -1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThanZero(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement GreaterThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Single)0;
+      var act = () => _ = value.RequiresGreaterThanZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)(-1);
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThanZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/TestData/NumberTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/NumberTypesTestData.cs
@@ -1,0 +1,28 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public class NumberTypesTestData : IEnumerable<Object[]>
+{
+   public IEnumerator<Object[]> GetEnumerator()
+   {
+      yield return new Object[] { new BigIntegerData() };
+      yield return new Object[] { new ByteData() };
+      yield return new Object[] { new CharData() };
+      yield return new Object[] { new DecimalData() };
+      yield return new Object[] { new DoubleData() };
+      yield return new Object[] { new HalfData() };
+      yield return new Object[] { new Int128Data() };
+      yield return new Object[] { new Int16Data() };
+      yield return new Object[] { new Int32Data() };
+      yield return new Object[] { new Int64Data() };
+      yield return new Object[] { new SByteData() };
+      yield return new Object[] { new SingleData() };
+      yield return new Object[] { new UInt128Data() };
+      yield return new Object[] { new UInt16Data() };
+      yield return new Object[] { new UInt32Data() };
+      yield return new Object[] { new UInt64Data() };
+      yield return new Object[] { new nintData() };
+      yield return new Object[] { new nuintData() };
+   }
+
+   IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/DbC.Net.Tests.Unit/TestData/SignedNumberTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/SignedNumberTypesTestData.cs
@@ -1,0 +1,21 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public sealed class SignedNumberTypesTestData : IEnumerable<Object[]>
+{
+   public IEnumerator<Object[]> GetEnumerator()
+   {
+      yield return new Object[] { new BigIntegerData() };
+      yield return new Object[] { new DecimalData() };
+      yield return new Object[] { new DoubleData() };
+      yield return new Object[] { new HalfData() };
+      yield return new Object[] { new Int128Data() };
+      yield return new Object[] { new Int16Data() };
+      yield return new Object[] { new Int32Data() };
+      yield return new Object[] { new Int64Data() };
+      yield return new Object[] { new SByteData() };
+      yield return new Object[] { new SingleData() };
+      yield return new Object[] { new nintData() };
+   }
+
+   IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\GreaterThan.md = Documentation\GreaterThan.md
 		Documentation\GreaterThanOrEqual.md = Documentation\GreaterThanOrEqual.md
+		Documentation\GreaterThanZero.md = Documentation\GreaterThanZero.md
 		Documentation\LessThan.md = Documentation\LessThan.md
 		Documentation\LessThanOrEqual.md = Documentation\LessThanOrEqual.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md

--- a/DbC.Net/GreaterThanZeroExtensions.cs
+++ b/DbC.Net/GreaterThanZeroExtensions.cs
@@ -1,0 +1,112 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement GreaterThanZero requirement for
+///   numeric types.
+/// </summary>
+public static class GreaterThanZeroExtensions
+{
+   private const String _requirementName = RequirementNames.GreaterThanZero;
+
+   /// <summary>
+   ///   Value GreaterThanZero postcondition. Confirm that <paramref name="value"/>
+   ///   is greater than zero and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than zero".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresGreaterThanZero<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
+   {
+      CheckGreaterThanZero(
+         value,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value GreaterThanZero precondition. Confirm that <paramref name="value"/>
+   ///   is greater than zero and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than zero".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresGreaterThanZero<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
+   {
+      CheckGreaterThanZero(
+         value,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   private static void CheckGreaterThanZero<T>(
+      T value,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression) where T : INumber<T>
+   {
+      if (value!.CompareTo(T.Zero) <= 0)
+      {
+         messageTemplate ??= MessageTemplates.GreaterThanZeroTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -106,6 +106,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be greater than zero.
+        /// </summary>
+        internal static string GreaterThanZeroTemplate {
+            get {
+                return ResourceManager.GetString("GreaterThanZeroTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}.
         /// </summary>
         internal static string LessThanOrEqualTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -132,6 +132,9 @@
   <data name="GreaterThanTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {LowerBound}</value>
   </data>
+  <data name="GreaterThanZeroTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than zero</value>
+  </data>
   <data name="LessThanOrEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -10,6 +10,7 @@ public static class RequirementNames
    public const String Equal = nameof(Equal);
    public const String GreaterThan = nameof(GreaterThan);
    public const String GreaterThanOrEqual = nameof(GreaterThanOrEqual);
+   public const String GreaterThanZero = nameof(GreaterThanZero);
    public const String LessThan = nameof(LessThan);
    public const String LessThanOrEqual = nameof(LessThanOrEqual);
    public const String NotDefault = nameof(NotDefault);

--- a/Documentation/GreaterThan.md
+++ b/Documentation/GreaterThan.md
@@ -7,17 +7,17 @@ StringComparison value that specifies how the comparison is performed.
 
 **Method signatures:**
 ```C#
-T RequiresGreaterThan<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T RequiresGreaterThan<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null]) where T : IComparable<T>
 
-T RequiresGreaterThan<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T RequiresGreaterThan<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 
-String RequiresGreaterThan(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresGreaterThan(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 
-T EnsuresGreaterThan<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T EnsuresGreaterThan<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null]) where T : IComparable<T>
 
-T EnsuresGreaterThan<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T EnsuresGreaterThan<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 
-String EnsuresGreaterThan(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresGreaterThan(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 ```
 
 The default message template for GreaterThan is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {LowerBound}".

--- a/Documentation/GreaterThanOrEqual.md
+++ b/Documentation/GreaterThanOrEqual.md
@@ -8,17 +8,17 @@ the comparison is performed.
 
 **Method signatures:**
 ```C#
-T RequiresGreaterThanOrEqual<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T RequiresGreaterThanOrEqual<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null]) where T : IComparable<T>
 
-T RequiresGreaterThanOrEqual<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T RequiresGreaterThanOrEqual<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 
-String RequiresGreaterThanOrEqual(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresGreaterThanOrEqual(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 
-T EnsuresGreaterThanOrEqual<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T EnsuresGreaterThanOrEqual<T>(this T value, T lowerBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null]) where T : IComparable<T>
 
-T EnsuresGreaterThanOrEqual<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T EnsuresGreaterThanOrEqual<T>(this T value, T lowerBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 
-String EnsuresGreaterThanOrEqual(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresGreaterThanOrEqual(this String value, String lowerBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? lowerBoundExpression = null])
 ```
 
 The default message template for GreaterThanOrEqual is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to {LowerBound}".

--- a/Documentation/GreaterThanZero.md
+++ b/Documentation/GreaterThanZero.md
@@ -20,4 +20,33 @@ RequirementName, Value, and ValueExpression.
 
 **Examples:**
 ```C#
+var customMessageTemplate = "{ValueExpression} must be greater than zero";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = Double.Pi;
+
+// Precondition with default message template and default exception factory.
+value.RequiresGreaterThanZero();
+
+// Precondition with custom message template and default exception factory.
+value.RequiresGreaterThanZero(customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresGreaterThanZero(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresGreaterThanZero(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.EnsuresGreaterThanZero();
+
+// Postcondition with custom message template and default exception factory.
+value.EnsuresGreaterThanZero(customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.EnsuresGreaterThanZero(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.EnsuresGreaterThanZero(customMessageTemplate, customExceptionFactory);
 ```

--- a/Documentation/GreaterThanZero.md
+++ b/Documentation/GreaterThanZero.md
@@ -5,9 +5,9 @@ zero.
 
 **Method signatures:**
 ```C#
-T RequiresGreaterThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumberBase<T>
+T RequiresGreaterThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
 
-T EnsuresGreaterThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumberBase<T>
+T EnsuresGreaterThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
 ```
 
 The default message template for GreaterThanZero is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than zero".

--- a/Documentation/GreaterThanZero.md
+++ b/Documentation/GreaterThanZero.md
@@ -1,0 +1,23 @@
+### GreaterThanZero
+
+GreaterThanZero requires that the numeric value being checked be greater than 
+zero.
+
+**Method signatures:**
+```C#
+T RequiresGreaterThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumberBase<T>
+
+T EnsuresGreaterThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumberBase<T>
+```
+
+The default message template for GreaterThanZero is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than zero".
+The default exception factory for RequiresGreaterThanZero is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresGreaterThanZero.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, and ValueExpression.
+
+**Examples:**
+```C#
+```

--- a/Documentation/LessThan.md
+++ b/Documentation/LessThan.md
@@ -7,17 +7,17 @@ StringComparison value that specifies how the comparison is performed.
 
 **Method signatures:**
 ```C#
-T RequiresLessThan<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T RequiresLessThan<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null]) where T : IComparable<T>
 
-T RequiresLessThan<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T RequiresLessThan<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 
-String RequiresLessThan(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresLessThan(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 
-T EnsuresLessThan<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T EnsuresLessThan<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null]) where T : IComparable<T>
 
-T EnsuresLessThan<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T EnsuresLessThan<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 
-String EnsuresLessThan(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresLessThan(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 ```
 
 The default message template for LessThan is "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than {UpperBound}".

--- a/Documentation/LessThanOrEqual.md
+++ b/Documentation/LessThanOrEqual.md
@@ -8,17 +8,17 @@ the comparison is performed.
 
 **Method signatures:**
 ```C#
-T RequiresLessThanOrEqual<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T RequiresLessThanOrEqual<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null]) where T : IComparable<T>
 
-T RequiresLessThanOrEqual<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T RequiresLessThanOrEqual<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 
-String RequiresLessThanOrEqual(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String RequiresLessThanOrEqual(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 
-T EnsuresLessThanOrEqual<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null]) where T : IComparable<T>
+T EnsuresLessThanOrEqual<T>(this T value, T upperBound, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null]) where T : IComparable<T>
 
-T EnsuresLessThanOrEqual<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+T EnsuresLessThanOrEqual<T>(this T value, T upperBound, IComparer<T> comparer, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 
-String EnsuresLessThanOrEqual(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+String EnsuresLessThanOrEqual(this String value, String upperBound, StringComparison comparisonType, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? upperBoundExpression = null])
 ```
 
 The default message template for LessThanOrEqual is "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}".

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 
     - [GreaterThan](/Documentation/GreaterThan.md)
     - [GreaterThanOrEqual](/Documentation/GreaterThanOrEqual.md)
+    - [GreaterThanZero](/Documentation/GreaterThanZero.md)
     - [LessThan](/Documentation/LessThan.md)
     - [LessThanOrEqual](/Documentation/LessThanOrEqual.md)
     - [Between](/Documentation/Between.md)


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a numeric value is greater than zero.

Requirements:

  RequiresGreaterThanZero (precondition), default ArgumentOutOfRangeException
  EnsuresGreaterThanZero (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresGreaterThanZero
2. Implement EnsuresGreaterThanZero
3. Unit tests for Requires/Ensures GreaterThanZero
4. Performance tests
5. Readme updates
6. Examples