### PR TITLE
S0017 max length

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -29,6 +29,8 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [LessThanZero Benchmarks](#lessthanzero-benchmarks)
   - [LessThanOrEqualToZero Benchmarks](#lessthanorequaltozero-benchmarks)
 
+  - [MaxLength Benchmarks](#maxlength-benchmarks)
+
 ### NotNull Benchmarks
 
 X indicates that the optional parameter was supplied; blank indicates that the 
@@ -464,3 +466,24 @@ parameter was omitted.
 | RequiresLessThanOrEqualToZero | Decimal     | X                |                   | 2.5169 ns | 0.0819 ns | 0.1434 ns |         - |
 | RequiresLessThanOrEqualToZero | Decimal     |                  | X                 | 4.6693 ns | 0.1231 ns | 0.2569 ns |         - |
 | RequiresLessThanOrEqualToZero | Decimal     | X                | X                 | 4.3924 ns | 0.1172 ns | 0.2852 ns |         - |
+
+### MaxLength Benchmarks
+
+| Method            | String content              | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:----------------- |:----------------------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresMaxLength | Non-empty string            |                  |                   | 0.0070 ns | 0.0112 ns | 0.0105 ns |         - |
+| RequiresMaxLength | Non-empty string            | X                |                   | 0.0280 ns | 0.0280 ns | 0.0262 ns |         - |
+| RequiresMaxLength | Non-empty string            |                  | X                 | 2.6625 ns | 0.0476 ns | 0.0445 ns |         - |
+| RequiresMaxLength | Non-empty string            | X                | X                 | 2.5481 ns | 0.0178 ns | 0.0158 ns |         - |
+| RequiresMaxLength | String w/Unicode characters |                  |                   | 0.0095 ns | 0.0108 ns | 0.0101 ns |         - |
+| RequiresMaxLength | String w/Unicode characters | X                |                   | 0.0078 ns | 0.0077 ns | 0.0064 ns |         - |
+| RequiresMaxLength | String w/Unicode characters |                  | X                 | 2.8855 ns | 0.0447 ns | 0.0396 ns |         - |
+| RequiresMaxLength | String w/Unicode characters | X                | X                 | 2.6974 ns | 0.0271 ns | 0.0240 ns |         - |
+| RequiresMaxLength | Null String                 |                  |                   | 0.0017 ns | 0.0040 ns | 0.0035 ns |         - |
+| RequiresMaxLength | Null String                 | X                |                   | 0.0065 ns | 0.0116 ns | 0.0103 ns |         - |
+| RequiresMaxLength | Null String                 |                  | X                 | 2.5399 ns | 0.0218 ns | 0.0182 ns |         - |
+| RequiresMaxLength | Null String                 | X                | X                 | 2.4789 ns | 0.0114 ns | 0.0101 ns |         - |
+| RequiresMaxLength | Empty String                |                  |                   | 0.0032 ns | 0.0044 ns | 0.0041 ns |         - |
+| RequiresMaxLength | Empty String                | X                |                   | 0.0115 ns | 0.0162 ns | 0.0152 ns |         - |
+| RequiresMaxLength | Empty String                |                  | X                 | 2.8678 ns | 0.0251 ns | 0.0223 ns |         - |
+| RequiresMaxLength | Empty String                | X                | X                 | 2.6799 ns | 0.0155 ns | 0.0129 ns |         - |

--- a/DbC.Net.Examples/MaxLengthExamples.cs
+++ b/DbC.Net.Examples/MaxLengthExamples.cs
@@ -1,0 +1,38 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class MaxLengthExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} may not exceed 10 characters in length";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
+      var maxLength = 10;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresMaxLength(maxLength);
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresMaxLength(maxLength, customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.RequiresMaxLength(maxLength);
+
+      // Postcondition with custom message template and default exception factory.
+      value.RequiresMaxLength(maxLength, customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.RequiresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/MaxLengthBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/MaxLengthBenchmarks.cs
@@ -1,0 +1,117 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class MaxLengthBenchmarks
+{
+   private const String _strEmpty = "";
+   private const String _strNull = null!;
+   private const String _strValue = "abcdefghij";
+   private const String _strValueWithUnicodeCharacters = "\u00C5\u00E5\u00C6\u00E6\u1E9E\u00DF\u0130\u0131\u00D8\u00F8";
+
+   private const Int32 _maxLength = 10;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must not be longer than 10 characters";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _strValue.RequiresMaxLength(_maxLength);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_String_P000()
+   {
+      var result = _strValue.RequiresMaxLength(_maxLength);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_String_P100()
+   {
+      var result = _strValue.RequiresMaxLength(_maxLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_String_P010()
+   {
+      var result = _strValue.RequiresMaxLength(_maxLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_String_P110()
+   {
+      var result = _strValue.RequiresMaxLength(_maxLength, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_StringWithUnicode_P000()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMaxLength(_maxLength);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_StringWithUnicode_P100()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMaxLength(_maxLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_StringWithUnicode_P010()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMaxLength(_maxLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_StringWithUnicode_P110()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMaxLength(_maxLength, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_NullString_P000()
+   {
+      var result = _strNull.RequiresMaxLength(_maxLength);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_NullString_P100()
+   {
+      var result = _strNull.RequiresMaxLength(_maxLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_NullString_P010()
+   {
+      var result = _strNull.RequiresMaxLength(_maxLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_NullString_P110()
+   {
+      var result = _strNull.RequiresMaxLength(_maxLength, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_EmptyString_P000()
+   {
+      var result = _strEmpty.RequiresMaxLength(_maxLength);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_EmptyString_P100()
+   {
+      var result = _strEmpty.RequiresMaxLength(_maxLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_EmptyString_P010()
+   {
+      var result = _strEmpty.RequiresMaxLength(_maxLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMaxLength_EmptyString_P110()
+   {
+      var result = _strEmpty.RequiresMaxLength(_maxLength, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -11,4 +11,5 @@
 //BenchmarkRunner.Run<GreaterThanZeroBenchmarks>();
 //BenchmarkRunner.Run<GreaterThanOrEqualToZeroBenchmarks>();
 //BenchmarkRunner.Run<LessThanZeroBenchmarks>();
-BenchmarkRunner.Run<LessThanOrEqualToZeroBenchmarks>();
+//BenchmarkRunner.Run<LessThanOrEqualToZeroBenchmarks>();
+BenchmarkRunner.Run<MaxLengthBenchmarks>();

--- a/DbC.Net.Tests.Unit/Exceptions/ExceptionDataBuilderTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ExceptionDataBuilderTests.cs
@@ -295,6 +295,73 @@ public class ExceptionDataBuilderTests
 
    #endregion
 
+   #region WithMaxLength Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMaxLength_ShouldAddMaxLengthAndMaxLengthExpressionItems()
+   {
+      // Arrange.
+      var maxLength = 100;
+      var maxLengthExpression = nameof(maxLength);
+      var expectedCount = 2;
+
+      var sut = ExceptionDataBuilder.Create();
+
+      // Act.
+      sut.WithMaxLength(maxLength, maxLengthExpression);
+
+      // Assert.
+      var data = sut.Build();
+      data.Should().HaveCount(expectedCount);
+      data[DataNames.MaxLength].Should().Be(maxLength);
+      data[DataNames.MaxLengthExpression].Should().Be(maxLengthExpression);
+   }
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMaxLength_ShouldReturnReferenceToSelf()
+   {
+      // Arrange.
+      var sut = ExceptionDataBuilder.Create();
+
+      // Act.
+      var result = sut.WithMaxLength(99, "maxLength");
+
+      // Assert.
+      result.Should().Be(sut);
+   }
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMaxLength_ShouldThrowArgumentException_WhenMaxLengthExpressionIsEmpty()
+   {
+      // Arrange.
+      var maxLength = 100;
+      var maxLengthExpression = String.Empty;
+      var sut = ExceptionDataBuilder.Create();
+      var act = () => _ = sut.WithMaxLength(maxLength, maxLengthExpression);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(nameof(maxLengthExpression));
+   }
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMaxLength_ShouldThrowArgumentNullException_WhenMaxLengthExpressionIsNull()
+   {
+      // Arrange.
+      var maxLength = 100;
+      String maxLengthExpression = null!;
+      var sut = ExceptionDataBuilder.Create();
+      var act = () => _ = sut.WithMaxLength(maxLength, maxLengthExpression);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(maxLengthExpression));
+   }
+
+   #endregion
+
    #region WithRequirement Method Tests
    // ==========================================================================
    // ==========================================================================

--- a/DbC.Net.Tests.Unit/MaxLengthExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/MaxLengthExtensionsTests.cs
@@ -1,0 +1,498 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class MaxLengthExtensionsTests
+{
+   private const Int32 _dataCount = 6;
+
+   #region EnsuresMaxLength Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   {
+      // Arrange.
+      var value = "qwerty";
+      var maxLength = 6;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenValueIsNullOrEmptyAndMaxLengthIsZero(String value)
+   {
+      // Arrange.
+      var maxLength = 0;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrow_WhenValueHasLengthGreaterThanMaxLength()
+   {
+      // Arrange.
+      var value = "abcdefghijklmnopqrstuvwxyz";
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 10;
+
+      // Act.
+      var result = value.EnsuresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   {
+      // Arrange.
+      var value = "qwerty";
+      var maxLength = 6;
+
+      // Act.
+      var result = value.EnsuresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var maxLength = 10;
+
+      // Act.
+      var result = value.EnsuresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var maxLength = 10;
+
+      // Act.
+      var result = value.EnsuresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenValueIsNullOrEmptyAndMaxLengthIsZero(String value)
+   {
+      // Arrange.
+      var maxLength = 0;
+
+      // Act.
+      var result = value.EnsuresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowArgumentOutOfRangeException_WhenMaxLengthIsNegative()
+   {
+      // Arrange.
+      var value = "asdf";
+      var maxLength = -1;
+      var expectedMessage = Messages.MaxLengthIsNegative;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(nameof(maxLength))
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(maxLength);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = "abcdefghijklmnopqrstuvwxyz";
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.MaxLength);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.MaxLength].Should().Be(maxLength);
+      ex.Data[DataNames.MaxLengthExpression].Should().Be(nameof(maxLength));
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 1;
+      var act = () => _ = value.EnsuresMaxLength(maxLength);
+      var expectedMessage = $"Postcondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "a";
+      var maxLength = 0;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresMaxLength(maxLength, messageTemplate);
+      var expectedMessage = $"Requirement MaxLength failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 1;
+      var act = () => _ = value.EnsuresMaxLength(maxLength, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 1;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresMaxLength(maxLength, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement MaxLength failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresMaxLength Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   {
+      // Arrange.
+      var value = "qwerty";
+      var maxLength = 6;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenValueIsNullOrEmptyAndMaxLengthIsZero(String value)
+   {
+      // Arrange.
+      var maxLength = 0;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrow_WhenValueHasLengthGreaterThanMaxLength()
+   {
+      // Arrange.
+      var value = "abcdefghijklmnopqrstuvwxyz";
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 10;
+
+      // Act.
+      var result = value.RequiresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   {
+      // Arrange.
+      var value = "qwerty";
+      var maxLength = 6;
+
+      // Act.
+      var result = value.RequiresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var maxLength = 10;
+
+      // Act.
+      var result = value.RequiresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var maxLength = 10;
+
+      // Act.
+      var result = value.RequiresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenValueIsNullOrEmptyAndMaxLengthIsZero(String value)
+   {
+      // Arrange.
+      var maxLength = 0;
+
+      // Act.
+      var result = value.RequiresMaxLength(maxLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentOutOfRangeException_WhenMaxLengthIsNegative()
+   {
+      // Arrange.
+      var value = "asdf";
+      var maxLength = -1;
+      var expectedMessage = Messages.MaxLengthIsNegative;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(nameof(maxLength))
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(maxLength);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = "abcdefghijklmnopqrstuvwxyz";
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.MaxLength);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.MaxLength].Should().Be(maxLength);
+      ex.Data[DataNames.MaxLengthExpression].Should().Be(nameof(maxLength));
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 1;
+      var act = () => _ = value.RequiresMaxLength(maxLength);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "a";
+      var maxLength = 0;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresMaxLength(maxLength, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement MaxLength failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 1;
+      var act = () => _ = value.RequiresMaxLength(maxLength, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var maxLength = 1;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresMaxLength(maxLength, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement MaxLength failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/MaxLengthExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/MaxLengthExtensionsTests.cs
@@ -4,28 +4,40 @@ public class MaxLengthExtensionsTests
 {
    private const Int32 _dataCount = 6;
 
+   public static TheoryData<String> TenCharacterStrings => new()
+   {
+      { "abcdefghij" },
+      { 
+         StringData.LowerCaseAWithDiaeresis + StringData.LowerCaseAWithOverring +
+         StringData.LowerCaseDiphthongAE + StringData.LowerCaseDotlessI +
+         StringData.LowerCaseEszett + StringData.LowerCaseOWithDiaeresis +
+         StringData.UpperCaseSlashedO + StringData.UpperCaseOWithDiaeresis +
+         StringData.UpperCaseDottedI + StringData.UpperCaseAWithOverring
+      }
+   };
+
    #region EnsuresMaxLength Tests
    // ==========================================================================
    // ==========================================================================
 
-   [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength(String value)
    {
       // Arrange.
-      var value = "abc";
-      var maxLength = 10;
+      var maxLength = 11;
       var act = () => _ = value.EnsuresMaxLength(maxLength);
 
       // Act/assert.
       act.Should().NotThrow();
    }
 
-   [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthEqualToMaxLength(String value)
    {
       // Arrange.
-      var value = "qwerty";
-      var maxLength = 6;
+      var maxLength = 10;
       var act = () => _ = value.EnsuresMaxLength(maxLength);
 
       // Act/assert.
@@ -69,24 +81,24 @@ public class MaxLengthExtensionsTests
       act.Should().NotThrow();
    }
 
-   [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrow_WhenValueHasLengthGreaterThanMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrow_WhenValueHasLengthGreaterThanMaxLength(String value)
    {
       // Arrange.
-      var value = "abcdefghijklmnopqrstuvwxyz";
-      var maxLength = 10;
+      var maxLength = 9;
       var act = () => _ = value.EnsuresMaxLength(maxLength);
 
       // Act/assert.
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength(String value)
    {
       // Arrange.
-      var value = "abc";
-      var maxLength = 10;
+      var maxLength = 11;
 
       // Act.
       var result = value.EnsuresMaxLength(maxLength);
@@ -95,12 +107,12 @@ public class MaxLengthExtensionsTests
       result.Should().Be(value);
    }
 
-   [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthEqualToMaxLength(String value)
    {
       // Arrange.
-      var value = "qwerty";
-      var maxLength = 6;
+      var maxLength = 10;
 
       // Act.
       var result = value.EnsuresMaxLength(maxLength);
@@ -252,24 +264,24 @@ public class MaxLengthExtensionsTests
    // ==========================================================================
    // ==========================================================================
 
-   [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength(String value)
    {
       // Arrange.
-      var value = "abc";
-      var maxLength = 10;
+      var maxLength = 11;
       var act = () => _ = value.RequiresMaxLength(maxLength);
 
       // Act/assert.
       act.Should().NotThrow();
    }
 
-   [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthEqualToMaxLength(String value)
    {
       // Arrange.
-      var value = "qwerty";
-      var maxLength = 6;
+      var maxLength = 10;
       var act = () => _ = value.RequiresMaxLength(maxLength);
 
       // Act/assert.
@@ -313,24 +325,24 @@ public class MaxLengthExtensionsTests
       act.Should().NotThrow();
    }
 
-   [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrow_WhenValueHasLengthGreaterThanMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrow_WhenValueHasLengthGreaterThanMaxLength(String value)
    {
       // Arrange.
-      var value = "abcdefghijklmnopqrstuvwxyz";
-      var maxLength = 10;
+      var maxLength = 9;
       var act = () => _ = value.RequiresMaxLength(maxLength);
 
       // Act/assert.
       act.Should().Throw<ArgumentException>();
    }
 
-   [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessThanMaxLength(String value)
    {
       // Arrange.
-      var value = "abc";
-      var maxLength = 10;
+      var maxLength = 11;
 
       // Act.
       var result = value.RequiresMaxLength(maxLength);
@@ -339,12 +351,12 @@ public class MaxLengthExtensionsTests
       result.Should().Be(value);
    }
 
-   [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthLessEqualToMaxLength()
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthEqualToMaxLength(String value)
    {
       // Arrange.
-      var value = "qwerty";
-      var maxLength = 6;
+      var maxLength = 10;
 
       // Act.
       var result = value.RequiresMaxLength(maxLength);

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -34,6 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\LessThanOrEqual.md = Documentation\LessThanOrEqual.md
 		Documentation\LessThanOrEqualToZero.md = Documentation\LessThanOrEqualToZero.md
 		Documentation\LessThanZero.md = Documentation\LessThanZero.md
+		Documentation\MaxLength.md = Documentation\MaxLength.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md

--- a/DbC.Net/Exceptions/ExceptionDataBuilder.cs
+++ b/DbC.Net/Exceptions/ExceptionDataBuilder.cs
@@ -129,6 +129,35 @@ public class ExceptionDataBuilder
    }
 
    /// <summary>
+   ///   Add max length information to the exception data dictionary.
+   /// </summary>
+   /// <param name="maxLength">
+   ///   The max length value.
+   /// </param>
+   /// <param name="maxLengthExpression">
+   ///   The max length parameter expression in the calling method.
+   /// </param>
+   /// <returns>
+   ///   A reference to this <see cref="ExceptionDataBuilder"/> object to 
+   ///   support method chaining.
+   /// </returns>
+   /// <exception cref="ArgumentException">
+   ///   <paramref name="maxLengthExpression"/> is <see cref="String.Empty"/>.
+   /// </exception>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="maxLengthExpression"/> is <see langword="null"/>.
+   /// </exception>
+   public ExceptionDataBuilder WithMaxLength(Int32 maxLength, String maxLengthExpression)
+   {
+      ArgumentException.ThrowIfNullOrEmpty(maxLengthExpression, nameof(maxLengthExpression));
+
+      _data[DataNames.MaxLength] = maxLength;
+      _data[DataNames.MaxLengthExpression] = maxLengthExpression;
+
+      return this;
+   }
+
+   /// <summary>
    ///   Add requirement information to the exception data dictionary.
    /// </summary>
    /// <param name="requirementType">

--- a/DbC.Net/MaxLengthExtensions.cs
+++ b/DbC.Net/MaxLengthExtensions.cs
@@ -1,0 +1,149 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement string MaxLength requirement.
+/// </summary>
+public static class MaxLengthExtensions
+{
+   private const String _requirementName = RequirementNames.MaxLength;
+
+   /// <summary>
+   ///   String MaxLength postcondition. Confirm that the length of the 
+   ///   <paramref name="value"/> is less than or equal to the 
+   ///   <paramref name="maxLength"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="maxLength">
+   ///   The maximum allowed length of the string <paramref name="value"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must have a maximum length of {MaxLength}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="maxLengthExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="maxLength"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentOutOfRangeException">
+   ///   <paramref name="maxLength"/> is negative.
+   /// </exception>
+   public static String EnsuresMaxLength(
+      this String value,
+      Int32 maxLength,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(maxLength))] String maxLengthExpression = null!)
+   {
+      CheckMaxLength(
+         value,
+         maxLength,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         maxLengthExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   String MaxLength precondition. Confirm that the length of the 
+   ///   <paramref name="value"/> is less than or equal to the 
+   ///   <paramref name="maxLength"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="maxLength">
+   ///   The maximum allowed length of the string <paramref name="value"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must have a maximum length of {MaxLength}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="maxLengthExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="maxLength"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentOutOfRangeException">
+   ///   <paramref name="maxLength"/> is negative.
+   /// </exception>
+   public static String RequiresMaxLength(
+      this String value,
+      Int32 maxLength,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(maxLength))] String maxLengthExpression = null!)
+   {
+      CheckMaxLength(
+         value,
+         maxLength,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         maxLengthExpression);
+
+      return value;
+   }
+
+   private static void CheckMaxLength(
+      String value,
+      Int32 maxLength,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String maxLengthExpression)
+   {
+      if (maxLength < 0)
+      {
+         throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, Messages.MaxLengthIsNegative);
+      }
+
+      if ((value?.Length ?? 0) > maxLength)
+      {
+         messageTemplate ??= MessageTemplates.MaxLengthTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithMaxLength(maxLength, maxLengthExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -160,6 +160,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must have a maximum length of {MaxLength}.
+        /// </summary>
+        internal static string MaxLengthTemplate {
+            get {
+                return ResourceManager.GetString("MaxLengthTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype}).
         /// </summary>
         internal static string NotDefaultTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -150,6 +150,9 @@
   <data name="LessThanZeroTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be less than zero</value>
   </data>
+  <data name="MaxLengthTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must have a maximum length of {MaxLength}</value>
+  </data>
   <data name="NotDefaultTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
   </data>

--- a/DbC.Net/Messages.Designer.cs
+++ b/DbC.Net/Messages.Designer.cs
@@ -142,6 +142,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MaxLength may not be negative.
+        /// </summary>
+        internal static string MaxLengthIsNegative {
+            get {
+                return ResourceManager.GetString("MaxLengthIsNegative", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Message template may not be null, String.Empty or all whitespace characters.
         /// </summary>
         internal static string MessageTemplateIsEmpty {

--- a/DbC.Net/Messages.resx
+++ b/DbC.Net/Messages.resx
@@ -144,6 +144,9 @@
   <data name="MaskCharacterIsNull" xml:space="preserve">
     <value>Mask character may not be null ('\0')</value>
   </data>
+  <data name="MaxLengthIsNegative" xml:space="preserve">
+    <value>MaxLength may not be negative</value>
+  </data>
   <data name="MessageTemplateIsEmpty" xml:space="preserve">
     <value>Message template may not be null, String.Empty or all whitespace characters</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -16,6 +16,7 @@ public static class RequirementNames
    public const String LessThanOrEqual = nameof(LessThanOrEqual);
    public const String LessThanOrEqualToZero = nameof(LessThanOrEqualToZero);
    public const String LessThanZero = nameof(LessThanZero);
+   public const String MaxLength = nameof(MaxLength);
    public const String NotDefault = nameof(NotDefault);
    public const String NotEqual = nameof(NotEqual);
    public const String NotNull = nameof(NotNull);

--- a/Documentation/MaxLength.md
+++ b/Documentation/MaxLength.md
@@ -1,0 +1,28 @@
+### MaxLength
+
+MaxLength requires that the string value being checked has a length that does not
+exceed the specified maximum length. MaxLength treats a null string as a zero 
+length string.
+
+RequiresMaxLength and EnsuresMaxLength overloads will throw an ArgumentOutOfRangeException
+if the supplied maxLength is negative.
+
+**Method signatures:**
+```C#
+String RequiresMaxLength(this String value, Int32 maxLength, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? maxLengthExpression = null])
+
+String EnsuresMaxLength(this String value, Int32 maxLength, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? maxLengthExpression = null])
+```
+
+The default message template for MaxLength is "{RequirementType} {RequirementName} failed: {ValueExpression} must have a maximum length of {MaxLength}".
+The default exception factory for RequiresMaxLength is StandardExceptionFactories.ArgumentExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresMaxLength.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, MaxLength and MaxLengthExpression.
+
+**Examples:**
+```C#
+```
+

--- a/Documentation/MaxLength.md
+++ b/Documentation/MaxLength.md
@@ -24,5 +24,35 @@ RequirementName, Value, ValueExpression, MaxLength and MaxLengthExpression.
 
 **Examples:**
 ```C#
+var customMessageTemplate = "{ValueExpression} may not exceed 10 characters in length";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
+var maxLength = 10;
+
+// Precondition with default message template and default exception factory.
+value.RequiresMaxLength(maxLength);
+
+// Precondition with custom message template and default exception factory.
+value.RequiresMaxLength(maxLength, customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.RequiresMaxLength(maxLength);
+
+// Postcondition with custom message template and default exception factory.
+value.RequiresMaxLength(maxLength, customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.RequiresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/Stories/S0017-MaxLength.txt
+++ b/Documentation/Stories/S0017-MaxLength.txt
@@ -4,7 +4,6 @@ Requirements:
 
   RequiresMaxLength (precondition), default ArgumentException
   EnsuresMaxLength (postcondition), default PostconditionFailedException
-  Support supplying IComparer<T> object to perform the comparison
 
 DEFINITION OF DONE:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@
     - [LessThanZero](/Documentation/LessThanZero.md)
     - [Between](/Documentation/Between.md)
 
+  - String Requirements
+
+    - [MaxLength](/Documentation/MaxLength.md)
+
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 
 	- Not currently released


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value does not exceed a target maximum length. 

Requirements:

  RequiresMaxLength (precondition), default ArgumentException
  EnsuresMaxLength (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresMaxLength
2. Implement EnsuresMaxLength
3. Unit tests for Requires/Ensures MaxLength
4. Performance tests
5. Readme updates
6. Examples