### PR TITLE
S0019 not null or empty

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -514,10 +514,12 @@ parameter was omitted.
 
 | Method                 | Message Template | Null Exception Factory | Empty Exception Factory |      Mean |     Error |    StdDev | Allocated |
 |:---------------------- |:----------------:|:----------------------:|:-----------------------:|----------:|----------:|----------:|----------:|
-| RequiredNotNullOrEmpty |                  |                        |                         | 0.0032 ns | 0.0038 ns | 0.0035 ns |         - |
-| RequiredNotNullOrEmpty | X                |                        |                         | 0.0051 ns | 0.0056 ns | 0.0050 ns |         - |
-| RequiredNotNullOrEmpty |                  | X                      |                         | 0.0015 ns | 0.0033 ns | 0.0029 ns |         - |
-| RequiredNotNullOrEmpty |                  |                        | X                       | 0.0072 ns | 0.0118 ns | 0.0105 ns |         - |
-| RequiredNotNullOrEmpty | X                | X                      |                         | 0.0042 ns | 0.0095 ns | 0.0084 ns |         - |
-| RequiredNotNullOrEmpty | X                |                        | X                       | 0.0423 ns | 0.0282 ns | 0.0508 ns |         - |
-| RequiredNotNullOrEmpty | X                | X                      | X                       | 0.0631 ns | 0.0292 ns | 0.0658 ns |         - |
+| RequiredNotNullOrEmpty |                  |                        |                         | 0.0016 ns | 0.0038 ns | 0.0034 ns |         - |
+| RequiredNotNullOrEmpty | X                |                        |                         | 0.0074 ns | 0.0098 ns | 0.0082 ns |         - |
+| RequiredNotNullOrEmpty |                  | X                      |                         | 0.0051 ns | 0.0066 ns | 0.0062 ns |         - |
+| RequiredNotNullOrEmpty |                  |                        | X                       | 0.0067 ns | 0.0090 ns | 0.0084 ns |         - |
+| RequiredNotNullOrEmpty |                  | X                      | X                       | 0.0060 ns | 0.0077 ns | 0.0068 ns |         - |
+| RequiredNotNullOrEmpty | X                | X                      |                         | 0.0485 ns | 0.0287 ns | 0.0572 ns |         - |
+| RequiredNotNullOrEmpty | X                |                        | X                       | 0.0405 ns | 0.0264 ns | 0.0528 ns |         - |
+| RequiredNotNullOrEmpty | X                | X                      | X                       | 0.0393 ns | 0.0289 ns | 0.0333 ns |         - |
+

--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -510,3 +510,14 @@ parameter was omitted.
 | RequiresMinLength | Empty String                |                  | X                 | 2.6954 ns | 0.0259 ns | 0.0230 ns |         - |
 | RequiresMinLength | Empty String                | X                | X                 | 2.6405 ns | 0.0316 ns | 0.0264 ns |         - |
 
+### RequiredNotNullOrEmpty Benchmarks
+
+| Method                 | Message Template | Null Exception Factory | Empty Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:---------------------- |:----------------:|:----------------------:|:-----------------------:|----------:|----------:|----------:|----------:|
+| RequiredNotNullOrEmpty |                  |                        |                         | 0.0032 ns | 0.0038 ns | 0.0035 ns |         - |
+| RequiredNotNullOrEmpty | X                |                        |                         | 0.0051 ns | 0.0056 ns | 0.0050 ns |         - |
+| RequiredNotNullOrEmpty |                  | X                      |                         | 0.0015 ns | 0.0033 ns | 0.0029 ns |         - |
+| RequiredNotNullOrEmpty |                  |                        | X                       | 0.0072 ns | 0.0118 ns | 0.0105 ns |         - |
+| RequiredNotNullOrEmpty | X                | X                      |                         | 0.0042 ns | 0.0095 ns | 0.0084 ns |         - |
+| RequiredNotNullOrEmpty | X                |                        | X                       | 0.0423 ns | 0.0282 ns | 0.0508 ns |         - |
+| RequiredNotNullOrEmpty | X                | X                      | X                       | 0.0631 ns | 0.0292 ns | 0.0658 ns |         - |

--- a/DbC.Net.Examples/MaxLengthExamples.cs
+++ b/DbC.Net.Examples/MaxLengthExamples.cs
@@ -24,15 +24,15 @@ public sealed class MaxLengthExamples
 
 
       // Postcondition with default message template and default exception factory.
-      value.RequiresMaxLength(maxLength);
+      value.EnsuresMaxLength(maxLength);
 
       // Postcondition with custom message template and default exception factory.
-      value.RequiresMaxLength(maxLength, customMessageTemplate);
+      value.EnsuresMaxLength(maxLength, customMessageTemplate);
 
       // Postcondition with default message template and custom exception factory.
-      value.RequiresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
+      value.EnsuresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
 
       // Postcondition with custom message template and custom exception factory.
-      value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
+      value.EnsuresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/MinLengthExamples.cs
+++ b/DbC.Net.Examples/MinLengthExamples.cs
@@ -24,15 +24,15 @@ public sealed class MinLengthExamples
 
 
       // Postcondition with default message template and default exception factory.
-      value.RequiresMinLength(minLength);
+      value.EnsuresMinLength(minLength);
 
       // Postcondition with custom message template and default exception factory.
-      value.RequiresMinLength(minLength, customMessageTemplate);
+      value.EnsuresMinLength(minLength, customMessageTemplate);
 
       // Postcondition with default message template and custom exception factory.
-      value.RequiresMinLength(minLength, exceptionFactory: customExceptionFactory);
+      value.EnsuresMinLength(minLength, exceptionFactory: customExceptionFactory);
 
       // Postcondition with custom message template and custom exception factory.
-      value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory);
+      value.EnsuresMinLength(minLength, customMessageTemplate, customExceptionFactory);
    }
 }

--- a/DbC.Net.Examples/NotNullOrEmptyExamples.cs
+++ b/DbC.Net.Examples/NotNullOrEmptyExamples.cs
@@ -1,0 +1,43 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class NotNullOrEmptyExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must have a non-null/non-empty value";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = String.Empty;
+
+      // Precondition with default message template and default exception factories.
+      value.RequiresNotNullOrEmpty();
+
+      // Precondition with custom message template and default exception factories.
+      value.RequiresNotNullOrEmpty(customMessageTemplate);
+
+      // Precondition with default message template and custom null value exception factory.
+      value.RequiresNotNullOrEmpty(nullExceptionFactory: customExceptionFactory);
+
+      // Precondition with default message template and custom empty value exception factory.
+      value.RequiresNotNullOrEmpty(emptyExceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factories.
+      value.RequiresNotNullOrEmpty(customMessageTemplate, customExceptionFactory, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factories.
+      value.EnsuresNotNullOrEmpty();
+
+      // Postcondition with custom message template and default exception factories.
+      value.EnsuresNotNullOrEmpty(customMessageTemplate);
+
+      // Postcondition with default message template and custom null value exception factory.
+      value.EnsuresNotNullOrEmpty(nullExceptionFactory: customExceptionFactory);
+
+      // Postcondition with default message template and custom empty value exception factory.
+      value.EnsuresNotNullOrEmpty(emptyExceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factories.
+      value.EnsuresNotNullOrEmpty(customMessageTemplate, customExceptionFactory, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/NotNullOrEmptyBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/NotNullOrEmptyBenchmarks.cs
@@ -38,6 +38,12 @@ public class NotNullOrEmptyBenchmarks
    }
 
    [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P011()
+   {
+      var result = _value.RequiresNotNullOrEmpty(nullExceptionFactory: _exceptionFactory, emptyExceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
    public void RequiresNotNullOrEmpty_String_P110()
    {
       var result = _value.RequiresNotNullOrEmpty(_messageTemplate, _exceptionFactory);

--- a/DbC.Net.Tests.Benchmarks/NotNullOrEmptyBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/NotNullOrEmptyBenchmarks.cs
@@ -1,0 +1,57 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class NotNullOrEmptyBenchmarks
+{
+   private const String _value = "asdf";
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must have a non-null/non-empty value";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _value.RequiresNotNullOrEmpty();
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P000()
+   {
+      var result = _value.RequiresNotNullOrEmpty();
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P100()
+   {
+      var result = _value.RequiresNotNullOrEmpty(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P010()
+   {
+      var result = _value.RequiresNotNullOrEmpty(nullExceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P001()
+   {
+      var result = _value.RequiresNotNullOrEmpty(emptyExceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P110()
+   {
+      var result = _value.RequiresNotNullOrEmpty(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P101()
+   {
+      var result = _value.RequiresNotNullOrEmpty(_messageTemplate, emptyExceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotNullOrEmpty_String_P111()
+   {
+      var result = _value.RequiresNotNullOrEmpty(_messageTemplate, _exceptionFactory, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -13,4 +13,5 @@
 //BenchmarkRunner.Run<LessThanZeroBenchmarks>();
 //BenchmarkRunner.Run<LessThanOrEqualToZeroBenchmarks>();
 //BenchmarkRunner.Run<MaxLengthBenchmarks>();
-BenchmarkRunner.Run<MinLengthBenchmarks>();
+//BenchmarkRunner.Run<MinLengthBenchmarks>();
+BenchmarkRunner.Run<NotNullOrEmptyBenchmarks>();

--- a/DbC.Net.Tests.Unit/NotNullOrEmptyExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullOrEmptyExtensionsTests.cs
@@ -1,0 +1,424 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public  class NotNullOrEmptyExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresNotNullOrEmpty Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldNotThrow_WhenValueIsNotANullOrEmptyString()
+   {
+      // Arrange.
+      var value = "asdf";
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldNotThrow_WhenValueIsAllWhiteSpace()
+   {
+      // Arrange.
+      var value = "\t  \t";
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrow_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrow_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldReturnOriginalValue_WhenValueIsNotANullOrEmptyString()
+   {
+      // Arrange.
+      var value = "asdf";
+
+      // Act.
+      var result = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowWithExpectedDataDictionary_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotNullOrEmpty);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowWithExpectedDataDictionary_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotNullOrEmpty);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+      var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.EnsuresNotNullOrEmpty();
+      var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotNullOrEmpty(messageTemplate);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyAndAllCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotNullOrEmpty(messageTemplate);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresNotNullOrEmpty(nullExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomEmptyExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.EnsuresNotNullOrEmpty(emptyExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotNullOrEmpty(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotNullOrEmpty(messageTemplate, emptyExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+
+   #region RequiresNotNullOrEmpty Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldNotThrow_WhenValueIsNotANullOrEmptyString()
+   {
+      // Arrange.
+      var value = "asdf";
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldNotThrow_WhenValueIsAllWhiteSpace()
+   {
+      // Arrange.
+      var value = "\t  \t";
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowArgumentNullException_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowArgumentException_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldReturnOriginalValue_WhenValueIsNotANullOrEmptyString()
+   {
+      // Arrange.
+      var value = "asdf";
+
+      // Act.
+      var result = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowWithExpectedDataDictionary_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentNullException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotNullOrEmpty);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowWithExpectedDataDictionary_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotNullOrEmpty);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.RequiresNotNullOrEmpty();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotNullOrEmpty(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentNullException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyAndAllCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotNullOrEmpty(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresNotNullOrEmpty(nullExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomEmptyExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.RequiresNotNullOrEmpty(emptyExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      String value = null!;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotNullOrEmpty(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotNullOrEmpty(messageTemplate, emptyExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotNullOrEmpty failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\NotDefault.md = Documentation\NotDefault.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md
+		Documentation\NotNullOrEmpty.md = Documentation\NotNullOrEmpty.md
 	EndProjectSection
 EndProject
 Global

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -196,6 +196,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be null or String.Empty.
+        /// </summary>
+        internal static string NotNullOrEmptyTemplate {
+            get {
+                return ResourceManager.GetString("NotNullOrEmptyTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be null.
         /// </summary>
         internal static string NotNullTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -162,6 +162,9 @@
   <data name="NotEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}</value>
   </data>
+  <data name="NotNullOrEmptyTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be null or String.Empty</value>
+  </data>
   <data name="NotNullTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be null</value>
   </data>

--- a/DbC.Net/NotNullOrEmptyExtensions.cs
+++ b/DbC.Net/NotNullOrEmptyExtensions.cs
@@ -1,0 +1,134 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement String NotNullOrEmpty requirement.
+/// </summary>
+public static class NotNullOrEmptyExtensions
+{
+   private const String _requirementName = RequirementNames.NotNullOrEmpty;
+
+   /// <summary>
+   ///   NotNullOrEmpty postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is not <see langword="null"/> or 
+   ///   <see cref="String.Empty"/> and throw an exception if it is null or 
+   ///   empty.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null or empty".
+   /// </param>
+   /// <param name="nullExceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="emptyExceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see cref="String.Empty"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String EnsuresNotNullOrEmpty(
+      this String value,
+      String? messageTemplate = null,
+      IExceptionFactory? nullExceptionFactory = null,
+      IExceptionFactory? emptyExceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!)
+   {
+      CheckNotNullOrEmpty(
+         value,
+         RequirementType.Postcondition,
+         messageTemplate,
+         nullExceptionFactory,
+         emptyExceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   NotNullOrEmpty precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is not <see langword="null"/> or 
+   ///   <see cref="String.Empty"/> and throw an exception if it is null or 
+   ///   empty.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null or empty".
+   /// </param>
+   /// <param name="nullExceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentNullExceptionFactory"/>.
+   /// </param>
+   /// <param name="emptyExceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see cref="String.Empty"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String RequiresNotNullOrEmpty(
+      this String value,
+      String? messageTemplate = null,
+      IExceptionFactory? nullExceptionFactory = null,
+      IExceptionFactory? emptyExceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!)
+   {
+      CheckNotNullOrEmpty(
+         value,
+         RequirementType.Precondition,
+         messageTemplate,
+         nullExceptionFactory,
+         emptyExceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   private static void CheckNotNullOrEmpty(
+      String? value,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? nullExceptionFactory,
+      IExceptionFactory? emptyExceptionFactory,
+      String valueExpression)
+   {
+      if (String.IsNullOrEmpty(value))
+      {
+         messageTemplate ??= MessageTemplates.NotNullOrEmptyTemplate;
+         var exceptionFactory = value is null
+            ? nullExceptionFactory ?? StandardExceptionFactories.ResolveArgumentNullExceptionFactory(requirementType)
+            : emptyExceptionFactory ?? StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -21,4 +21,5 @@ public static class RequirementNames
    public const String NotDefault = nameof(NotDefault);
    public const String NotEqual = nameof(NotEqual);
    public const String NotNull = nameof(NotNull);
+   public const String NotNullOrEmpty = nameof(NotNullOrEmpty);
 }

--- a/Documentation/MaxLength.md
+++ b/Documentation/MaxLength.md
@@ -44,15 +44,15 @@ value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory
 
 
 // Postcondition with default message template and default exception factory.
-value.RequiresMaxLength(maxLength);
+value.EnsuresMaxLength(maxLength);
 
 // Postcondition with custom message template and default exception factory.
-value.RequiresMaxLength(maxLength, customMessageTemplate);
+value.EnsuresMaxLength(maxLength, customMessageTemplate);
 
 // Postcondition with default message template and custom exception factory.
-value.RequiresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
+value.EnsuresMaxLength(maxLength, exceptionFactory: customExceptionFactory);
 
 // Postcondition with custom message template and custom exception factory.
-value.RequiresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
+value.EnsuresMaxLength(maxLength, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/MinLength.md
+++ b/Documentation/MinLength.md
@@ -44,15 +44,15 @@ value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory
 
 
 // Postcondition with default message template and default exception factory.
-value.RequiresMinLength(minLength);
+value.EnsuresMinLength(minLength);
 
 // Postcondition with custom message template and default exception factory.
-value.RequiresMinLength(minLength, customMessageTemplate);
+value.EnsuresMinLength(minLength, customMessageTemplate);
 
 // Postcondition with default message template and custom exception factory.
-value.RequiresMinLength(minLength, exceptionFactory: customExceptionFactory);
+value.EnsuresMinLength(minLength, exceptionFactory: customExceptionFactory);
 
 // Postcondition with custom message template and custom exception factory.
-value.RequiresMinLength(minLength, customMessageTemplate, customExceptionFactory);
+value.EnsuresMinLength(minLength, customMessageTemplate, customExceptionFactory);
 ```
 

--- a/Documentation/NotNullOrEmpty.md
+++ b/Documentation/NotNullOrEmpty.md
@@ -1,0 +1,26 @@
+### NotNullOrEmpty
+
+NotNull requires that the string value being checked not be null or String.Empty.
+
+**Method signatures:**
+```C#
+String RequiresNotNullOrEmpty(this String value, [String? messageTemplate = null], [IExceptionFactory? nullExceptionFactory = null], [IExceptionFactory? emptyExceptionFactory = null], [String? valueExpression = null])
+
+String EnsuresNotNullOrEmpty(this String value, [String? messageTemplate = null], [IExceptionFactory? nullExceptionFactory = null], [IExceptionFactory? emptyExceptionFactory = null], [String? valueExpression = null])
+```
+
+The default message template for NotNullOrEmpty is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null or String.Empty".
+Requires/EnsuresNotNullOrEmpty use two exception factories, one for exceptions
+thrown when the value being checked is null and one for exceptions thrown when
+the value being checked is empty. The default exception factories for RequiresNotNullOrEmpty
+are StandardExceptionFactories.ArgumentNullExceptionFactory and 
+StandardExceptionFactories.ArgumentExceptionFactory. EnsuresNotNullOrEmpty uses
+StandardExceptionFactories.PostconditionFailedExceptionFactory as the default for
+both null and empty values.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName and ValueExpression.
+
+**Examples:**
+```C#
+```

--- a/Documentation/NotNullOrEmpty.md
+++ b/Documentation/NotNullOrEmpty.md
@@ -1,6 +1,6 @@
 ### NotNullOrEmpty
 
-NotNull requires that the string value being checked not be null or String.Empty.
+NotNullOrEmpty requires that the string value being checked not be null or String.Empty.
 
 **Method signatures:**
 ```C#
@@ -23,4 +23,39 @@ RequirementName and ValueExpression.
 
 **Examples:**
 ```C#
+var customMessageTemplate = "{ValueExpression} must have a non-null/non-empty value";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = String.Empty;
+
+// Precondition with default message template and default exception factories.
+value.RequiresNotNullOrEmpty();
+
+// Precondition with custom message template and default exception factories.
+value.RequiresNotNullOrEmpty(customMessageTemplate);
+
+// Precondition with default message template and custom null value exception factory.
+value.RequiresNotNullOrEmpty(nullExceptionFactory: customExceptionFactory);
+
+// Precondition with default message template and custom empty value exception factory.
+value.RequiresNotNullOrEmpty(emptyExceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factories.
+value.RequiresNotNullOrEmpty(customMessageTemplate, customExceptionFactory, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factories.
+value.EnsuresNotNullOrEmpty();
+
+// Postcondition with custom message template and default exception factories.
+value.EnsuresNotNullOrEmpty(customMessageTemplate);
+
+// Postcondition with default message template and custom null value exception factory.
+value.EnsuresNotNullOrEmpty(nullExceptionFactory: customExceptionFactory);
+
+// Postcondition with default message template and custom empty value exception factory.
+value.EnsuresNotNullOrEmpty(emptyExceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factories.
+value.EnsuresNotNullOrEmpty(customMessageTemplate, customExceptionFactory, customExceptionFactory);
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 
     - [MaxLength](/Documentation/MaxLength.md)
     - [MinLength](/Documentation/MinLength.md)
+    - [NotNullOrEmpty](/Documentation/NotNullOrEmpty.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value is neither null or String.Empty.

Requirements:

  RequiresNotNullOrEmpty (precondition), default ArgumentNullException, ArgumentException 
  EnsuresNotNullOrEmpty (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresNotNullOrEmpty
2. Implement EnsuresNotNullOrEmpty
3. Unit tests for Requires/Ensures NotNullOrEmpty
4. Performance tests
5. Readme updates
6. Examples