### PR TITLE
S0021 not empty or white space

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -510,28 +510,37 @@ parameter was omitted.
 | RequiresMinLength | Empty String                |                  | X                 | 2.6954 ns | 0.0259 ns | 0.0230 ns |         - |
 | RequiresMinLength | Empty String                | X                | X                 | 2.6405 ns | 0.0316 ns | 0.0264 ns |         - |
 
-### RequiredNotNullOrEmpty Benchmarks
+### NotNullOrEmpty Benchmarks
 
 | Method                 | Message Template | Null Exception Factory | Empty Exception Factory |      Mean |     Error |    StdDev | Allocated |
 |:---------------------- |:----------------:|:----------------------:|:-----------------------:|----------:|----------:|----------:|----------:|
-| RequiredNotNullOrEmpty |                  |                        |                         | 0.0016 ns | 0.0038 ns | 0.0034 ns |         - |
-| RequiredNotNullOrEmpty | X                |                        |                         | 0.0074 ns | 0.0098 ns | 0.0082 ns |         - |
-| RequiredNotNullOrEmpty |                  | X                      |                         | 0.0051 ns | 0.0066 ns | 0.0062 ns |         - |
-| RequiredNotNullOrEmpty |                  |                        | X                       | 0.0067 ns | 0.0090 ns | 0.0084 ns |         - |
-| RequiredNotNullOrEmpty |                  | X                      | X                       | 0.0060 ns | 0.0077 ns | 0.0068 ns |         - |
-| RequiredNotNullOrEmpty | X                | X                      |                         | 0.0485 ns | 0.0287 ns | 0.0572 ns |         - |
-| RequiredNotNullOrEmpty | X                |                        | X                       | 0.0405 ns | 0.0264 ns | 0.0528 ns |         - |
-| RequiredNotNullOrEmpty | X                | X                      | X                       | 0.0393 ns | 0.0289 ns | 0.0333 ns |         - |
+| RequiresNotNullOrEmpty |                  |                        |                         | 0.0016 ns | 0.0038 ns | 0.0034 ns |         - |
+| RequiresNotNullOrEmpty | X                |                        |                         | 0.0074 ns | 0.0098 ns | 0.0082 ns |         - |
+| RequiresNotNullOrEmpty |                  | X                      |                         | 0.0051 ns | 0.0066 ns | 0.0062 ns |         - |
+| RequiresNotNullOrEmpty |                  |                        | X                       | 0.0067 ns | 0.0090 ns | 0.0084 ns |         - |
+| RequiresNotNullOrEmpty |                  | X                      | X                       | 0.0060 ns | 0.0077 ns | 0.0068 ns |         - |
+| RequiresNotNullOrEmpty | X                | X                      |                         | 0.0485 ns | 0.0287 ns | 0.0572 ns |         - |
+| RequiresNotNullOrEmpty | X                |                        | X                       | 0.0405 ns | 0.0264 ns | 0.0528 ns |         - |
+| RequiresNotNullOrEmpty | X                | X                      | X                       | 0.0393 ns | 0.0289 ns | 0.0333 ns |         - |
 
-### RequiredNotNullOrWhiteSpace Benchmarks
+### NotNullOrWhiteSpace Benchmarks
 
 | Method                      | Message Template | Null Exception Factory | Empty Exception Factory |     Mean |     Error |    StdDev | Allocated |
 |:--------------------------- |:----------------:|:----------------------:|:-----------------------:|---------:|----------:|----------:|----------:|
-| RequiredNotNullOrWhiteSpace |                  |                        |                         | 2.167 ns | 0.0175 ns | 0.0163 ns |         - |
-| RequiredNotNullOrWhiteSpace | X                |                        |                         | 2.447 ns | 0.0215 ns | 0.0191 ns |         - |
-| RequiredNotNullOrWhiteSpace |                  | X                      |                         | 1.915 ns | 0.0123 ns | 0.0096 ns |         - |
-| RequiredNotNullOrWhiteSpace |                  |                        | X                       | 2.935 ns | 0.0268 ns | 0.0251 ns |         - |
-| RequiredNotNullOrWhiteSpace |                  | X                      | X                       | 2.756 ns | 0.0198 ns | 0.0154 ns |         - |
-| RequiredNotNullOrWhiteSpace | X                | X                      |                         | 2.215 ns | 0.0188 ns | 0.0166 ns |         - |
-| RequiredNotNullOrWhiteSpace | X                |                        | X                       | 2.298 ns | 0.0470 ns | 0.0393 ns |         - |
-| RequiredNotNullOrWhiteSpace | X                | X                      | X                       | 2.225 ns | 0.0223 ns | 0.0198 ns |         - |
+| RequiresNotNullOrWhiteSpace |                  |                        |                         | 2.167 ns | 0.0175 ns | 0.0163 ns |         - |
+| RequiresNotNullOrWhiteSpace | X                |                        |                         | 2.447 ns | 0.0215 ns | 0.0191 ns |         - |
+| RequiresNotNullOrWhiteSpace |                  | X                      |                         | 1.915 ns | 0.0123 ns | 0.0096 ns |         - |
+| RequiresNotNullOrWhiteSpace |                  |                        | X                       | 2.935 ns | 0.0268 ns | 0.0251 ns |         - |
+| RequiresNotNullOrWhiteSpace |                  | X                      | X                       | 2.756 ns | 0.0198 ns | 0.0154 ns |         - |
+| RequiresNotNullOrWhiteSpace | X                | X                      |                         | 2.215 ns | 0.0188 ns | 0.0166 ns |         - |
+| RequiresNotNullOrWhiteSpace | X                |                        | X                       | 2.298 ns | 0.0470 ns | 0.0393 ns |         - |
+| RequiresNotNullOrWhiteSpace | X                | X                      | X                       | 2.225 ns | 0.0223 ns | 0.0198 ns |         - |
+
+### NotEmptyOrWhiteSpace Benchmarks
+
+| Method            | Message Template | Exception Factory |     Mean |     Error |    StdDev | Allocated |
+|:----------------- |:----------------:|:-----------------:|---------:|----------:|----------:|----------:|
+| RequiresMinLength |                  |                   | 1.907 ns | 0.0316 ns | 0.0295 ns |         - |
+| RequiresMinLength | X                |                   | 2.461 ns | 0.0270 ns | 0.0253 ns |         - |
+| RequiresMinLength |                  | X                 | 2.981 ns | 0.0201 ns | 0.0179 ns |         - |
+| RequiresMinLength | X                | X                 | 2.533 ns | 0.0230 ns | 0.0204 ns |         - |

--- a/DbC.Net.Examples/NotEmptyOrWhiteSpaceExamples.cs
+++ b/DbC.Net.Examples/NotEmptyOrWhiteSpaceExamples.cs
@@ -1,0 +1,37 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class NotEmptyOrWhiteSpaceExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must have a non-empty/non-whitespace value";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = String.Empty;
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresNotEmptyOrWhiteSpace();
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresNotEmptyOrWhiteSpace(customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresNotEmptyOrWhiteSpace(exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresNotEmptyOrWhiteSpace(customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.EnsuresNotEmptyOrWhiteSpace();
+
+      // Postcondition with custom message template and default exception factory.
+      value.EnsuresNotEmptyOrWhiteSpace(customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.EnsuresNotEmptyOrWhiteSpace(exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.EnsuresNotEmptyOrWhiteSpace(customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/NotEmptyOrWhiteSpaceBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/NotEmptyOrWhiteSpaceBenchmarks.cs
@@ -1,0 +1,39 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class NotEmptyOrWhiteSpaceBenchmarks
+{
+   private const String _value = "asdf";
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must have a non-empty/non-whitespace value";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _value.RequiresNotEmptyOrWhiteSpace();
+   }
+
+   [Benchmark]
+   public void RequiresNotEmptyOrWhiteSpace_String_P000()
+   {
+      var result = _value.RequiresNotEmptyOrWhiteSpace();
+   }
+
+   [Benchmark]
+   public void RequiresNotEmptyOrWhiteSpace_String_P100()
+   {
+      var result = _value.RequiresNotEmptyOrWhiteSpace(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresNotEmptyOrWhiteSpace_String_P010()
+   {
+      var result = _value.RequiresNotEmptyOrWhiteSpace(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresNotEmptyOrWhiteSpace_String_P110()
+   {
+      var result = _value.RequiresNotEmptyOrWhiteSpace(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -15,4 +15,5 @@
 //BenchmarkRunner.Run<MaxLengthBenchmarks>();
 //BenchmarkRunner.Run<MinLengthBenchmarks>();
 //BenchmarkRunner.Run<NotNullOrEmptyBenchmarks>();
-BenchmarkRunner.Run<NotNullOrWhiteSpaceBenchmarks>();
+//BenchmarkRunner.Run<NotNullOrWhiteSpaceBenchmarks>();
+BenchmarkRunner.Run<NotEmptyOrWhiteSpaceBenchmarks>();

--- a/DbC.Net.Tests.Unit/NotEmptyOrWhiteSpaceExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEmptyOrWhiteSpaceExtensionsTests.cs
@@ -1,0 +1,222 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class NotEmptyOrWhiteSpaceExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresNotEmptyOrWhiteSpace Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("asdf")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldNotThrow_WhenValueIsNotEmptyOrWhiteSpace(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrow_WhenValueIsEmptyOrWhiteSpace(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace();
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowWithExpectedDataDictionary_WhenValueIsEmptyOrWhiteSpace(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace();
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEmptyOrWhiteSpace);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllDefaultsAreUsed(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace();
+      var expectedMessage = $"Postcondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
+   {
+      // Arrange.
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace(messageTemplate);
+      var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
+
+      // Act/assert.
+      act.Should().Throw<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomExceptionFactoryIsUsed(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed(String value)
+   {
+      // Arrange.
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+
+   #region RequiresNotEmptyOrWhiteSpace Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("asdf")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldNotThrow_WhenValueIsNotEmptyOrWhiteSpace(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowArgumentException_WhenValueIsEmptyOrWhiteSpace(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace();
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowWithExpectedDataDictionary_WhenValueIsEmptyOrWhiteSpace(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace();
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.NotEmptyOrWhiteSpace);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllDefaultsAreUsed(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
+   {
+      // Arrange.
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
+
+      // Act/assert.
+      act.Should().Throw<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomExceptionFactoryIsUsed(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Theory]
+   [InlineData("")]
+   [InlineData("\t")]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed(String value)
+   {
+      // Arrange.
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresNotEmptyOrWhiteSpace(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/NotNullOrEmptyExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullOrEmptyExtensionsTests.cs
@@ -100,7 +100,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
    {
       // Arrange.
       String value = null!;
@@ -113,7 +113,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyAndAllDefaultsAreUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyAndAllDefaultsAreUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -126,7 +126,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -140,7 +140,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyAndAllCustomMessageTemplateIsUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyAndAllCustomMessageTemplateIsUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -154,7 +154,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -167,7 +167,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomEmptyExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomEmptyExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -180,7 +180,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -194,7 +194,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_EnsuresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -305,7 +305,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
    {
       // Arrange.
       String value = null!;
@@ -320,7 +320,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyAndAllDefaultsAreUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyAndAllDefaultsAreUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -335,7 +335,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -351,7 +351,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyAndAllCustomMessageTemplateIsUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyAndAllCustomMessageTemplateIsUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -367,7 +367,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -380,7 +380,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomEmptyExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomEmptyExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = String.Empty;
@@ -393,7 +393,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -407,7 +407,7 @@ public  class NotNullOrEmptyExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed()
+   public void NotNullOrEmptyExtensions_RequiresNotNullOrEmpty_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed()
    {
       // Arrange.
       var value = String.Empty;

--- a/DbC.Net.Tests.Unit/NotNullOrWhiteSpaceExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullOrWhiteSpaceExtensionsTests.cs
@@ -77,7 +77,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
    {
       // Arrange.
       String value = null!;
@@ -92,7 +92,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllDefaultsAreUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllDefaultsAreUsed(String value)
    {
       // Arrange.
       var act = () => _ = value.EnsuresNotNullOrWhiteSpace();
@@ -104,7 +104,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -120,7 +120,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
    {
       // Arrange.
       var messageTemplate = "Requirement {RequirementName} failed";
@@ -133,7 +133,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -148,7 +148,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomEmptyExceptionFactoryIsUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomEmptyExceptionFactoryIsUsed(String value)
    {
       // Arrange.
       var act = () => _ = value.EnsuresNotNullOrWhiteSpace(emptyExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
@@ -160,7 +160,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -176,7 +176,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_EnsuresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_EnsuresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed(String value)
    {
       // Arrange.
       var messageTemplate = "Requirement {RequirementName} failed";
@@ -246,7 +246,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndAllDefaultsAreUsed()
    {
       // Arrange.
       String value = null!;
@@ -263,7 +263,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllDefaultsAreUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllDefaultsAreUsed(String value)
    {
       // Arrange.
       var act = () => _ = value.RequiresNotNullOrWhiteSpace();
@@ -277,7 +277,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowArgumentNullExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -295,7 +295,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
    {
       // Arrange.
       var messageTemplate = "Requirement {RequirementName} failed";
@@ -310,7 +310,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -325,7 +325,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomEmptyExceptionFactoryIsUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomEmptyExceptionFactoryIsUsed(String value)
    {
       // Arrange.
       var act = () => _ = value.RequiresNotNullOrWhiteSpace(emptyExceptionFactory: TestExceptionFactories.CustomExceptionFactory);
@@ -337,7 +337,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    }
 
    [Fact]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsNullAndCustomMessageTemplateAndCustomNullExceptionFactoryIsUsed()
    {
       // Arrange.
       String value = null!;
@@ -353,7 +353,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void MaxLengthExtensions_RequiresMaxLength_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed(String value)
+   public void NotNullOrWhiteSpaceExtensions_RequiresNotNullOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateAndCustomEmptyExceptionFactoryIsUsed(String value)
    {
       // Arrange.
       var messageTemplate = "Requirement {RequirementName} failed";

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -37,6 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\MaxLength.md = Documentation\MaxLength.md
 		Documentation\MinLength.md = Documentation\MinLength.md
 		Documentation\NotDefault.md = Documentation\NotDefault.md
+		Documentation\NotEmptyOrWhiteSpace.md = Documentation\NotEmptyOrWhiteSpace.md
 		Documentation\NotEqual.md = Documentation\NotEqual.md
 		Documentation\NotNull.md = Documentation\NotNull.md
 		Documentation\NotNullOrEmpty.md = Documentation\NotNullOrEmpty.md

--- a/DbC.Net/ApproximatelyEqualExtensions.cs
+++ b/DbC.Net/ApproximatelyEqualExtensions.cs
@@ -18,7 +18,7 @@ public static class ApproximatelyEqualExtensions
    ///   The value to check.
    /// </param>
    /// <param name="target">
-   ///   The target that <paramref name="value"/> should be close to..
+   ///   The target that <paramref name="value"/> should be close to.
    /// </param>
    /// <param name="epsilon">
    ///   The allowed error margin. 
@@ -34,8 +34,8 @@ public static class ApproximatelyEqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> not within 
+   ///   +/- <paramref name="epsilon"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -92,7 +92,7 @@ public static class ApproximatelyEqualExtensions
    ///   The value to check.
    /// </param>
    /// <param name="target">
-   ///   The target that <paramref name="value"/> should be close to..
+   ///   The target that <paramref name="value"/> should be close to.
    /// </param>
    /// <param name="epsilon">
    ///   The allowed error margin. 
@@ -108,8 +108,8 @@ public static class ApproximatelyEqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> not within 
+   ///   +/- <paramref name="epsilon"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/BetweenExtensions.cs
+++ b/DbC.Net/BetweenExtensions.cs
@@ -30,8 +30,9 @@ public static class BetweenExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is less than
+   ///   <paramref name="lowerBound"/> or greater than <paramref name="upperBound"/>.
+   ///   Defaults to
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -103,8 +104,9 @@ public static class BetweenExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is less than
+   ///   <paramref name="lowerBound"/> or greater than <paramref name="upperBound"/>.
+   ///   Defaults to
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/EqualExtensions.cs
+++ b/DbC.Net/EqualExtensions.cs
@@ -25,8 +25,8 @@ public static class EqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not equal
+   ///   to <paramref name="target"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -81,8 +81,8 @@ public static class EqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not equal
+   ///   to <paramref name="target"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -26,8 +26,8 @@ public static class GreaterThanExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater
+   ///   than <paramref name="lowerBound"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -83,8 +83,8 @@ public static class GreaterThanExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater
+   ///   than <paramref name="lowerBound"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/GreaterThanOrEqualExtensions.cs
+++ b/DbC.Net/GreaterThanOrEqualExtensions.cs
@@ -27,8 +27,8 @@ public static class GreaterThanOrEqualToExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater
+   ///   than or equal to <paramref name="lowerBound"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -85,8 +85,8 @@ public static class GreaterThanOrEqualToExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater
+   ///   than or equal to <paramref name="lowerBound"/>. Defaults to
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/GreaterThanOrEqualToZeroExtensions.cs
+++ b/DbC.Net/GreaterThanOrEqualToZeroExtensions.cs
@@ -25,8 +25,8 @@ public static class GreaterThanOrEqualToZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater
+   ///   than or equal to zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -70,8 +70,8 @@ public static class GreaterThanOrEqualToZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater
+   ///   than or equal to zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/GreaterThanZeroExtensions.cs
+++ b/DbC.Net/GreaterThanZeroExtensions.cs
@@ -21,8 +21,8 @@ public static class GreaterThanZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater 
+   ///   than zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -62,8 +62,8 @@ public static class GreaterThanZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not greater 
+   ///   than zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/LessThanExtensions.cs
+++ b/DbC.Net/LessThanExtensions.cs
@@ -27,8 +27,8 @@ public static class LessThanExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less
+   ///   than <paramref name="upperBound"/>. Defaults to
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -85,8 +85,8 @@ public static class LessThanExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less
+   ///   than <paramref name="upperBound"/>. Defaults to
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/LessThanOrEqualExtensions.cs
+++ b/DbC.Net/LessThanOrEqualExtensions.cs
@@ -26,8 +26,8 @@ public static class LessThanOrEqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less
+   ///   than or equal to <paramref name="upperBound"/>. Defaults to
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -83,8 +83,8 @@ public static class LessThanOrEqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less
+   ///   than or equal to <paramref name="upperBound"/>. Defaults to
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/LessThanOrEqualToZeroExtensions.cs
+++ b/DbC.Net/LessThanOrEqualToZeroExtensions.cs
@@ -21,8 +21,8 @@ public static class LessThanOrEqualToZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less 
+   ///   than or equal to zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -62,8 +62,8 @@ public static class LessThanOrEqualToZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less 
+   ///   than or equal to zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/LessThanZeroExtensions.cs
+++ b/DbC.Net/LessThanZeroExtensions.cs
@@ -24,8 +24,8 @@ public static class LessThanZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is not less 
+   ///   than zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -68,8 +68,8 @@ public static class LessThanZeroExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is less than 
+   ///   zero. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/MaxLengthExtensions.cs
+++ b/DbC.Net/MaxLengthExtensions.cs
@@ -24,8 +24,8 @@ public static class MaxLengthExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/>'s length is
+   ///   greater than <paramref name="maxLength"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -80,8 +80,8 @@ public static class MaxLengthExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/>'s length is
+   ///   greater than <paramref name="maxLength"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -187,6 +187,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may not be String.Empty or all whitespace characters.
+        /// </summary>
+        internal static string NotEmptyOrWhiteSpaceTemplate {
+            get {
+                return ResourceManager.GetString("NotEmptyOrWhiteSpaceTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}.
         /// </summary>
         internal static string NotEqualTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -159,6 +159,9 @@
   <data name="NotDefaultTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})</value>
   </data>
+  <data name="NotEmptyOrWhiteSpaceTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be String.Empty or all whitespace characters</value>
+  </data>
   <data name="NotEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must not be equal to {Target}</value>
   </data>

--- a/DbC.Net/MinLengthExtensions.cs
+++ b/DbC.Net/MinLengthExtensions.cs
@@ -24,8 +24,8 @@ public static class MinLengthExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/>'s length is
+   ///   less than <paramref name="minLength"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -80,8 +80,8 @@ public static class MinLengthExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/>'s length is
+   ///   less than <paramref name="minLength"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentOutOfRangeExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/NotEmptyOrWhiteSpaceExtensions.cs
+++ b/DbC.Net/NotEmptyOrWhiteSpaceExtensions.cs
@@ -1,28 +1,28 @@
 ﻿namespace DbC.Net;
 
 /// <summary>
-///   Extension methods that implement NotDefault requirement.
+///   Extension methods that implement String NotEmptyOrWhiteSpace requirement.
 /// </summary>
-public static class NotDefaultExtensions
+public static class NotEmptyOrWhiteSpaceExtensions
 {
-   private const String _requirementName = RequirementNames.NotDefault;
+   private const String _requirementName = RequirementNames.NotEmptyOrWhiteSpace;
 
    /// <summary>
-   ///   NotDefault postcondition. Confirm that <paramref name="value"/> is not 
-   ///   the default for type {T} and throw an exception if it is default for 
-   ///   type {T}.
+   ///   NotEmptyOrWhiteSpace postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is not  <see cref="String.Empty"/> or all 
+   ///   whitespace characters and throw an exception if it is empty or whitespace.
    /// </summary>
    /// <param name="value">
    ///   The value to check.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be empty or all whitespace characters".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is not default
-   ///   for type {T}. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see cref="String.Empty"/> or all whitespace characters. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -33,14 +33,14 @@ public static class NotDefaultExtensions
    ///   The tested <paramref name="value"/> is returned unaltered to support 
    ///   chaining requirements.
    /// </returns>
-   public static T EnsuresNotDefault<T>(
-      this T value,
+   public static String EnsuresNotEmptyOrWhiteSpace(
+      this String value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
       [CallerArgumentExpression("value")] String valueExpression = null!)
    {
-      CheckNotDefault(
-         value!,
+      CheckNotEmptyOrWhiteSpace(
+         value,
          RequirementType.Postcondition,
          messageTemplate,
          exceptionFactory,
@@ -50,21 +50,21 @@ public static class NotDefaultExtensions
    }
 
    /// <summary>
-   ///   NotDefault precondition. Confirm that <paramref name="value"/> is not 
-   ///   the default for type {T} and throw an exception if it is default for 
-   ///   type {T}.
+   ///   NotEmptyOrWhiteSpace precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> is not  <see cref="String.Empty"/> or all 
+   ///   whitespace characters and throw an exception if it is empty or whitespace.
    /// </summary>
    /// <param name="value">
    ///   The value to check.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
-   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be default({ValueDatatype})".
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may not be empty or all whitespace characters".
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is not default
-   ///   for type {T}. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see cref="String.Empty"/> or all whitespace characters. Defaults to 
    ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -75,14 +75,14 @@ public static class NotDefaultExtensions
    ///   The tested <paramref name="value"/> is returned unaltered to support 
    ///   chaining requirements.
    /// </returns>
-   public static T RequiresNotDefault<T>(
-      this T value,
+   public static String RequiresNotEmptyOrWhiteSpace(
+      this String value,
       String? messageTemplate = null,
       IExceptionFactory? exceptionFactory = null,
       [CallerArgumentExpression("value")] String valueExpression = null!)
    {
-      CheckNotDefault(
-         value!,
+      CheckNotEmptyOrWhiteSpace(
+         value,
          RequirementType.Precondition,
          messageTemplate,
          exceptionFactory,
@@ -91,21 +91,20 @@ public static class NotDefaultExtensions
       return value;
    }
 
-   private static void CheckNotDefault<T>(
-      T value,
+   private static void CheckNotEmptyOrWhiteSpace(
+      String? value,
       RequirementType requirementType,
       String? messageTemplate,
       IExceptionFactory? exceptionFactory,
       String valueExpression)
    {
-      if (EqualityComparer<T>.Default.Equals(value, default))
+      if (value is not null && String.IsNullOrWhiteSpace(value))
       {
-         messageTemplate ??= MessageTemplates.NotDefaultTemplate;
-         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         messageTemplate ??= MessageTemplates.NotEmptyOrWhiteSpaceTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentNullExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
-            .WithItem(DataNames.ValueExpression, valueExpression)
-            .WithItem(DataNames.ValueDatatype, typeof(T).Name)
+            .WithValue(value!, valueExpression)
             .Build();
 
          throw exceptionFactory.CreateException(data, messageTemplate);

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -25,8 +25,8 @@ public static class NotEqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is equal to
+   ///   <paramref name="target"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">
@@ -81,8 +81,8 @@ public static class NotEqualExtensions
    /// </param>
    /// <param name="exceptionFactory">
    ///   Optional. The <see cref="IExceptionFactory"/> used to create the
-   ///   exception that is thrown if the <paramref name="value"/> is 
-   ///   <see langword="null"/>. Defaults to 
+   ///   exception that is thrown if the <paramref name="value"/> is equal to
+   ///   <paramref name="target"/>. Defaults to 
    ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
    /// </param>
    /// <param name="valueExpression">

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -19,6 +19,7 @@ public static class RequirementNames
    public const String MaxLength = nameof(MaxLength);
    public const String MinLength = nameof(MinLength);
    public const String NotDefault = nameof(NotDefault);
+   public const String NotEmptyOrWhiteSpace = nameof(NotEmptyOrWhiteSpace);
    public const String NotEqual = nameof(NotEqual);
    public const String NotNull = nameof(NotNull);
    public const String NotNullOrEmpty = nameof(NotNullOrEmpty);

--- a/Documentation/NotEmptyOrWhiteSpace.md
+++ b/Documentation/NotEmptyOrWhiteSpace.md
@@ -23,4 +23,33 @@ RequirementName, Value and ValueExpression.
 
 **Examples:**
 ```C#
+var customMessageTemplate = "{ValueExpression} must have a non-empty/non-whitespace value";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = String.Empty;
+
+// Precondition with default message template and default exception factory.
+value.RequiresNotEmptyOrWhiteSpace();
+
+// Precondition with custom message template and default exception factory.
+value.RequiresNotEmptyOrWhiteSpace(customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresNotEmptyOrWhiteSpace(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresNotEmptyOrWhiteSpace(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.EnsuresNotEmptyOrWhiteSpace();
+
+// Postcondition with custom message template and default exception factory.
+value.EnsuresNotEmptyOrWhiteSpace(customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.EnsuresNotEmptyOrWhiteSpace(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.EnsuresNotEmptyOrWhiteSpace(customMessageTemplate, customExceptionFactory);
 ```

--- a/Documentation/NotEmptyOrWhiteSpace.md
+++ b/Documentation/NotEmptyOrWhiteSpace.md
@@ -1,0 +1,26 @@
+### NotEmptyOrWhiteSpace
+
+NotEmptyOrWhiteSpace requires that the string value being checked not be String.Empty 
+or all whitespace characters. Null is allowed.
+
+Use NotEmptyOrWhiteSpace where a string may be completed uninitialized (null) or
+if initialized may not be empty.
+
+**Method signatures:**
+```C#
+String RequiresNotEmptyOrWhiteSpace(this String value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
+
+String EnsuresNotEmptyOrWhiteSpace(this String value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
+```
+
+The default message template for NotEmptyOrWhiteSpace is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be String.Empty or all whitespace characters".
+The default exception factory for RequiresNotEmptyOrWhiteSpace is StandardExceptionFactories.ArgumentNullExceptionFactory 
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresNotEmptyOrWhiteSpace.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value and ValueExpression.
+
+**Examples:**
+```C#
+```

--- a/Documentation/NotNullOrWhiteSpace.md
+++ b/Documentation/NotNullOrWhiteSpace.md
@@ -10,7 +10,7 @@ String RequiresNotNullOrWhiteSpace(this String value, [String? messageTemplate =
 String EnsuresNotNullOrWhiteSpace(this String value, [String? messageTemplate = null], [IExceptionFactory? nullExceptionFactory = null], [IExceptionFactory? emptyExceptionFactory = null], [String? valueExpression = null])
 ```
 
-The default message template for NotNullOrWhiteSpace is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null String.Empty or all whitespace characters".
+The default message template for NotNullOrWhiteSpace is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be null, String.Empty or all whitespace characters".
 Requires/EnsuresNotNullOrWhiteSpace use two exception factories, one for exceptions
 thrown when the value being checked is null and one for exceptions thrown when
 the value being checked is empty or all whitespace characters. The default exception 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value is neither String.Empty or all whitespace characters. Null is allowed.

Requirements:

  RequiresNotEmptyOrWhiteSpace (precondition), default ArgumentException 
  EnsuresNotEmptyOrWhiteSpace (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresEmptyOrWhiteSpace
2. Implement EnsuresEmptyOrWhiteSpace
3. Unit tests for Requires/Ensures NotEmptyOrWhiteSpace
4. Performance tests
5. Readme updates
6. Examples