### PR TITLE
S0016 less than or equal to zero

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -27,6 +27,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [GreaterThanZero Benchmarks](#greaterthanzero-benchmarks)
   - [GreaterThanOrEqualToZero Benchmarks](#greaterthanorequaltozero-benchmarks)
   - [LessThanZero Benchmarks](#lessthanzero-benchmarks)
+  - [LessThanOrEqualToZero Benchmarks](#lessthanorequaltozero-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -447,3 +448,19 @@ parameter was omitted.
 | RequiresThanZero | Decimal     |                  | X                 | 4.3049 ns | 0.0358 ns | 0.0335 ns |         - |
 | RequiresThanZero | Decimal     | X                | X                 | 4.1347 ns | 0.0837 ns | 0.0783 ns |         - |
 
+### LessThanOrEqualToZero Benchmarks
+
+| Method                        | Value Type  | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:----------------------------- |:------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresLessThanOrEqualToZero | Int32       |                  |                   | 0.2472 ns | 0.0207 ns | 0.0194 ns |         - |
+| RequiresLessThanOrEqualToZero | Int32       | X                |                   | 0.4837 ns | 0.0373 ns | 0.0349 ns |         - |
+| RequiresLessThanOrEqualToZero | Int32       |                  | X                 | 2.2319 ns | 0.0515 ns | 0.0430 ns |         - |
+| RequiresLessThanOrEqualToZero | Int32       | X                | X                 | 1.7007 ns | 0.0369 ns | 0.0328 ns |         - |
+| RequiresLessThanOrEqualToZero | Double      |                  |                   | 0.9152 ns | 0.0125 ns | 0.0117 ns |         - |
+| RequiresLessThanOrEqualToZero | Double      | X                |                   | 0.6585 ns | 0.0186 ns | 0.0174 ns |         - |
+| RequiresLessThanOrEqualToZero | Double      |                  | X                 | 1.8286 ns | 0.0418 ns | 0.0371 ns |         - |
+| RequiresLessThanOrEqualToZero | Double      | X                | X                 | 2.3557 ns | 0.0764 ns | 0.1070 ns |         - |
+| RequiresLessThanOrEqualToZero | Decimal     |                  |                   | 2.5296 ns | 0.0844 ns | 0.2407 ns |         - |
+| RequiresLessThanOrEqualToZero | Decimal     | X                |                   | 2.5169 ns | 0.0819 ns | 0.1434 ns |         - |
+| RequiresLessThanOrEqualToZero | Decimal     |                  | X                 | 4.6693 ns | 0.1231 ns | 0.2569 ns |         - |
+| RequiresLessThanOrEqualToZero | Decimal     | X                | X                 | 4.3924 ns | 0.1172 ns | 0.2852 ns |         - |

--- a/DbC.Net.Examples/LessThanOrEqualToZeroExamples.cs
+++ b/DbC.Net.Examples/LessThanOrEqualToZeroExamples.cs
@@ -1,0 +1,37 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class LessThanOrEqualToZeroExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must be less than or equal to zero";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = Double.MinValue;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresLessThanOrEqualToZero();
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresLessThanOrEqualToZero(customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresLessThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresLessThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.EnsuresLessThanOrEqualToZero();
+
+      // Postcondition with custom message template and default exception factory.
+      value.EnsuresLessThanOrEqualToZero(customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.EnsuresLessThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.EnsuresLessThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/LessThanOrEqualToZeroBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/LessThanOrEqualToZeroBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class LessThanOrEqualToZeroBenchmarks
+{
+   private const Int32 _intValue = -42;
+   private const Double _doubleValue = Double.MinValue;
+   private const Decimal _decimalValue = Decimal.MinValue;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be less than or equal to zero";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _intValue.RequiresLessThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Int32_P000()
+   {
+      var result = _intValue.RequiresLessThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Int32_P100()
+   {
+      var result = _intValue.RequiresLessThanOrEqualToZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Int32_P010()
+   {
+      var result = _intValue.RequiresLessThanOrEqualToZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Int32_P110()
+   {
+      var result = _intValue.RequiresLessThanOrEqualToZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Double_P000()
+   {
+      var result = _doubleValue.RequiresLessThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Double_P100()
+   {
+      var result = _doubleValue.RequiresLessThanOrEqualToZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Double_P010()
+   {
+      var result = _doubleValue.RequiresLessThanOrEqualToZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Double_P110()
+   {
+      var result = _doubleValue.RequiresLessThanOrEqualToZero(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Decimal_P000()
+   {
+      var result = _decimalValue.RequiresLessThanOrEqualToZero();
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Decimal_P100()
+   {
+      var result = _decimalValue.RequiresLessThanOrEqualToZero(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Decimal_P010()
+   {
+      var result = _decimalValue.RequiresLessThanOrEqualToZero(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresLessThanOrEqualToZero_Decimal_P110()
+   {
+      var result = _decimalValue.RequiresLessThanOrEqualToZero(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -10,4 +10,5 @@
 //BenchmarkRunner.Run<BetweenBenchmarks>();
 //BenchmarkRunner.Run<GreaterThanZeroBenchmarks>();
 //BenchmarkRunner.Run<GreaterThanOrEqualToZeroBenchmarks>();
-BenchmarkRunner.Run<LessThanZeroBenchmarks>();
+//BenchmarkRunner.Run<LessThanZeroBenchmarks>();
+BenchmarkRunner.Run<LessThanOrEqualToZeroBenchmarks>();

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
@@ -13,7 +13,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -52,7 +52,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
+   public void GreaterThanOrEqualToZeroExtensions_EnsuresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -159,7 +159,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanOrEqualToZero<T>(
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldNotThrow_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.
@@ -198,7 +198,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
 
    [Theory]
    [ClassData(typeof(NumberTypesTestData))]
-   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanOrEqualToZero<T>(
+   public void GreaterThanOrEqualToZeroExtensions_RequiresGreaterThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsGreaterThanZero<T>(
       IComparableTestData<T> data) where T : INumber<T>
    {
       // Arrange.

--- a/DbC.Net.Tests.Unit/LessThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualToZeroExtensionsTests.cs
@@ -1,0 +1,307 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+public class LessThanOrEqualToZeroExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresLessThanOrEqualToZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldNotThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldThrow_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+
+      // Act.
+      var result = value.EnsuresLessThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = 1;
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqualToZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = 1.5;
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero();
+      var expectedMessage = $"Postcondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = 1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero(messageTemplate);
+      var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Single.MaxValue;
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_EnsuresLessThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)1;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresLessThanOrEqualToZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresLessThanOrEqualToZero Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldNotThrow_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+      var act = () => _ = value.RequiresLessThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldNotThrow_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+      var act = () => _ = value.RequiresLessThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldThrow_WhenValueIsGreaterThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MaxValue;
+      var act = () => _ = value.RequiresLessThanOrEqualToZero();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>();
+   }
+
+   [Theory]
+   [ClassData(typeof(SignedNumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsLessThanZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = data.MinValue;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [ClassData(typeof(NumberTypesTestData))]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldReturnOriginalValue_WhenValueIsZero<T>(
+      IComparableTestData<T> data) where T : INumber<T>
+   {
+      // Arrange.
+      var value = T.Zero;
+
+      // Act.
+      var result = value.RequiresLessThanOrEqualToZero();
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = 1;
+      var act = () => _ = value.RequiresLessThanOrEqualToZero();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.LessThanOrEqualToZero);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = 1.5;
+      var act = () => _ = value.RequiresLessThanOrEqualToZero();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldThrowArgumentOutOfRangeExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = 1.5M;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqualToZero(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(value);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = Single.MaxValue;
+      var act = () => _ = value.RequiresLessThanOrEqualToZero(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void LessThanOrEqualToZeroExtensions_RequiresLessThanOrEqualToZero_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = (Half)1;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresLessThanOrEqualToZero(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\GreaterThanZero.md = Documentation\GreaterThanZero.md
 		Documentation\LessThan.md = Documentation\LessThan.md
 		Documentation\LessThanOrEqual.md = Documentation\LessThanOrEqual.md
+		Documentation\LessThanOrEqualToZero.md = Documentation\LessThanOrEqualToZero.md
 		Documentation\LessThanZero.md = Documentation\LessThanZero.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md

--- a/DbC.Net/LessThanOrEqualToZeroExtensions.cs
+++ b/DbC.Net/LessThanOrEqualToZeroExtensions.cs
@@ -1,0 +1,112 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement LessThanOrEqualToZero requirement for
+///   numeric types.
+/// </summary>
+public static class LessThanOrEqualToZeroExtensions
+{
+   private const String _requirementName = RequirementNames.LessThanOrEqualToZero;
+
+   /// <summary>
+   ///   Value LessThanOrEqualToZero postcondition. Confirm that <paramref name="value"/>
+   ///   is less than or equal to zero and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to zero".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T EnsuresLessThanOrEqualToZero<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
+   {
+      CheckLessThanOrEqualToZero(
+         value,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   Value LessThanOrEqualToZero precondition. Confirm that <paramref name="value"/>
+   ///   is less than or equal to zero and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to zero".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static T RequiresLessThanOrEqualToZero<T>(
+      this T value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!) where T : INumber<T>
+   {
+      CheckLessThanOrEqualToZero(
+         value,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   private static void CheckLessThanOrEqualToZero<T>(
+      T value,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression) where T : INumber<T>
+   {
+      if (value.CompareTo(T.Zero) > 0)
+      {
+         messageTemplate ??= MessageTemplates.LessThanOrEqualToZeroTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentOutOfRangeFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -133,6 +133,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to zero.
+        /// </summary>
+        internal static string LessThanOrEqualToZeroTemplate {
+            get {
+                return ResourceManager.GetString("LessThanOrEqualToZeroTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be less than {UpperBound}.
         /// </summary>
         internal static string LessThanTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -141,6 +141,9 @@
   <data name="LessThanOrEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to {UpperBound}</value>
   </data>
+  <data name="LessThanOrEqualToZeroTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to zero</value>
+  </data>
   <data name="LessThanTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than {UpperBound}</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -14,6 +14,7 @@ public static class RequirementNames
    public const String GreaterThanZero = nameof(GreaterThanZero);
    public const String LessThan = nameof(LessThan);
    public const String LessThanOrEqual = nameof(LessThanOrEqual);
+   public const String LessThanOrEqualToZero = nameof(LessThanOrEqualToZero);
    public const String LessThanZero = nameof(LessThanZero);
    public const String NotDefault = nameof(NotDefault);
    public const String NotEqual = nameof(NotEqual);

--- a/Documentation/LessThanOrEqualToZero.md
+++ b/Documentation/LessThanOrEqualToZero.md
@@ -3,8 +3,6 @@
 LessThanOrEqualToZero requires that the INumber<T> value being checked be less 
 than or equal to zero.
 
-NOTE: Unsigned numeric types will always fail LessThanOrEqualToZero.
-
 **Method signatures:**
 ```C#
 T RequiresLessThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>

--- a/Documentation/LessThanOrEqualToZero.md
+++ b/Documentation/LessThanOrEqualToZero.md
@@ -1,0 +1,54 @@
+### LessThanOrEqualToZero
+
+LessThanOrEqualToZero requires that the INumber<T> value being checked be less 
+than or equal to zero.
+
+NOTE: Unsigned numeric types will always fail LessThanOrEqualToZero.
+
+**Method signatures:**
+```C#
+T RequiresLessThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
+
+T EnsuresLessThanOrEqualToZero<T>(this T value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null]) where T : INumber<T>
+```
+
+The default message template for LessThanOrEqualToZero is "{RequirementType} {RequirementName} failed: {ValueExpression} must be less than or equal to zero".
+The default exception factory for RequiresLessThanOrEqualToZero is StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresLessThanOrEqualToZero.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, and ValueExpression.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be less than or equal to zero";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = Double.MinValue;
+
+// Precondition with default message template and default exception factory.
+value.RequiresLessThanOrEqualToZero();
+
+// Precondition with custom message template and default exception factory.
+value.RequiresLessThanOrEqualToZero(customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresLessThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresLessThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.EnsuresLessThanOrEqualToZero();
+
+// Postcondition with custom message template and default exception factory.
+value.EnsuresLessThanOrEqualToZero(customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.EnsuresLessThanOrEqualToZero(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.EnsuresLessThanOrEqualToZero(customMessageTemplate, customExceptionFactory);
+```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
     - [GreaterThanOrEqualToZero](/Documentation/GreaterThanOrEqualToZero.md)
     - [LessThan](/Documentation/LessThan.md)
     - [LessThanOrEqual](/Documentation/LessThanOrEqual.md)
+    - [LessThanOrEqualToZero](/Documentation/LessThanOrEqualToZero.md)
     - [LessThanZero](/Documentation/LessThanZero.md)
     - [Between](/Documentation/Between.md)
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a numeric value is less than or equal to zero.

Requirements:

  RequiresLessThanOrEqualToZero (precondition), default ArgumentOutOfRangeException
  EnsuresLessThanOrEqualToZero (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresLessThanOrEqualToZero
2. Implement EnsuresLessThanOrEqualToZero
3. Unit tests for Requires/Ensures LessThanOrEqualToZero
4. Performance tests
5. Readme updates
6. Examples