### PR TITLE
S0018 min length

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -30,6 +30,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [LessThanOrEqualToZero Benchmarks](#lessthanorequaltozero-benchmarks)
 
   - [MaxLength Benchmarks](#maxlength-benchmarks)
+  - [MinLength Benchmarks](#minlength-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -487,3 +488,25 @@ parameter was omitted.
 | RequiresMaxLength | Empty String                | X                |                   | 0.0115 ns | 0.0162 ns | 0.0152 ns |         - |
 | RequiresMaxLength | Empty String                |                  | X                 | 2.8678 ns | 0.0251 ns | 0.0223 ns |         - |
 | RequiresMaxLength | Empty String                | X                | X                 | 2.6799 ns | 0.0155 ns | 0.0129 ns |         - |
+
+### MinLength Benchmarks
+
+| Method            | String content              | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:----------------- |:----------------------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresMinLength | Non-empty string            |                  |                   | 0.0003 ns | 0.0011 ns | 0.0009 ns |         - |
+| RequiresMinLength | Non-empty string            | X                |                   | 0.0002 ns | 0.0009 ns | 0.0008 ns |         - |
+| RequiresMinLength | Non-empty string            |                  | X                 | 2.6453 ns | 0.0178 ns | 0.0149 ns |         - |
+| RequiresMinLength | Non-empty string            | X                | X                 | 2.5455 ns | 0.0158 ns | 0.0132 ns |         - |
+| RequiresMinLength | String w/Unicode characters |                  |                   | 0.0033 ns | 0.0071 ns | 0.0059 ns |         - |
+| RequiresMinLength | String w/Unicode characters | X                |                   | 0.0022 ns | 0.0043 ns | 0.0038 ns |         - |
+| RequiresMinLength | String w/Unicode characters |                  | X                 | 2.8725 ns | 0.0290 ns | 0.0257 ns |         - |
+| RequiresMinLength | String w/Unicode characters | X                | X                 | 2.7093 ns | 0.0272 ns | 0.0241 ns |         - |
+| RequiresMinLength | Null String                 |                  |                   | 0.0045 ns | 0.0078 ns | 0.0073 ns |         - |
+| RequiresMinLength | Null String                 | X                |                   | 0.0051 ns | 0.0062 ns | 0.0058 ns |         - |
+| RequiresMinLength | Null String                 |                  | X                 | 2.5437 ns | 0.0321 ns | 0.0300 ns |         - |
+| RequiresMinLength | Null String                 | X                | X                 | 2.7542 ns | 0.0762 ns | 0.0713 ns |         - |
+| RequiresMinLength | Empty String                |                  |                   | 0.0001 ns | 0.0002 ns | 0.0002 ns |         - |
+| RequiresMinLength | Empty String                | X                |                   | 0.0008 ns | 0.0019 ns | 0.0017 ns |         - |
+| RequiresMinLength | Empty String                |                  | X                 | 2.6954 ns | 0.0259 ns | 0.0230 ns |         - |
+| RequiresMinLength | Empty String                | X                | X                 | 2.6405 ns | 0.0316 ns | 0.0264 ns |         - |
+

--- a/DbC.Net.Examples/MinLengthExamples.cs
+++ b/DbC.Net.Examples/MinLengthExamples.cs
@@ -1,0 +1,38 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class MinLengthExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} may not be less than 10 characters in length";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = "ABC";
+      var minLength = 10;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresMinLength(minLength);
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresMinLength(minLength, customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresMinLength(minLength, exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.RequiresMinLength(minLength);
+
+      // Postcondition with custom message template and default exception factory.
+      value.RequiresMinLength(minLength, customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.RequiresMinLength(minLength, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/MinLengthBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/MinLengthBenchmarks.cs
@@ -1,0 +1,118 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class MinLengthBenchmarks
+{
+   private const String _strEmpty = "";
+   private const String _strNull = null!;
+   private const String _strValue = "abcdefghij";
+   private const String _strValueWithUnicodeCharacters = "\u00C5\u00E5\u00C6\u00E6\u1E9E\u00DF\u0130\u0131\u00D8\u00F8";
+
+   private const Int32 _minLength = 5;
+   private const Int32 _emptyStringMinLength = 0;
+
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be at least 10 characters in length";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _strValue.RequiresMinLength(_minLength);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_String_P000()
+   {
+      var result = _strValue.RequiresMinLength(_minLength);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_String_P100()
+   {
+      var result = _strValue.RequiresMinLength(_minLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_String_P010()
+   {
+      var result = _strValue.RequiresMinLength(_minLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_String_P110()
+   {
+      var result = _strValue.RequiresMinLength(_minLength, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_StringWithUnicode_P000()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMinLength(_minLength);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_StringWithUnicode_P100()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMinLength(_minLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_StringWithUnicode_P010()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMinLength(_minLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_StringWithUnicode_P110()
+   {
+      var result = _strValueWithUnicodeCharacters.RequiresMinLength(_minLength, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_NullString_P000()
+   {
+      var result = _strNull.RequiresMinLength(_emptyStringMinLength);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_NullString_P100()
+   {
+      var result = _strNull.RequiresMinLength(_emptyStringMinLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_NullString_P010()
+   {
+      var result = _strNull.RequiresMinLength(_emptyStringMinLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_NullString_P110()
+   {
+      var result = _strNull.RequiresMinLength(_emptyStringMinLength, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_EmptyString_P000()
+   {
+      var result = _strEmpty.RequiresMinLength(_emptyStringMinLength);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_EmptyString_P100()
+   {
+      var result = _strEmpty.RequiresMinLength(_emptyStringMinLength, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_EmptyString_P010()
+   {
+      var result = _strEmpty.RequiresMinLength(_emptyStringMinLength, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresMinLength_EmptyString_P110()
+   {
+      var result = _strEmpty.RequiresMinLength(_emptyStringMinLength, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -12,4 +12,5 @@
 //BenchmarkRunner.Run<GreaterThanOrEqualToZeroBenchmarks>();
 //BenchmarkRunner.Run<LessThanZeroBenchmarks>();
 //BenchmarkRunner.Run<LessThanOrEqualToZeroBenchmarks>();
-BenchmarkRunner.Run<MaxLengthBenchmarks>();
+//BenchmarkRunner.Run<MaxLengthBenchmarks>();
+BenchmarkRunner.Run<MinLengthBenchmarks>();

--- a/DbC.Net.Tests.Unit/Exceptions/ExceptionDataBuilderTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ExceptionDataBuilderTests.cs
@@ -362,6 +362,73 @@ public class ExceptionDataBuilderTests
 
    #endregion
 
+   #region WithMinLength Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMinLength_ShouldAddMinLengthAndMinLengthExpressionItems()
+   {
+      // Arrange.
+      var minLength = 100;
+      var minLengthExpression = nameof(minLength);
+      var expectedCount = 2;
+
+      var sut = ExceptionDataBuilder.Create();
+
+      // Act.
+      sut.WithMinLength(minLength, minLengthExpression);
+
+      // Assert.
+      var data = sut.Build();
+      data.Should().HaveCount(expectedCount);
+      data[DataNames.MinLength].Should().Be(minLength);
+      data[DataNames.MinLengthExpression].Should().Be(minLengthExpression);
+   }
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMinLength_ShouldReturnReferenceToSelf()
+   {
+      // Arrange.
+      var sut = ExceptionDataBuilder.Create();
+
+      // Act.
+      var result = sut.WithMinLength(99, "minLength");
+
+      // Assert.
+      result.Should().Be(sut);
+   }
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMinLength_ShouldThrowArgumentException_WhenMinLengthExpressionIsEmpty()
+   {
+      // Arrange.
+      var minLength = 100;
+      var minLengthExpression = String.Empty;
+      var sut = ExceptionDataBuilder.Create();
+      var act = () => _ = sut.WithMinLength(minLength, minLengthExpression);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(nameof(minLengthExpression));
+   }
+
+   [Fact]
+   public void ExceptionDataBuilder_WithMinLength_ShouldThrowArgumentNullException_WhenMinLengthExpressionIsNull()
+   {
+      // Arrange.
+      var minLength = 100;
+      String minLengthExpression = null!;
+      var sut = ExceptionDataBuilder.Create();
+      var act = () => _ = sut.WithMinLength(minLength, minLengthExpression);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(nameof(minLengthExpression));
+   }
+
+   #endregion
+
    #region WithRequirement Method Tests
    // ==========================================================================
    // ==========================================================================

--- a/DbC.Net.Tests.Unit/MinLengthExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/MinLengthExtensionsTests.cs
@@ -1,0 +1,454 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class MinLengthExtensionsTests
+{
+   private const Int32 _dataCount = 6;
+
+   public static TheoryData<String> TenCharacterStrings => new()
+   {
+      { "abcdefghij" },
+      {
+         StringData.LowerCaseAWithDiaeresis + StringData.LowerCaseAWithOverring +
+         StringData.LowerCaseDiphthongAE + StringData.LowerCaseDotlessI +
+         StringData.LowerCaseEszett + StringData.LowerCaseOWithDiaeresis +
+         StringData.UpperCaseSlashedO + StringData.UpperCaseOWithDiaeresis +
+         StringData.UpperCaseDottedI + StringData.UpperCaseAWithOverring
+      }
+   };
+
+   #region EnsuresMinLength Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthGreaterThanMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 9;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthEqualToMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 10;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldNotThrow_WhenValueIsNullOrEmptyAndMinLengthIsZero(String value)
+   {
+      // Arrange.
+      var minLength = 0;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrow_WhenValueHasLengthGreaterThanMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 11;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrow_WhenValueIsNullAndMinLengthIsGreaterThanZero()
+   {
+      // Arrange.
+      String value = null!;
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMinLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrow_WhenValueIsEmptyAndMinLengthIsGreaterThanZero()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var maxLength = 10;
+      var act = () => _ = value.EnsuresMinLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthGreaterThanMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 9;
+
+      // Assert.
+      var result = _ = value.EnsuresMinLength(minLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthEqualToMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 10;
+
+      // Assert.
+      var result = _ = value.EnsuresMinLength(minLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldReturnOriginalValue_WhenValueIsNullOrEmptyAndMinLengthIsZero(String value)
+   {
+      // Arrange.
+      var minLength = 0;
+
+      // Assert.
+      var result = _ = value.EnsuresMinLength(minLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrowArgumentOutOfRangeException_WhenMinLengthIsNegative()
+   {
+      // Arrange.
+      var value = "asdf";
+      var minLength = -1;
+      var expectedMessage = Messages.MinLengthIsNegative;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(nameof(minLength))
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(minLength);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.MinLength);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.MinLength].Should().Be(minLength);
+      ex.Data[DataNames.MinLengthExpression].Should().Be(nameof(minLength));
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var act = () => _ = value.EnsuresMinLength(minLength);
+      var expectedMessage = $"Postcondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresMinLength(minLength, messageTemplate);
+      var expectedMessage = $"Requirement MinLength failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var act = () => _ = value.EnsuresMinLength(minLength, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_EnsuresMinLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresMinLength(minLength, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement MinLength failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+
+   #region RequiresMinLength Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_RequiresMinLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthGreaterThanMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 9;
+      var act = () => _ = value.RequiresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_RequiresMinLength_ShouldNotThrow_WhenNonNullNonEmptyValueHasLengthEqualToMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 10;
+      var act = () => _ = value.RequiresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MinLengthExtensions_RequiresMinLength_ShouldNotThrow_WhenValueIsNullOrEmptyAndMinLengthIsZero(String value)
+   {
+      // Arrange.
+      var minLength = 0;
+      var act = () => _ = value.RequiresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrow_WhenValueHasLengthGreaterThanMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 11;
+      var act = () => _ = value.RequiresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrow_WhenValueIsNullAndMinLengthIsGreaterThanZero()
+   {
+      // Arrange.
+      String value = null!;
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMinLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrow_WhenValueIsEmptyAndMinLengthIsGreaterThanZero()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var maxLength = 10;
+      var act = () => _ = value.RequiresMinLength(maxLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_RequiresMinLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthGreaterThanMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 9;
+
+      // Assert.
+      var result = _ = value.RequiresMinLength(minLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [MemberData(nameof(TenCharacterStrings))]
+   public void MinLengthExtensions_RequiresMinLength_ShouldReturnOriginalValue_WhenNonNullNonEmptyValueHasLengthEqualToMinLength(String value)
+   {
+      // Arrange.
+      var minLength = 10;
+
+      // Assert.
+      var result = _ = value.RequiresMinLength(minLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void MinLengthExtensions_RequiresMinLength_ShouldReturnOriginalValue_WhenValueIsNullOrEmptyAndMinLengthIsZero(String value)
+   {
+      // Arrange.
+      var minLength = 0;
+
+      // Assert.
+      var result = _ = value.RequiresMinLength(minLength);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrowArgumentOutOfRangeException_WhenMinLengthIsNegative()
+   {
+      // Arrange.
+      var value = "asdf";
+      var minLength = -1;
+      var expectedMessage = Messages.MinLengthIsNegative;
+      var act = () => _ = value.RequiresMinLength(minLength);
+
+      // Act/assert.
+      act.Should().Throw<ArgumentOutOfRangeException>()
+         .WithParameterName(nameof(minLength))
+         .WithMessage(expectedMessage + "*")
+         .And.ActualValue.Should().Be(minLength);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var act = () => _ = value.RequiresMinLength(minLength);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.MinLength);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.MinLength].Should().Be(minLength);
+      ex.Data[DataNames.MinLengthExpression].Should().Be(nameof(minLength));
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var act = () => _ = value.RequiresMinLength(minLength);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresMinLength(minLength, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement MinLength failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var act = () => _ = value.RequiresMinLength(minLength, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   [Fact]
+   public void MinLengthExtensions_RequiresMinLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "abc";
+      var minLength = 10;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresMinLength(minLength, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement MinLength failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage);
+   }
+
+   #endregion
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\LessThanOrEqualToZero.md = Documentation\LessThanOrEqualToZero.md
 		Documentation\LessThanZero.md = Documentation\LessThanZero.md
 		Documentation\MaxLength.md = Documentation\MaxLength.md
+		Documentation\MinLength.md = Documentation\MinLength.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md

--- a/DbC.Net/Exceptions/ExceptionDataBuilder.cs
+++ b/DbC.Net/Exceptions/ExceptionDataBuilder.cs
@@ -158,6 +158,35 @@ public class ExceptionDataBuilder
    }
 
    /// <summary>
+   ///   Add min length information to the exception data dictionary.
+   /// </summary>
+   /// <param name="minLength">
+   ///   The min length value.
+   /// </param>
+   /// <param name="minLengthExpression">
+   ///   The min length parameter expression in the calling method.
+   /// </param>
+   /// <returns>
+   ///   A reference to this <see cref="ExceptionDataBuilder"/> object to 
+   ///   support method chaining.
+   /// </returns>
+   /// <exception cref="ArgumentException">
+   ///   <paramref name="minLengthExpression"/> is <see cref="String.Empty"/>.
+   /// </exception>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="minLengthExpression"/> is <see langword="null"/>.
+   /// </exception>
+   public ExceptionDataBuilder WithMinLength(Int32 minLength, String minLengthExpression)
+   {
+      ArgumentException.ThrowIfNullOrEmpty(minLengthExpression, nameof(minLengthExpression));
+
+      _data[DataNames.MinLength] = minLength;
+      _data[DataNames.MinLengthExpression] = minLengthExpression;
+
+      return this;
+   }
+
+   /// <summary>
    ///   Add requirement information to the exception data dictionary.
    /// </summary>
    /// <param name="requirementType">

--- a/DbC.Net/Exceptions/ExceptionFactoryBase.cs
+++ b/DbC.Net/Exceptions/ExceptionFactoryBase.cs
@@ -5,229 +5,229 @@
 /// </summary>
 public abstract class ExceptionFactoryBase : IExceptionFactory
 {
-    private const string _ensuresPrefix = "Ensures";
-    private const string _requiresPrefix = "Requires";
+   private const string _ensuresPrefix = "Ensures";
+   private const string _requiresPrefix = "Requires";
 
-    private readonly Dictionary<string, IValueTransform> _transforms = new();
+   private readonly Dictionary<string, IValueTransform> _transforms = new();
 
-    /// <summary>
-    ///   Initialize a new <see cref="ExceptionFactoryBase"/> object with all
-    ///   defaults.
-    /// </summary>
-    public ExceptionFactoryBase() { }
+   /// <summary>
+   ///   Initialize a new <see cref="ExceptionFactoryBase"/> object with all
+   ///   defaults.
+   /// </summary>
+   public ExceptionFactoryBase() { }
 
-    /// <summary>
-    ///   Initialize a new <see cref="ExceptionFactoryBase"/> with the 
-    ///   <paramref name="transform"/> to use for the specified data dictionary
-    ///   <paramref name="keys"/>.
-    /// </summary>
-    /// <param name="keys">
-    ///   Keys that identify data dictionary entries that should be transformed
-    ///   when creating exceptions.
-    /// </param>
-    /// <param name="transform">
-    ///   The <see cref="IValueTransform"/> to use for the specified data 
-    ///   dictionary <paramref name="keys"/>.
-    /// </param>
-    /// <exception cref="ArgumentNullException">
-    ///   <paramref name="keys"/> is <see langword="null"/>.
-    ///   - or -
-    ///   <paramref name="transform"/> is <see langword="null"/>.
-    /// </exception>
-    public ExceptionFactoryBase(IReadOnlyCollection<string> keys, IValueTransform transform)
-    {
-        _ = keys ?? throw new ArgumentNullException(nameof(keys), Messages.TransformKeysCollectonIsNull);
-        _ = transform ?? throw new ArgumentNullException(nameof(transform), Messages.ValueTransformIsNull);
+   /// <summary>
+   ///   Initialize a new <see cref="ExceptionFactoryBase"/> with the 
+   ///   <paramref name="transform"/> to use for the specified data dictionary
+   ///   <paramref name="keys"/>.
+   /// </summary>
+   /// <param name="keys">
+   ///   Keys that identify data dictionary entries that should be transformed
+   ///   when creating exceptions.
+   /// </param>
+   /// <param name="transform">
+   ///   The <see cref="IValueTransform"/> to use for the specified data 
+   ///   dictionary <paramref name="keys"/>.
+   /// </param>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="keys"/> is <see langword="null"/>.
+   ///   - or -
+   ///   <paramref name="transform"/> is <see langword="null"/>.
+   /// </exception>
+   public ExceptionFactoryBase(IReadOnlyCollection<string> keys, IValueTransform transform)
+   {
+      _ = keys ?? throw new ArgumentNullException(nameof(keys), Messages.TransformKeysCollectonIsNull);
+      _ = transform ?? throw new ArgumentNullException(nameof(transform), Messages.ValueTransformIsNull);
 
-        foreach (var key in keys)
-        {
-            _transforms[key] = transform;
-        }
-    }
+      foreach (var key in keys)
+      {
+         _transforms[key] = transform;
+      }
+   }
 
-    /// <summary>
-    ///   Initialize a new <see cref="ExceptionFactoryBase"/> with the specified
-    ///   value <paramref name="transforms"/>.
-    /// </summary>
-    /// <param name="transforms">
-    ///   Dictionary of value transforms to apply to data dictionary entries.
-    /// </param>
-    public ExceptionFactoryBase(IReadOnlyDictionary<string, IValueTransform> transforms)
-    {
-        _ = transforms ?? throw new ArgumentNullException(nameof(transforms), Messages.TransformsDictionaryIsNull);
+   /// <summary>
+   ///   Initialize a new <see cref="ExceptionFactoryBase"/> with the specified
+   ///   value <paramref name="transforms"/>.
+   /// </summary>
+   /// <param name="transforms">
+   ///   Dictionary of value transforms to apply to data dictionary entries.
+   /// </param>
+   public ExceptionFactoryBase(IReadOnlyDictionary<string, IValueTransform> transforms)
+   {
+      _ = transforms ?? throw new ArgumentNullException(nameof(transforms), Messages.TransformsDictionaryIsNull);
 
-        foreach (var kvp in transforms)
-        {
-            _transforms[kvp.Key] = kvp.Value;
-        }
-    }
+      foreach (var kvp in transforms)
+      {
+         _transforms[kvp.Key] = kvp.Value;
+      }
+   }
 
-    /// <summary>
-    ///   Apply value transformations to the data dictionary. 
-    /// </summary>
-    /// <param name="data">
-    ///   Details to include in the new exception's <see cref="Exception.Data"/>
-    ///   dictionary.
-    /// </param>
-    /// <returns>
-    ///   A new data dictionary, containing values the transformed data values.
-    /// </returns>
-    public IReadOnlyDictionary<string, object> ApplyTransforms(IReadOnlyDictionary<string, object> data)
-    {
-        var transformed = new Dictionary<string, object>();
-        foreach (var kvp in data)
-        {
-            transformed[kvp.Key] = _transforms.TryGetValue(kvp.Key, out var transform)
-               ? transform.TransformValue(kvp.Value)
-               : kvp.Value;
-        }
+   /// <summary>
+   ///   Apply value transformations to the data dictionary. 
+   /// </summary>
+   /// <param name="data">
+   ///   Details to include in the new exception's <see cref="Exception.Data"/>
+   ///   dictionary.
+   /// </param>
+   /// <returns>
+   ///   A new data dictionary, containing values the transformed data values.
+   /// </returns>
+   public IReadOnlyDictionary<string, object> ApplyTransforms(IReadOnlyDictionary<string, object> data)
+   {
+      var transformed = new Dictionary<string, object>();
+      foreach (var kvp in data)
+      {
+         transformed[kvp.Key] = _transforms.TryGetValue(kvp.Key, out var transform)
+            ? transform.TransformValue(kvp.Value)
+            : kvp.Value;
+      }
 
-        return transformed;
-    }
+      return transformed;
+   }
 
-    /// <inheritdoc/>
-    public abstract Exception CreateException(
-       IReadOnlyDictionary<string, object> data,
-       string messageTemplate);
+   /// <inheritdoc/>
+   public abstract Exception CreateException(
+      IReadOnlyDictionary<string, object> data,
+      string messageTemplate);
 
-    /// <summary>
-    ///   Create an exception message by populating the 
-    ///   <paramref name="messageTemplate"/> with values from the exception
-    ///   details <paramref name="data"/> collection.
-    /// </summary>
-    /// <param name="messageTemplate">
-    ///   Template to create the new exception message.
-    /// </param>
-    /// <param name="data">
-    ///   Details to include in the new exception's <see cref="Exception.Data"/>
-    ///   dictionary.
-    /// </param>
-    /// <returns>
-    ///   An exception message.
-    /// </returns>
-    /// <exception cref="ArgumentException">
-    ///   <paramref name="messageTemplate"/> is <see cref="string.Empty"/> or all
-    ///   whitespace characters.
-    /// </exception>
-    /// <exception cref="ArgumentNullException">
-    ///   <paramref name="messageTemplate"/> is <see langword="null"/>.
-    ///   - or -
-    ///   <paramref name="data"/> is <see langword="null"/>.
-    /// </exception>
-    public virtual string CreateMessage(
-       string messageTemplate,
-       IReadOnlyDictionary<string, object> data)
-    {
-        ValidateMessageTemplate(messageTemplate);
-        ValidateDataDictionary(data);
+   /// <summary>
+   ///   Create an exception message by populating the 
+   ///   <paramref name="messageTemplate"/> with values from the exception
+   ///   details <paramref name="data"/> collection.
+   /// </summary>
+   /// <param name="messageTemplate">
+   ///   Template to create the new exception message.
+   /// </param>
+   /// <param name="data">
+   ///   Details to include in the new exception's <see cref="Exception.Data"/>
+   ///   dictionary.
+   /// </param>
+   /// <returns>
+   ///   An exception message.
+   /// </returns>
+   /// <exception cref="ArgumentException">
+   ///   <paramref name="messageTemplate"/> is <see cref="string.Empty"/> or all
+   ///   whitespace characters.
+   /// </exception>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="messageTemplate"/> is <see langword="null"/>.
+   ///   - or -
+   ///   <paramref name="data"/> is <see langword="null"/>.
+   /// </exception>
+   public virtual string CreateMessage(
+      string messageTemplate,
+      IReadOnlyDictionary<string, object> data)
+   {
+      ValidateMessageTemplate(messageTemplate);
+      ValidateDataDictionary(data);
 
-        var message = messageTemplate;
-        foreach (var item in data)
-        {
-            message = message.Replace($"{{{item.Key}}}", item.Value?.ToString());
-        }
+      var message = messageTemplate;
+      foreach (var item in data)
+      {
+         message = message.Replace($"{{{item.Key}}}", item.Value?.ToString());
+      }
 
-        return message;
-    }
+      return message;
+   }
 
-    /// <summary>
-    ///   Get the parameter name value from the value expression in supplied 
-    ///   <paramref name="data"/> dictionary.
-    /// </summary>
-    /// <param name="data">
-    ///   Details to include in the new exception's <see cref="Exception.Data"/>
-    ///   dictionary.
-    /// </param>
-    /// <returns>
-    ///   The parameter name, or <see cref="string.Empty"/> if not available.
-    /// </returns>
-    /// <remarks>
-    ///   The entry in the <paramref name="data"/> dictionary with the 
-    ///   <see cref="DataNames.ValueExpression"/> is a string containing the 
-    ///   full expression passed to the Requires... or Ensures... method. Because
-    ///   Requires... and Ensures... methods can be chained together, it is
-    ///   possible that the value expression will contain preceding methods in
-    ///   the call chain. This method strips off any extra data and only returns
-    ///   the original value. 
-    ///   <para/>
-    ///   i.e. x.RequiresNotNull().RequiresGreaterThanZero() => x
-    /// </remarks>
-    // TODO: Note that the current implementation is not entirely bullet-proof. For
-    // TODO: example, a value expression of "thisValueRequiresMoreThought.EnsuresNotNull()"
-    // TODO: would return "thisValue".
-    public virtual string GetParamName(IReadOnlyDictionary<string, object> data)
-    {
-        ValidateDataDictionary(data);
+   /// <summary>
+   ///   Get the parameter name value from the value expression in supplied 
+   ///   <paramref name="data"/> dictionary.
+   /// </summary>
+   /// <param name="data">
+   ///   Details to include in the new exception's <see cref="Exception.Data"/>
+   ///   dictionary.
+   /// </param>
+   /// <returns>
+   ///   The parameter name, or <see cref="string.Empty"/> if not available.
+   /// </returns>
+   /// <remarks>
+   ///   The entry in the <paramref name="data"/> dictionary with the 
+   ///   <see cref="DataNames.ValueExpression"/> is a string containing the 
+   ///   full expression passed to the Requires... or Ensures... method. Because
+   ///   Requires... and Ensures... methods can be chained together, it is
+   ///   possible that the value expression will contain preceding methods in
+   ///   the call chain. This method strips off any extra data and only returns
+   ///   the original value. 
+   ///   <para/>
+   ///   i.e. x.RequiresNotNull().RequiresGreaterThanZero() => x
+   /// </remarks>
+   // TODO: Note that the current implementation is not entirely bullet-proof. For
+   // TODO: example, a value expression of "thisValueRequiresMoreThought.EnsuresNotNull()"
+   // TODO: would return "thisValue".
+   public virtual string GetParamName(IReadOnlyDictionary<string, object> data)
+   {
+      ValidateDataDictionary(data);
 
-        var paramName = string.Empty;
-        if (data.TryGetValue(DataNames.ValueExpression, out var valueExpression))
-        {
-            paramName = valueExpression as string;
-            var requiresIndex = paramName!.IndexOf(_requiresPrefix);
-            var ensuresIndex = paramName.IndexOf(_ensuresPrefix);
-            var offset = -1;
-            if (requiresIndex > -1 && ensuresIndex == -1)
-            {
-                offset = requiresIndex;
-            }
-            else if (requiresIndex == -1 && ensuresIndex > -1)
-            {
-                offset = ensuresIndex;
-            }
-            else if (requiresIndex > -1 && ensuresIndex > -1)
-            {
-                offset = Math.Min(requiresIndex, ensuresIndex);
-            }
+      var paramName = string.Empty;
+      if (data.TryGetValue(DataNames.ValueExpression, out var valueExpression))
+      {
+         paramName = valueExpression as string;
+         var requiresIndex = paramName!.IndexOf(_requiresPrefix);
+         var ensuresIndex = paramName.IndexOf(_ensuresPrefix);
+         var offset = -1;
+         if (requiresIndex > -1 && ensuresIndex == -1)
+         {
+               offset = requiresIndex;
+         }
+         else if (requiresIndex == -1 && ensuresIndex > -1)
+         {
+               offset = ensuresIndex;
+         }
+         else if (requiresIndex > -1 && ensuresIndex > -1)
+         {
+               offset = Math.Min(requiresIndex, ensuresIndex);
+         }
 
-            if (offset > -1)
-            {
-                paramName = paramName[..offset].TrimEnd();
-            }
-            if (paramName.EndsWith('.'))
-            {
-                paramName = paramName[..^1].TrimEnd();
-            }
-        }
+         if (offset > -1)
+         {
+               paramName = paramName[..offset].TrimEnd();
+         }
+         if (paramName.EndsWith('.'))
+         {
+               paramName = paramName[..^1].TrimEnd();
+         }
+      }
 
-        return paramName;
-    }
+      return paramName;
+   }
 
-    /// <summary>
-    ///   Confirm that the <paramref name="data"/> dictionary is not 
-    ///   <see langword="null"/>.
-    /// </summary>
-    /// <param name="data">
-    ///   Details to include in the new exception's <see cref="Exception.Data"/>
-    ///   dictionary.
-    /// </param>
-    /// <exception cref="ArgumentNullException">
-    ///   <paramref name="data"/> is <see langword="null"/>.
-    /// </exception>
-    public static void ValidateDataDictionary(IReadOnlyDictionary<string, object> data)
-       => _ = data ?? throw new ArgumentNullException(nameof(data), Messages.DataDictionaryIsNull);
+   /// <summary>
+   ///   Confirm that the <paramref name="data"/> dictionary is not 
+   ///   <see langword="null"/>.
+   /// </summary>
+   /// <param name="data">
+   ///   Details to include in the new exception's <see cref="Exception.Data"/>
+   ///   dictionary.
+   /// </param>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="data"/> is <see langword="null"/>.
+   /// </exception>
+   public static void ValidateDataDictionary(IReadOnlyDictionary<string, object> data)
+      => _ = data ?? throw new ArgumentNullException(nameof(data), Messages.DataDictionaryIsNull);
 
-    /// <summary>
-    ///   Confirm that the <paramref name="messageTemplate"/> is not 
-    ///   <see langword="null"/>, <see cref="string.Empty"/> or all whitespace 
-    ///   characters.
-    /// </summary>
-    /// <param name="messageTemplate">
-    ///   Template to create the new exception message.
-    /// </param>
-    /// </param>
-    /// <exception cref="ArgumentException">
-    ///   <paramref name="messageTemplate"/> is <see cref="String.Empty"/> or all
-    ///   whitespace characters.
-    /// </exception>
-    /// <exception cref="ArgumentNullException">
-    ///   <paramref name="messageTemplate"/> is <see langword="null"/>.
-    /// </exception>
-    public static void ValidateMessageTemplate(string messageTemplate)
-    {
-        _ = messageTemplate ?? throw new ArgumentNullException(nameof(messageTemplate), Messages.MessageTemplateIsEmpty);
-        if (string.IsNullOrWhiteSpace(messageTemplate))
-        {
-            throw new ArgumentException(Messages.MessageTemplateIsEmpty, nameof(messageTemplate));
-        }
-    }
+   /// <summary>
+   ///   Confirm that the <paramref name="messageTemplate"/> is not 
+   ///   <see langword="null"/>, <see cref="string.Empty"/> or all whitespace 
+   ///   characters.
+   /// </summary>
+   /// <param name="messageTemplate">
+   ///   Template to create the new exception message.
+   /// </param>
+   /// </param>
+   /// <exception cref="ArgumentException">
+   ///   <paramref name="messageTemplate"/> is <see cref="String.Empty"/> or all
+   ///   whitespace characters.
+   /// </exception>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="messageTemplate"/> is <see langword="null"/>.
+   /// </exception>
+   public static void ValidateMessageTemplate(string messageTemplate)
+   {
+      _ = messageTemplate ?? throw new ArgumentNullException(nameof(messageTemplate), Messages.MessageTemplateIsEmpty);
+      if (string.IsNullOrWhiteSpace(messageTemplate))
+      {
+         throw new ArgumentException(Messages.MessageTemplateIsEmpty, nameof(messageTemplate));
+      }
+   }
 }

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -169,6 +169,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must have a minimum length of {MinLength}.
+        /// </summary>
+        internal static string MinLengthTemplate {
+            get {
+                return ResourceManager.GetString("MinLengthTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype}).
         /// </summary>
         internal static string NotDefaultTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -153,6 +153,9 @@
   <data name="MaxLengthTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must have a maximum length of {MaxLength}</value>
   </data>
+  <data name="MinLengthTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must have a minimum length of {MinLength}</value>
+  </data>
   <data name="NotDefaultTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
   </data>

--- a/DbC.Net/Messages.Designer.cs
+++ b/DbC.Net/Messages.Designer.cs
@@ -160,6 +160,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MinLength may not be negative.
+        /// </summary>
+        internal static string MinLengthIsNegative {
+            get {
+                return ResourceManager.GetString("MinLengthIsNegative", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Pad character may not be null (&apos;\0&apos;).
         /// </summary>
         internal static string PadCharacterIsNull {

--- a/DbC.Net/Messages.resx
+++ b/DbC.Net/Messages.resx
@@ -150,6 +150,9 @@
   <data name="MessageTemplateIsEmpty" xml:space="preserve">
     <value>Message template may not be null, String.Empty or all whitespace characters</value>
   </data>
+  <data name="MinLengthIsNegative" xml:space="preserve">
+    <value>MinLength may not be negative</value>
+  </data>
   <data name="PadCharacterIsNull" xml:space="preserve">
     <value>Pad character may not be null ('\0')</value>
   </data>

--- a/DbC.Net/MinLengthExtensions.cs
+++ b/DbC.Net/MinLengthExtensions.cs
@@ -1,0 +1,149 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement string MinLength requirement.
+/// </summary>
+public static class MinLengthExtensions
+{
+   private const String _requirementName = RequirementNames.MinLength;
+
+   /// <summary>
+   ///   String MinLength postcondition. Confirm that the length of the 
+   ///   <paramref name="value"/> is greater than or equal to the 
+   ///   <paramref name="minLength"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="minLength">
+   ///   The minimum allowed length of the string <paramref name="value"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must have a minimum length of {MinLength}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="minLengthExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="minLength"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentOutOfRangeException">
+   ///   <paramref name="minLength"/> is negative.
+   /// </exception>
+   public static String EnsuresMinLength(
+      this String value,
+      Int32 minLength,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(minLength))] String minLengthExpression = null!)
+   {
+      CheckMinLength(
+         value,
+         minLength,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         minLengthExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   String MinLength precondition. Confirm that the length of the 
+   ///   <paramref name="value"/> is greater than or equal to the 
+   ///   <paramref name="minLength"/> and throw an exception if it is not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="minLength">
+   ///   The minimum allowed length of the string <paramref name="value"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} must have a minimum length of {MinLength}".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="minLengthExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="minLength"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentOutOfRangeException">
+   ///   <paramref name="minLength"/> is negative.
+   /// </exception>
+   public static String RequiresMinLength(
+      this String value,
+      Int32 minLength,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression(nameof(value))] String valueExpression = null!,
+      [CallerArgumentExpression(nameof(minLength))] String minLengthExpression = null!)
+   {
+      CheckMinLength(
+         value,
+         minLength,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         minLengthExpression);
+
+      return value;
+   }
+
+   private static void CheckMinLength(
+      String value,
+      Int32 minLength,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String minLengthExpression)
+   {
+      if (minLength < 0)
+      {
+         throw new ArgumentOutOfRangeException(nameof(minLength), minLength, Messages.MinLengthIsNegative);
+      }
+
+      if ((value?.Length ?? 0) < minLength)
+      {
+         messageTemplate ??= MessageTemplates.MinLengthTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithMinLength(minLength, minLengthExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -17,6 +17,7 @@ public static class RequirementNames
    public const String LessThanOrEqualToZero = nameof(LessThanOrEqualToZero);
    public const String LessThanZero = nameof(LessThanZero);
    public const String MaxLength = nameof(MaxLength);
+   public const String MinLength = nameof(MinLength);
    public const String NotDefault = nameof(NotDefault);
    public const String NotEqual = nameof(NotEqual);
    public const String NotNull = nameof(NotNull);

--- a/Documentation/MinLength.md
+++ b/Documentation/MinLength.md
@@ -24,10 +24,10 @@ RequirementName, Value, ValueExpression, MinLength and MinLengthExpression.
 
 **Examples:**
 ```C#
-var customMessageTemplate = "{ValueExpression} must be at least 10 characters in length";
+var customMessageTemplate = "{ValueExpression} may not be less than 10 characters in length";
 var customExceptionFactory = new CustomExceptionFactory();
 
-var value = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
+var value = "ABC";
 var minLength = 10;
 
 // Precondition with default message template and default exception factory.

--- a/Documentation/MinLength.md
+++ b/Documentation/MinLength.md
@@ -1,0 +1,58 @@
+### MinLength
+
+MinLength requires that the string value being checked has a length that is at
+least the specified minimum length. MinLength treats a null string as a zero 
+length string.
+
+RequiresMinLength and EnsuresMinLength overloads will throw an ArgumentOutOfRangeException
+if the supplied minLength is negative.
+
+**Method signatures:**
+```C#
+String RequiresMinLength(this String value, Int32 minLength, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? minLengthExpression = null])
+
+String EnsuresMinLength(this String value, Int32 minLength, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? minLengthExpression = null])
+```
+
+The default message template for MinLength is "{RequirementType} {RequirementName} failed: {ValueExpression} must have a minimum length of {MinLength}".
+The default exception factory for RequiresMinLength is StandardExceptionFactories.ArgumentExceptionFactory
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresMinLength.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, ValueExpression, MinLength and MinLengthExpression.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must be at least 10 characters in length";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
+var minLength = 10;
+
+// Precondition with default message template and default exception factory.
+value.RequiresMinLength(minLength);
+
+// Precondition with custom message template and default exception factory.
+value.RequiresMinLength(minLength, customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresMinLength(minLength, exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.RequiresMinLength(minLength);
+
+// Postcondition with custom message template and default exception factory.
+value.RequiresMinLength(minLength, customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.RequiresMinLength(minLength, exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory);
+```
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
   - String Requirements
 
     - [MaxLength](/Documentation/MaxLength.md)
+    - [MinLength](/Documentation/MinLength.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value has at least a target minimum length. 

Requirements:

  RequiresMinLength (precondition), default ArgumentException
  EnsuresMinLength (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresMinLength
2. Implement EnsuresMinLength
3. Unit tests for Requires/Ensures MinLength
4. Performance tests
5. Readme updates
6. Examples