### PR TITLE
S0015 less than zero

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -25,6 +25,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [LessThanOrEqual Benchmarks](#lessthanorequal-benchmarks)
   - [Between Benchmarks](#between-benchmarks)
   - [GreaterThanZero Benchmarks](#greaterthanzero-benchmarks)
+  - [GreaterThanOrEqualToZero Benchmarks](#greaterthanorequaltozero-benchmarks)
 
 ### NotNull Benchmarks
 

--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -26,6 +26,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [Between Benchmarks](#between-benchmarks)
   - [GreaterThanZero Benchmarks](#greaterthanzero-benchmarks)
   - [GreaterThanOrEqualToZero Benchmarks](#greaterthanorequaltozero-benchmarks)
+  - [LessThanZero Benchmarks](#lessthanzero-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -428,3 +429,21 @@ parameter was omitted.
 | RequiresGreaterThanOrEqualToZero | Decimal     | X                |                   | 2.2519 ns | 0.0247 ns | 0.0219 ns |         - |
 | RequiresGreaterThanOrEqualToZero | Decimal     |                  | X                 | 4.1155 ns | 0.0505 ns | 0.0472 ns |         - |
 | RequiresGreaterThanOrEqualToZero | Decimal     | X                | X                 | 3.9699 ns | 0.0422 ns | 0.0374 ns |         - |
+
+### LessThanZero Benchmarks
+
+| Method           | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:---------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresThanZero | Int32       |                  |                   | 0.2510 ns | 0.0234 ns | 0.0208 ns |         - |
+| RequiresThanZero | Int32       | X                |                   | 0.4442 ns | 0.0105 ns | 0.0082 ns |         - |
+| RequiresThanZero | Int32       |                  | X                 | 2.1038 ns | 0.0333 ns | 0.0311 ns |         - |
+| RequiresThanZero | Int32       | X                | X                 | 1.6793 ns | 0.0328 ns | 0.0291 ns |         - |
+| RequiresThanZero | Double      |                  |                   | 0.9623 ns | 0.0478 ns | 0.0491 ns |         - |
+| RequiresThanZero | Double      | X                |                   | 0.6556 ns | 0.0275 ns | 0.0258 ns |         - |
+| RequiresThanZero | Double      |                  | X                 | 1.8240 ns | 0.0408 ns | 0.0382 ns |         - |
+| RequiresThanZero | Double      | X                | X                 | 2.2645 ns | 0.0341 ns | 0.0319 ns |         - |
+| RequiresThanZero | Decimal     |                  |                   | 2.3017 ns | 0.0361 ns | 0.0320 ns |         - |
+| RequiresThanZero | Decimal     | X                |                   | 2.2129 ns | 0.0400 ns | 0.0374 ns |         - |
+| RequiresThanZero | Decimal     |                  | X                 | 4.3049 ns | 0.0358 ns | 0.0335 ns |         - |
+| RequiresThanZero | Decimal     | X                | X                 | 4.1347 ns | 0.0837 ns | 0.0783 ns |         - |
+

--- a/DbC.Net.Examples/LessThanZeroExamples.cs
+++ b/DbC.Net.Examples/LessThanZeroExamples.cs
@@ -1,0 +1,37 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class LessThanZeroExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be less than zero";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = Double.MinValue;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresLessThanZero();
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresLessThanZero(customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresLessThanZero(exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresLessThanZero(customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.RequiresLessThanZero();
+
+      // Postcondition with custom message template and default exception factory.
+      value.RequiresLessThanZero(customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.RequiresLessThanZero(exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.RequiresLessThanZero(customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/LessThanZeroBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/LessThanZeroBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class LessThanZeroBenchmarks
+{
+   private const Int32 _intValue = -42;
+   private const Double _doubleValue = Double.MinValue;
+   private const Decimal _decimalValue = Decimal.MinValue;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be less than zero";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresLessThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Int32_P000()
+   {
+      var result = _intValue.RequiresLessThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Int32_P100()
+   {
+      var result = _intValue.RequiresLessThanZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Int32_P010()
+   {
+      var result = _intValue.RequiresLessThanZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Int32_P110()
+   {
+      var result = _intValue.RequiresLessThanZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Double_P000()
+   {
+      var result = _doubleValue.RequiresLessThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Double_P100()
+   {
+      var result = _doubleValue.RequiresLessThanZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Double_P010()
+   {
+      var result = _doubleValue.RequiresLessThanZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Double_P110()
+   {
+      var result = _doubleValue.RequiresLessThanZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Decimal_P000()
+   {
+      var result = _decimalValue.RequiresLessThanZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Decimal_P100()
+   {
+      var result = _decimalValue.RequiresLessThanZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Decimal_P010()
+   {
+      var result = _decimalValue.RequiresLessThanZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanZero_Decimal_P110()
+   {
+      var result = _decimalValue.RequiresLessThanZero(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -8,5 +8,6 @@
 //BenchmarkRunner.Run<LessThanBenchmarks>();
 //BenchmarkRunner.Run<LessThanOrEqualBenchmarks>();
 //BenchmarkRunner.Run<BetweenBenchmarks>();
-BenchmarkRunner.Run<GreaterThanZeroBenchmarks>();
-BenchmarkRunner.Run<GreaterThanOrEqualToZeroBenchmarks>();
+//BenchmarkRunner.Run<GreaterThanZeroBenchmarks>();
+//BenchmarkRunner.Run<GreaterThanOrEqualToZeroBenchmarks>();
+BenchmarkRunner.Run<LessThanZeroBenchmarks>();

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
@@ -12,9 +12,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    // ==========================================================================
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -25,9 +25,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -40,7 +40,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrow_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -51,9 +51,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -66,9 +66,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -158,9 +158,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    // ==========================================================================
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -171,9 +171,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -186,7 +186,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrow_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -197,9 +197,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -212,9 +212,9 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = T.Zero;

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
@@ -14,7 +14,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -27,7 +27,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -40,7 +40,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldThrow_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -53,7 +53,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -68,7 +68,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -160,7 +160,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -173,7 +173,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -186,7 +186,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldThrow_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -199,7 +199,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -214,7 +214,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : INumber<T>
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
    {
       // Arrange.
       var value = T.Zero;

--- a/DbC.Net.Tests.Unit/LessThanZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanZeroExtensionsTests.cs
@@ -14,7 +14,7 @@ public class LessThanZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldNotThrow_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -25,9 +25,9 @@ public class LessThanZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrow_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -38,9 +38,9 @@ public class LessThanZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrow_WhenValueIsGreaterThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -53,7 +53,7 @@ public class LessThanZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldReturnOriginalValue_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -145,7 +145,7 @@ public class LessThanZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void LessThanZeroExtensions_RequiresLessThanZero_ShouldNotThrow_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MinValue;
@@ -156,9 +156,9 @@ public class LessThanZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrow_WhenValueIsZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = T.Zero;
@@ -169,9 +169,9 @@ public class LessThanZeroExtensionsTests
    }
 
    [Theory]
-   [ClassData(typeof(SignedNumberTypesTestData))]
+   [ClassData(typeof(NumberTypesTestData))]
    public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrow_WhenValueIsGreaterThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MaxValue;
@@ -184,7 +184,7 @@ public class LessThanZeroExtensionsTests
    [Theory]
    [ClassData(typeof(SignedNumberTypesTestData))]
    public void LessThanZeroExtensions_RequiresLessThanZero_ShouldReturnOriginalValue_WhenValueIsLessThanZero<T>(
-      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+      IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
       var value = data.MinValue;

--- a/DbC.Net.Tests.Unit/LessThanZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanZeroExtensionsTests.cs
@@ -1,0 +1,277 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class LessThanZeroExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresLessThanZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldNotThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.EnsuresLessThanZero();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrow_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.EnsuresLessThanZero();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldReturnOriginalValue_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+
+      // Act.
+      var result = value.EnsuresLessThanZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = 0;
+      var act = () => _ = value.EnsuresLessThanZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = 1.5;
+      var act = () => _ = value.EnsuresLessThanZero();
+      var expectedMessage = $"Postcondition LessThanZero failed: {nameof(value)} must be less than zero";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = 1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanZero(messageTemplate);
+      var expectedMessage = $"Requirement LessThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Single)0;
+      var act = () => _ = value.EnsuresLessThanZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition LessThanZero failed: {nameof(value)} must be less than zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_EnsuresLessThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)1;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresLessThanZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldNotThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.RequiresLessThanZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.RequiresLessThanZero();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrow_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.RequiresLessThanZero();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldReturnOriginalValue_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : ISignedNumber<T>, IComparable<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+
+      // Act.
+      var result = value.RequiresLessThanZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = 0;
+      var act = () => _ = value.RequiresLessThanZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = 1.5;
+      var act = () => _ = value.RequiresLessThanZero();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition LessThanZero failed: {nameof(value)} must be less than zero";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = 1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanZero(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement LessThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Single)0;
+      var act = () => _ = value.RequiresLessThanZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition LessThanZero failed: {nameof(value)} must be less than zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanZeroExtensions_RequiresLessThanZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)1;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/TestData/UnsignedNumberTypesTestData.cs
+++ b/DbC.Net.Tests.Unit/TestData/UnsignedNumberTypesTestData.cs
@@ -1,0 +1,17 @@
+﻿namespace DbC.Net.Tests.Unit.TestData;
+
+public class UnsignedNumberTypesTestData : IEnumerable<Object[]>
+{
+   public IEnumerator<Object[]> GetEnumerator()
+   {
+      yield return new Object[] { new ByteData() };
+      yield return new Object[] { new CharData() };
+      yield return new Object[] { new UInt128Data() };
+      yield return new Object[] { new UInt16Data() };
+      yield return new Object[] { new UInt32Data() };
+      yield return new Object[] { new UInt64Data() };
+      yield return new Object[] { new nuintData() };
+   }
+
+   IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\GreaterThanZero.md = Documentation\GreaterThanZero.md
 		Documentation\LessThan.md = Documentation\LessThan.md
 		Documentation\LessThanOrEqual.md = Documentation\LessThanOrEqual.md
+		Documentation\LessThanZero.md = Documentation\LessThanZero.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md

--- a/DbC.Net/GreaterThanOrEqualToZeroExtensions.cs
+++ b/DbC.Net/GreaterThanOrEqualToZeroExtensions.cs
@@ -2,7 +2,7 @@
 
 /// <summary>
 ///   Extension methods that implement GreaterThanOrEqualToZero requirement for
-///   signed numeric types.
+///   numeric types.
 /// </summary>
 public static class GreaterThanOrEqualToZeroExtensions
 {
@@ -12,6 +12,10 @@ public static class GreaterThanOrEqualToZeroExtensions
    ///   Value GreaterThanOrEqualToZero postcondition. Confirm that <paramref name="value"/>
    ///   is greater than or equal to zero and throw an exception if it is not.
    /// </summary>
+   /// <remarks>
+   ///   GreaterThanOrEqualToZero requirements will always pass for unsigned 
+   ///   numeric types.
+   /// </remarks>
    /// <param name="value">
    ///   The value to check.
    /// </param>
@@ -37,7 +41,7 @@ public static class GreaterThanOrEqualToZeroExtensions
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : ISignedNumber<T>, IComparable<T>
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
    {
       CheckGreaterThanOrEqualToZero(
          value,
@@ -53,6 +57,10 @@ public static class GreaterThanOrEqualToZeroExtensions
    ///   Value GreaterThanOrEqualToZero precondition. Confirm that <paramref name="value"/>
    ///   is greater than or equal to zero and throw an exception if it is not.
    /// </summary>
+   /// <remarks>
+   ///   GreaterThanOrEqualToZero requirements will always pass for unsigned 
+   ///   numeric types.
+   /// </remarks>
    /// <param name="value">
    ///   The value to check.
    /// </param>
@@ -78,7 +86,7 @@ public static class GreaterThanOrEqualToZeroExtensions
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : ISignedNumber<T>, IComparable<T>
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
    {
       CheckGreaterThanOrEqualToZero(
          value,
@@ -95,7 +103,7 @@ public static class GreaterThanOrEqualToZeroExtensions
       RequirementType requirementType,
       String? messageTemplate,
       IExceptionFactory? exceptionFactory,
-      String valueExpression) where T : ISignedNumber<T>, IComparable<T>
+      String valueExpression) where T : INumber<T>
    {
       if (value.CompareTo(T.Zero) < 0)
       {

--- a/DbC.Net/GreaterThanZeroExtensions.cs
+++ b/DbC.Net/GreaterThanZeroExtensions.cs
@@ -97,7 +97,7 @@ public static class GreaterThanZeroExtensions
       IExceptionFactory? exceptionFactory,
       String valueExpression) where T : INumber<T>
    {
-      if (value!.CompareTo(T.Zero) <= 0)
+      if (value.CompareTo(T.Zero) <= 0)
       {
          messageTemplate ??= MessageTemplates.GreaterThanZeroTemplate;
          exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);

--- a/DbC.Net/LessThanZeroExtensions.cs
+++ b/DbC.Net/LessThanZeroExtensions.cs
@@ -1,8 +1,8 @@
 ﻿namespace DbC.Net;
 
 /// <summary>
-///   Extension methods that implement LessThanZero requirement for signed 
-///   numeric types.
+///   Extension methods that implement LessThanZero requirement for numeric 
+///   types.
 /// </summary>
 public static class LessThanZeroExtensions
 {
@@ -12,6 +12,9 @@ public static class LessThanZeroExtensions
    ///   Value LessThanZero postcondition. Confirm that <paramref name="value"/>
    ///   is less than zero and throw an exception if it is not.
    /// </summary>
+   /// <remarks>
+   ///   LessThanZero requirements will always fail for unsigned numeric types.
+   /// </remarks>
    /// <param name="value">
    ///   The value to check.
    /// </param>
@@ -37,7 +40,7 @@ public static class LessThanZeroExtensions
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : ISignedNumber<T>, IComparable<T>
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
    {
       CheckLessThanZero(
          value,
@@ -53,6 +56,9 @@ public static class LessThanZeroExtensions
    ///   Value LessThanZero precondition. Confirm that <paramref name="value"/>
    ///   is less than zero and throw an exception if it is not.
    /// </summary>
+   /// <remarks>
+   ///   LessThanZero requirements will always fail for unsigned numeric types.
+   /// </remarks>
    /// <param name="value">
    ///   The value to check.
    /// </param>
@@ -78,7 +84,7 @@ public static class LessThanZeroExtensions
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
-      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : ISignedNumber<T>, IComparable<T>
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
    {
       CheckLessThanZero(
          value,
@@ -95,7 +101,7 @@ public static class LessThanZeroExtensions
       RequirementType requirementType,
       String? messageTemplate,
       IExceptionFactory? exceptionFactory,
-      String valueExpression) where T : ISignedNumber<T>, IComparable<T> 
+      String valueExpression) where T : INumber<T>
    {
       if (value.CompareTo(T.Zero) >= 0)
       {

--- a/DbC.Net/LessThanZeroExtensions.cs
+++ b/DbC.Net/LessThanZeroExtensions.cs
@@ -1,23 +1,23 @@
 ﻿namespace DbC.Net;
 
 /// <summary>
-///   Extension methods that implement GreaterThanOrEqualToZero requirement for
-///   signed numeric types.
+///   Extension methods that implement LessThanZero requirement for signed 
+///   numeric types.
 /// </summary>
-public static class GreaterThanOrEqualToZeroExtensions
+public static class LessThanZeroExtensions
 {
-   private const String _requirementName = RequirementNames.GreaterThanOrEqualToZero;
+   private const String _requirementName = RequirementNames.LessThanZero;
 
    /// <summary>
-   ///   Value GreaterThanOrEqualToZero postcondition. Confirm that <paramref name="value"/>
-   ///   is greater than or equal to zero and throw an exception if it is not.
+   ///   Value LessThanZero postcondition. Confirm that <paramref name="value"/>
+   ///   is less than zero and throw an exception if it is not.
    /// </summary>
    /// <param name="value">
    ///   The value to check.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than zero".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
@@ -33,13 +33,13 @@ public static class GreaterThanOrEqualToZeroExtensions
    ///   The tested <paramref name="value"/> is returned unaltered to support 
    ///   chaining requirements.
    /// </returns>
-   public static T EnsuresGreaterThanOrEqualToZero<T>(
+   public static T EnsuresLessThanZero<T>(
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
       [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : ISignedNumber<T>, IComparable<T>
    {
-      CheckGreaterThanOrEqualToZero(
+      CheckLessThanZero(
          value,
          RequirementType.Postcondition,
          messageTemplate,
@@ -50,15 +50,15 @@ public static class GreaterThanOrEqualToZeroExtensions
    }
 
    /// <summary>
-   ///   Value GreaterThanOrEqualToZero precondition. Confirm that <paramref name="value"/>
-   ///   is greater than or equal to zero and throw an exception if it is not.
+   ///   Value LessThanZero precondition. Confirm that <paramref name="value"/>
+   ///   is less than zero and throw an exception if it is not.
    /// </summary>
    /// <param name="value">
    ///   The value to check.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than zero".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
@@ -74,13 +74,13 @@ public static class GreaterThanOrEqualToZeroExtensions
    ///   The tested <paramref name="value"/> is returned unaltered to support 
    ///   chaining requirements.
    /// </returns>
-   public static T RequiresGreaterThanOrEqualToZero<T>(
+   public static T RequiresLessThanZero<T>(
       this T value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
       [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : ISignedNumber<T>, IComparable<T>
    {
-      CheckGreaterThanOrEqualToZero(
+      CheckLessThanZero(
          value,
          RequirementType.Precondition,
          messageTemplate,
@@ -90,16 +90,16 @@ public static class GreaterThanOrEqualToZeroExtensions
       return value;
    }
 
-   private static void CheckGreaterThanOrEqualToZero<T>(
+   private static void CheckLessThanZero<T>(
       T value,
       RequirementType requirementType,
       String? messageTemplate,
       IExceptionFactory? exceptionFactory,
-      String valueExpression) where T : ISignedNumber<T>, IComparable<T>
+      String valueExpression) where T : ISignedNumber<T>, IComparable<T> 
    {
-      if (value.CompareTo(T.Zero) < 0)
+      if (value.CompareTo(T.Zero) >= 0)
       {
-         messageTemplate ??= MessageTemplates.GreaterThanOrEqualToZeroTemplate;
+         messageTemplate ??= MessageTemplates.LessThanZeroTemplate;
          exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -142,6 +142,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be less than zero.
+        /// </summary>
+        internal static string LessThanZeroTemplate {
+            get {
+                return ResourceManager.GetString("LessThanZeroTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype}).
         /// </summary>
         internal static string NotDefaultTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -144,6 +144,9 @@
   <data name="LessThanTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than {UpperBound}</value>
   </data>
+  <data name="LessThanZeroTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than zero</value>
+  </data>
   <data name="NotDefaultTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -14,6 +14,7 @@ public static class RequirementNames
    public const String GreaterThanZero = nameof(GreaterThanZero);
    public const String LessThan = nameof(LessThan);
    public const String LessThanOrEqual = nameof(LessThanOrEqual);
+   public const String LessThanZero = nameof(LessThanZero);
    public const String NotDefault = nameof(NotDefault);
    public const String NotEqual = nameof(NotEqual);
    public const String NotNull = nameof(NotNull);

--- a/Documentation/GreaterThanOrEqualToZero.md
+++ b/Documentation/GreaterThanOrEqualToZero.md
@@ -1,14 +1,15 @@
 ### GreaterThanOrEqualToZero
 
-GreaterThanOrEqualToZero requires that the signed numeric value being checked be 
-greater than or equal to zero. GreaterThanOrEqualToZero is only implemented for
-signed numeric types because unsigned numeric types would always pass the requirement.
+GreaterThanOrEqualToZero requires that the INumber<T> value being checked be 
+greater than or equal to zero.
+
+NOTE: Unsigned numeric types will always pass GreaterThanOrEqualToZero.
 
 **Method signatures:**
 ```C#
-T RequiresGreaterThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : ISignedNumber<T>
+T RequiresGreaterThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
 
-T EnsuresGreaterThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : ISignedNumber<T>
+T EnsuresGreaterThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
 ```
 
 The default message template for GreaterThanOrEqualToZero is "{RequirementType} {RequirementName} failed: {ValueExpression} must be greater than or equal to zero".

--- a/Documentation/GreaterThanZero.md
+++ b/Documentation/GreaterThanZero.md
@@ -1,6 +1,6 @@
 ### GreaterThanZero
 
-GreaterThanZero requires that the numeric value being checked be greater than 
+GreaterThanZero requires that the INumber<T> value being checked be greater than 
 zero.
 
 **Method signatures:**

--- a/Documentation/LessThanZero.md
+++ b/Documentation/LessThanZero.md
@@ -24,7 +24,7 @@ RequirementName, Value, and ValueExpression.
 var customMessageTemplate = "{ValueExpression} must be less than zero";
 var customExceptionFactory = new CustomExceptionFactory();
 
-var value = Double.Pi;
+var value = Double.MinValue;
 
 // Precondition with default message template and default exception factory.
 value.RequiresLessThanZero();
@@ -40,14 +40,14 @@ value.RequiresLessThanZero(customMessageTemplate, customExceptionFactory);
 
 
 // Postcondition with default message template and default exception factory.
-value.EnsuresLessThanZero();
+value.RequiresLessThanZero();
 
 // Postcondition with custom message template and default exception factory.
-value.EnsuresLessThanZero(customMessageTemplate);
+value.RequiresLessThanZero(customMessageTemplate);
 
 // Postcondition with default message template and custom exception factory.
-value.EnsuresLessThanZero(exceptionFactory: customExceptionFactory);
+value.RequiresLessThanZero(exceptionFactory: customExceptionFactory);
 
 // Postcondition with custom message template and custom exception factory.
-value.EnsuresLessThanZero(customMessageTemplate, customExceptionFactory);
+value.RequiresLessThanZero(customMessageTemplate, customExceptionFactory);
 ```

--- a/Documentation/LessThanZero.md
+++ b/Documentation/LessThanZero.md
@@ -1,0 +1,51 @@
+### LessThanZero
+
+LessThanZero requires that the numeric value being checked be less than zero.
+
+**Method signatures:**
+```C#
+T RequiresLessThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
+
+T EnsuresLessThanZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
+```
+
+The default message template for LessThanZero is "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than zero".
+The default exception factory for RequiresLessThanZero is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresLessThanZero.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, and ValueExpression.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be less than zero";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = Double.Pi;
+
+// Precondition with default message template and default exception factory.
+value.RequiresLessThanZero();
+
+// Precondition with custom message template and default exception factory.
+value.RequiresLessThanZero(customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresLessThanZero(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresLessThanZero(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.EnsuresLessThanZero();
+
+// Postcondition with custom message template and default exception factory.
+value.EnsuresLessThanZero(customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.EnsuresLessThanZero(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.EnsuresLessThanZero(customMessageTemplate, customExceptionFactory);
+```

--- a/Documentation/LessThanZero.md
+++ b/Documentation/LessThanZero.md
@@ -1,6 +1,8 @@
 ### LessThanZero
 
-LessThanZero requires that the numeric value being checked be less than zero.
+LessThanZero requires that the numeric value being checked be less than zero. 
+LessThanZero is only implemented for signed numeric types because unsigned 
+numeric types would always fail the requirement.
 
 **Method signatures:**
 ```C#

--- a/Documentation/LessThanZero.md
+++ b/Documentation/LessThanZero.md
@@ -1,8 +1,8 @@
 ### LessThanZero
 
-LessThanZero requires that the numeric value being checked be less than zero. 
-LessThanZero is only implemented for signed numeric types because unsigned 
-numeric types would always fail the requirement.
+LessThanZero requires that the INumber<T> value being checked be less than zero.
+
+NOTE: Unsigned numeric types will always fail LessThanZero.
 
 **Method signatures:**
 ```C#

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
     - [GreaterThanOrEqualToZero](/Documentation/GreaterThanOrEqualToZero.md)
     - [LessThan](/Documentation/LessThan.md)
     - [LessThanOrEqual](/Documentation/LessThanOrEqual.md)
+    - [LessThanZero](/Documentation/LessThanZero.md)
     - [Between](/Documentation/Between.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a numeric value is less than zero.

Requirements:

  RequiresLessThanZero (precondition), default ArgumentOutOfRangeException
  EnsuresLessThanZero (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresLessThanZero
2. Implement EnsuresLessThanZero
3. Unit tests for Requires/Ensures LessThanZero
4. Performance tests
5. Readme updates
6. Examples