### PR TITLE
S0014 greater than or equal to zero

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -398,6 +398,10 @@ parameter was omitted.
 
 | Method                  | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
 |:----------------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresGreaterThanZero | Int32       |                  |                   | 0.2333 ns | 0.0194 ns | 0.0181 ns |         - |
+| RequiresGreaterThanZero | Int32       | X                |                   | 0.4801 ns | 0.0157 ns | 0.0140 ns |         - |
+| RequiresGreaterThanZero | Int32       |                  | X                 | 2.1925 ns | 0.0659 ns | 0.0617 ns |         - |
+| RequiresGreaterThanZero | Int32       | X                | X                 | 1.7096 ns | 0.0329 ns | 0.0308 ns |         - |
 | RequiresGreaterThanZero | Double      |                  |                   | 0.6312 ns | 0.0198 ns | 0.0185 ns |         - |
 | RequiresGreaterThanZero | Double      | X                |                   | 0.9438 ns | 0.0115 ns | 0.0102 ns |         - |
 | RequiresGreaterThanZero | Double      |                  | X                 | 2.0147 ns | 0.0189 ns | 0.0177 ns |         - |
@@ -407,3 +411,19 @@ parameter was omitted.
 | RequiresGreaterThanZero | Decimal     |                  | X                 | 3.9250 ns | 0.0179 ns | 0.0158 ns |         - |
 | RequiresGreaterThanZero | Decimal     | X                | X                 | 3.9672 ns | 0.0404 ns | 0.0359 ns |         - |
 
+### GreaterThanOrEqualToZero Benchmarks
+
+| Method                           | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:-------------------------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresGreaterThanOrEqualToZero | Int32       |                  |                   | 0.2676 ns | 0.0204 ns | 0.0191 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Int32       | X                |                   | 0.5805 ns | 0.0294 ns | 0.0275 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Int32       |                  | X                 | 2.3188 ns | 0.0755 ns | 0.0706 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Int32       | X                | X                 | 1.8308 ns | 0.0334 ns | 0.0312 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Double      |                  |                   | 0.6458 ns | 0.0175 ns | 0.0156 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Double      | X                |                   | 0.6677 ns | 0.0153 ns | 0.0143 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Double      |                  | X                 | 1.9825 ns | 0.0244 ns | 0.0216 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Double      | X                | X                 | 2.0095 ns | 0.0128 ns | 0.0107 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Decimal     |                  |                   | 2.3769 ns | 0.0642 ns | 0.0600 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Decimal     | X                |                   | 2.2519 ns | 0.0247 ns | 0.0219 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Decimal     |                  | X                 | 4.1155 ns | 0.0505 ns | 0.0472 ns |         - |
+| RequiresGreaterThanOrEqualToZero | Decimal     | X                | X                 | 3.9699 ns | 0.0422 ns | 0.0374 ns |         - |

--- a/DbC.Net.Examples/GreaterThanOrEqualToZeroExamples.cs
+++ b/DbC.Net.Examples/GreaterThanOrEqualToZeroExamples.cs
@@ -1,0 +1,37 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class GreaterThanOrEqualToZeroExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be greater than or equal to zero";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = Double.Pi;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresGreaterThanOrEqualToZero();
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresGreaterThanOrEqualToZero(customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresGreaterThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresGreaterThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.EnsuresGreaterThanOrEqualToZero();
+
+      // Postcondition with custom message template and default exception factory.
+      value.EnsuresGreaterThanOrEqualToZero(customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.EnsuresGreaterThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.EnsuresGreaterThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/GreaterThanOrEqualToZeroBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/GreaterThanOrEqualToZeroBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class GreaterThanOrEqualToZeroBenchmarks
+{
+   private const Int32 _intValue = 42;
+   private const Double _doubleValue = Double.Pi;
+   private const Decimal _decimalValue = Decimal.MaxValue;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be greater than or equal to zero";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresGreaterThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Int32_P000()
+   {
+      var result = _intValue.RequiresGreaterThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Int32_P100()
+   {
+      var result = _intValue.RequiresGreaterThanOrEqualToZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Int32_P010()
+   {
+      var result = _intValue.RequiresGreaterThanOrEqualToZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Int32_P110()
+   {
+      var result = _intValue.RequiresGreaterThanOrEqualToZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Double_P000()
+   {
+      var result = _doubleValue.RequiresGreaterThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Double_P100()
+   {
+      var result = _doubleValue.RequiresGreaterThanOrEqualToZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Double_P010()
+   {
+      var result = _doubleValue.RequiresGreaterThanOrEqualToZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Double_P110()
+   {
+      var result = _doubleValue.RequiresGreaterThanOrEqualToZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Decimal_P000()
+   {
+      var result = _decimalValue.RequiresGreaterThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Decimal_P100()
+   {
+      var result = _decimalValue.RequiresGreaterThanOrEqualToZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Decimal_P010()
+   {
+      var result = _decimalValue.RequiresGreaterThanOrEqualToZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanOrEqualToZero_Decimal_P110()
+   {
+      var result = _decimalValue.RequiresGreaterThanOrEqualToZero(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/GreaterThanZeroBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/GreaterThanZeroBenchmarks.cs
@@ -3,8 +3,8 @@
 [MemoryDiagnoser]
 public class GreaterThanZeroBenchmarks
 {
+   private const Int32 _intValue = 42;
    private const Double _doubleValue = Double.Pi;
-
    private const Decimal _decimalValue = Decimal.MaxValue;
 
    private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be greater than zero";
@@ -13,7 +13,31 @@ public class GreaterThanZeroBenchmarks
    [Benchmark]
    public void ThrowAway()
    {
-      var result = _doubleValue.RequiresGreaterThanZero();
+      var result = _intValue.RequiresGreaterThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Int32_P000()
+   {
+      var result = _intValue.RequiresGreaterThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Int32_P100()
+   {
+      var result = _intValue.RequiresGreaterThanZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Int32_P010()
+   {
+      var result = _intValue.RequiresGreaterThanZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresGreaterThanZero_Int32_P110()
+   {
+      var result = _intValue.RequiresGreaterThanZero(_messageTemplate, _exceptionFactory);
    }
 
    [Benchmark]

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -9,3 +9,4 @@
 //BenchmarkRunner.Run<LessThanOrEqualBenchmarks>();
 //BenchmarkRunner.Run<BetweenBenchmarks>();
 BenchmarkRunner.Run<GreaterThanZeroBenchmarks>();
+BenchmarkRunner.Run<GreaterThanOrEqualToZeroBenchmarks>();

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
@@ -1,0 +1,307 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class GreaterThanOrEqualToZeroExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresGreaterThanOrEqualToZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+
+      // Act.
+      var result = value.EnsuresGreaterThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+
+      // Act.
+      var result = value.EnsuresGreaterThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = -1;
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThanOrEqualToZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = -1.5;
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
+      var expectedMessage = $"Postcondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = -1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero(messageTemplate);
+      var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Single.MinValue;
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)(-1);
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresGreaterThanOrEqualToZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresGreaterThanOrEqualToZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+
+      // Act.
+      var result = value.RequiresGreaterThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+
+      // Act.
+      var result = value.RequiresGreaterThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = -1;
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.GreaterThanOrEqualToZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = -1.5;
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = -1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Single.MinValue;
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)(-1);
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresGreaterThanOrEqualToZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/GreaterThanZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanZeroExtensionsTests.cs
@@ -13,7 +13,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -26,7 +26,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldThrow_WhenValueIsZero<T>(
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrow_WhenValueIsZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -39,7 +39,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
-   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldThrow_WhenValueIsLessThanZero<T>(
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrow_WhenValueIsLessThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -52,7 +52,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanZeroExtensions_EnsuresGreaterThan_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -66,7 +66,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
    {
       // Arrange.
       var value = 0;
@@ -83,7 +83,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
    {
       // Arrange.
       var value = -1.5;
@@ -96,7 +96,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
    {
       // Arrange.
       var value = -1.5M;
@@ -110,7 +110,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = (Single)0;
@@ -123,7 +123,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_EnsuresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void GreaterThanZeroExtensions_EnsuresGreaterThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = (Half)(-1);
@@ -144,7 +144,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -157,7 +157,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldThrow_WhenValueIsZero<T>(
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrow_WhenValueIsZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -170,7 +170,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
-   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldThrow_WhenValueIsLessThanZero<T>(
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrow_WhenValueIsLessThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -183,7 +183,7 @@ public class GreaterThanZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanZeroExtensions_RequiresGreaterThan_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -197,7 +197,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
    {
       // Arrange.
       var value = 0;
@@ -214,7 +214,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
    {
       // Arrange.
       var value = -1.5;
@@ -230,7 +230,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
    {
       // Arrange.
       var value = -1.5M;
@@ -247,7 +247,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = (Single)0;
@@ -260,7 +260,7 @@ public class GreaterThanZeroExtensionsTests
    }
 
    [Fact]
-   public void GreaterThanExtensions_RequiresGreaterThan_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   public void GreaterThanZeroExtensions_RequiresGreaterThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = (Half)(-1);

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\GreaterThan.md = Documentation\GreaterThan.md
 		Documentation\GreaterThanOrEqual.md = Documentation\GreaterThanOrEqual.md
+		Documentation\GreaterThanOrEqualToZero.md = Documentation\GreaterThanOrEqualToZero.md
 		Documentation\GreaterThanZero.md = Documentation\GreaterThanZero.md
 		Documentation\LessThan.md = Documentation\LessThan.md
 		Documentation\LessThanOrEqual.md = Documentation\LessThanOrEqual.md

--- a/DbC.Net/GreaterThanOrEqualToZeroExtensions.cs
+++ b/DbC.Net/GreaterThanOrEqualToZeroExtensions.cs
@@ -1,0 +1,112 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement GreaterThanOrEqualToZero requirement for
+///   signed numeric types.
+/// </summary>
+public static class GreaterThanOrEqualToZeroExtensions
+{
+   private const String _requirementName = RequirementNames.GreaterThanOrEqualToZero;
+
+   /// <summary>
+   ///   Value GreaterThanOrEqualToZero postcondition. Confirm that <paramref name="value"/>
+   ///   is greater than or equal to zero and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresGreaterThanOrEqualToZero<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
+   {
+      CheckGreaterThanOrEqualToZero(
+         value,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value GreaterThanOrEqualToZero precondition. Confirm that <paramref name="value"/>
+   ///   is greater than or equal to zero and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresGreaterThanOrEqualToZero<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
+   {
+      CheckGreaterThanOrEqualToZero(
+         value,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   private static void CheckGreaterThanOrEqualToZero<T>(
+      T value,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression) where T : INumber<T>
+   {
+      if (value!.CompareTo(T.Zero) < 0)
+      {
+         messageTemplate ??= MessageTemplates.GreaterThanOrEqualToZeroTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -97,6 +97,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero.
+        /// </summary>
+        internal static string GreaterThanOrEqualToZeroTemplate {
+            get {
+                return ResourceManager.GetString("GreaterThanOrEqualToZeroTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {LowerBound}.
         /// </summary>
         internal static string GreaterThanTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -129,6 +129,9 @@
   <data name="GreaterThanOrEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to {LowerBound}</value>
   </data>
+  <data name="GreaterThanOrEqualToZeroTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero</value>
+  </data>
   <data name="GreaterThanTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than {LowerBound}</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -10,6 +10,7 @@ public static class RequirementNames
    public const String Equal = nameof(Equal);
    public const String GreaterThan = nameof(GreaterThan);
    public const String GreaterThanOrEqual = nameof(GreaterThanOrEqual);
+   public const String GreaterThanOrEqualToZero = nameof(GreaterThanOrEqualToZero);
    public const String GreaterThanZero = nameof(GreaterThanZero);
    public const String LessThan = nameof(LessThan);
    public const String LessThanOrEqual = nameof(LessThanOrEqual);

--- a/Documentation/GreaterThanOrEqualToZero.md
+++ b/Documentation/GreaterThanOrEqualToZero.md
@@ -1,0 +1,53 @@
+### GreaterThanOrEqualToZero
+
+GreaterThanOrEqualToZero requires that the signed numeric value being checked be 
+greater than or equal to zero. GreaterThanOrEqualToZero is only implemented for
+signed numeric types because unsigned numeric types would always pass the requirement.
+
+**Method signatures:**
+```C#
+T RequiresGreaterThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : ISignedNumber<T>
+
+T EnsuresGreaterThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : ISignedNumber<T>
+```
+
+The default message template for GreaterThanOrEqualToZero is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero".
+The default exception factory for RequiresGreaterThanOrEqualToZero is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresGreaterThanOrEqualToZero.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, and ValueExpression.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be greater than or equal to zero";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = Double.Pi;
+
+// Precondition with default message template and default exception factory.
+value.RequiresGreaterThanOrEqualToZero();
+
+// Precondition with custom message template and default exception factory.
+value.RequiresGreaterThanOrEqualToZero(customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresGreaterThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresGreaterThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.EnsuresGreaterThanOrEqualToZero();
+
+// Postcondition with custom message template and default exception factory.
+value.EnsuresGreaterThanOrEqualToZero(customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.EnsuresGreaterThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.EnsuresGreaterThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
     - [GreaterThan](/Documentation/GreaterThan.md)
     - [GreaterThanOrEqual](/Documentation/GreaterThanOrEqual.md)
     - [GreaterThanZero](/Documentation/GreaterThanZero.md)
+    - [GreaterThanOrEqualToZero](/Documentation/GreaterThanOrEqualToZero.md)
     - [LessThan](/Documentation/LessThan.md)
     - [LessThanOrEqual](/Documentation/LessThanOrEqual.md)
     - [Between](/Documentation/Between.md)
@@ -61,8 +62,8 @@
 DbC.Net is inspired by the concept of Design by Contract, first introduced by 
 Bertrand Meyer in the Eiffel programming language and also by Microsoft's Code 
 Contracts (no longer supported by .NET 5 or higher). DbC.Net lets you create
-robust requirements based pre- and post-conditions with an expressive fluent
-syntax.
+robust requirements based pre-conditions and post-conditions with an expressive 
+fluent syntax.
 
 # Using DbC.Net
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a numeric value is greater than or equal to zero.

Requirements:

  RequiresGreaterThanOrEqualToZero (precondition), default ArgumentOutOfRangeException
  EnsuresGreaterThanOrEqualToZero (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresGreaterThanOrEqualToZero
2. Implement EnsuresGreaterThanOrEqualToZero
3. Unit tests for Requires/Ensures GreaterThanOrEqualToZero
4. Performance tests
5. Readme updates
6. Examples