### PR TITLE
S0022 alpha numeric only

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -31,6 +31,10 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
 
   - [MaxLength Benchmarks](#maxlength-benchmarks)
   - [MinLength Benchmarks](#minlength-benchmarks)
+  - [NotNullOrEmpty Benchmarks](#notnullorempty-benchmarks)
+  - [NotNullOrWhiteSpace Benchmarks](#notnullorwhitespace-benchmarks)
+  - [NotEmptyOrWhiteSpace Benchmarks](#notemptyorwhitespace-benchmarks)
+  - [AlphaNumericOnly Benchmarks](#alphanumericonly-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -544,3 +548,20 @@ parameter was omitted.
 | RequiresMinLength | X                |                   | 2.461 ns | 0.0270 ns | 0.0253 ns |         - |
 | RequiresMinLength |                  | X                 | 2.981 ns | 0.0201 ns | 0.0179 ns |         - |
 | RequiresMinLength | X                | X                 | 2.533 ns | 0.0230 ns | 0.0204 ns |         - |
+
+### AlphaNumericOnly Benchmarks
+
+| Method                   | String content      | Message Template | Exception Factory |       Mean |     Error |    StdDev | Allocated |
+|:------------------------ |:--------------------|:----------------:|:-----------------:|-----------:|----------:|----------:|----------:|
+| RequiresAlphaNumericOnly | Null String         |                  |                   |   1.440 ns | 0.0125 ns | 0.0098 ns |         - |
+| RequiresAlphaNumericOnly | Null String         | X                |                   |   1.247 ns | 0.0245 ns | 0.0229 ns |         - |
+| RequiresAlphaNumericOnly | Null String         |                  | X                 |   1.870 ns | 0.0055 ns | 0.0046 ns |         - |
+| RequiresAlphaNumericOnly | Null String         | X                | X                 |   1.444 ns | 0.0095 ns | 0.0089 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 10)  |                  |                   |  14.056 ns | 0.0816 ns | 0.0724 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 10)  | X                |                   |  14.423 ns | 0.2091 ns | 0.1746 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 10)  |                  | X                 |  14.459 ns | 0.0728 ns | 0.0569 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 10)  | X                | X                 |  14.703 ns | 0.1031 ns | 0.0914 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 100) |                  |                   | 139.280 ns | 0.9190 ns | 0.8147 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 100) | X                |                   | 140.831 ns | 1.7650 ns | 1.6510 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 100) |                  | X                 | 138.831 ns | 0.8712 ns | 0.8149 ns |         - |
+| RequiresAlphaNumericOnly | String (Length 100) | X                | X                 | 140.733 ns | 0.7224 ns | 0.6757 ns |         - |

--- a/DbC.Net.Examples/AlphaNumericOnlyExamples.cs
+++ b/DbC.Net.Examples/AlphaNumericOnlyExamples.cs
@@ -1,0 +1,37 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class AlphaNumericOnlyExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must contain only letters or digits";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = "abc123";
+
+      // Precondition with default message template and default exception factory.
+      value.RequiresAlphaNumericOnly();
+
+      // Precondition with custom message template and default exception factory.
+      value.RequiresAlphaNumericOnly(customMessageTemplate);
+
+      // Precondition with default message template and custom exception factory.
+      value.RequiresAlphaNumericOnly(exceptionFactory: customExceptionFactory);
+
+      // Precondition with custom message template and custom exception factory.
+      value.RequiresAlphaNumericOnly(customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default message template and default exception factory.
+      value.EnsuresAlphaNumericOnly();
+
+      // Postcondition with custom message template and default exception factory.
+      value.EnsuresAlphaNumericOnly(customMessageTemplate);
+
+      // Postcondition with default message template and custom exception factory.
+      value.EnsuresAlphaNumericOnly(exceptionFactory: customExceptionFactory);
+
+      // Postcondition with custom message template and custom exception factory.
+      value.EnsuresAlphaNumericOnly(customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/AlphaNumericOnlyBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/AlphaNumericOnlyBenchmarks.cs
@@ -1,0 +1,89 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class AlphaNumericOnlyBenchmarks
+{
+   private const String _nullString = null!;
+   private const String _shortString = "asdf123456";
+   private const String _longString = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+   private const String _messageTemplate = "Requires{RequirementName} failed: {Value} must be alphanumeric only";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _shortString.RequiresAlphaNumericOnly();
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_NullString_P000()
+   {
+      var result = _nullString.RequiresAlphaNumericOnly();
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_NullString_P100()
+   {
+      var result = _nullString.RequiresAlphaNumericOnly(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_NullString_P010()
+   {
+      var result = _nullString.RequiresAlphaNumericOnly(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_NullString_P110()
+   {
+      var result = _nullString.RequiresAlphaNumericOnly(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_ShortString_P000()
+   {
+      var result = _shortString.RequiresAlphaNumericOnly();
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_ShortString_P100()
+   {
+      var result = _shortString.RequiresAlphaNumericOnly(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_ShortString_P010()
+   {
+      var result = _shortString.RequiresAlphaNumericOnly(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_ShortString_P110()
+   {
+      var result = _shortString.RequiresAlphaNumericOnly(_messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_LongString_P000()
+   {
+      var result = _longString.RequiresAlphaNumericOnly();
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_LongString_P100()
+   {
+      var result = _longString.RequiresAlphaNumericOnly(_messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_LongString_P010()
+   {
+      var result = _longString.RequiresAlphaNumericOnly(exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresAlphaNumericOnly_LongString_P110()
+   {
+      var result = _longString.RequiresAlphaNumericOnly(_messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -16,4 +16,5 @@
 //BenchmarkRunner.Run<MinLengthBenchmarks>();
 //BenchmarkRunner.Run<NotNullOrEmptyBenchmarks>();
 //BenchmarkRunner.Run<NotNullOrWhiteSpaceBenchmarks>();
-BenchmarkRunner.Run<NotEmptyOrWhiteSpaceBenchmarks>();
+//BenchmarkRunner.Run<NotEmptyOrWhiteSpaceBenchmarks>();
+BenchmarkRunner.Run<AlphaNumericOnlyBenchmarks>();

--- a/DbC.Net.Tests.Unit/AlphaNumericOnlyExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/AlphaNumericOnlyExtensionsTests.cs
@@ -1,0 +1,270 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class AlphaNumericOnlyExtensionsTests
+{
+   private const Int32 _dataCount = 4;
+
+   #region EnsuresAlphaNumericOnly Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("123")]
+   [InlineData("asdf")]
+   [InlineData("QWERTY")]
+   [InlineData(StringData.UpperCaseDiphthongAE)]
+   [InlineData(StringData.LowerCaseAWithOverring)]
+   [InlineData("abc123XYZ")]
+   [InlineData("s\u00F8ster")]  // s + lower case slashed 'o' + ster - Danish for sister
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldNotThrow_WhenValueContainsOnlyLetterOrDigitCharacters(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldNotThrow_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldNotThrow_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.EnsuresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData("This is a test!")]
+   [InlineData("\t")]
+   [InlineData("\tASDF\t")]
+   [InlineData(StringData.LowerCaseAPlusDiaeresisCombiningCharacter)]
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldThrow_WhenValueContainsNonLetterOrNonDigitCharacters(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = "(555) 123-4567";
+      var act = () => _ = value.EnsuresAlphaNumericOnly();
+
+      // Act/assert.
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.AlphaNumericOnly);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "(555) 123-4567";
+      var act = () => _ = value.EnsuresAlphaNumericOnly();
+      var expectedMessage = $"Postcondition AlphaNumericOnly failed: value may only contain alphanumeric characters";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_EnsuresAlphaNumericOnly_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "\t123\t";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresAlphaNumericOnly(messageTemplate);
+      var expectedMessage = $"Requirement AlphaNumericOnly failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "!@#$%^&*()_+";
+      var act = () => _ = value.EnsuresAlphaNumericOnly(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition AlphaNumericOnly failed: value may only contain alphanumeric characters";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.DiaeresisCombiningCharacter;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresAlphaNumericOnly(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement AlphaNumericOnly failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+
+   #region RequiresAlphaNumericOnly Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("123")]
+   [InlineData("asdf")]
+   [InlineData("QWERTY")]
+   [InlineData(StringData.UpperCaseDiphthongAE)]
+   [InlineData(StringData.LowerCaseAWithOverring)]
+   [InlineData("abc123XYZ")]
+   [InlineData("s\u00F8ster")]  // s + lower case slashed 'o' + ster - Danish for sister
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldNotThrow_WhenValueContainsOnlyLetterOrDigitCharacters(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldNotThrow_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldNotThrow_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var act = () => _ = value.RequiresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Theory]
+   [InlineData("This is a test!")]
+   [InlineData("\t")]
+   [InlineData("\tASDF\t")]
+   [InlineData(StringData.LowerCaseAPlusDiaeresisCombiningCharacter)]
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldThrow_WhenValueContainsNonLetterOrNonDigitCharacters(String value)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresAlphaNumericOnly();
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed()
+   {
+      // Arrange.
+      var value = "(555) 123-4567";
+      var act = () => _ = value.RequiresAlphaNumericOnly();
+
+      // Act/assert.
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.AlphaNumericOnly);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "(555) 123-4567";
+      var act = () => _ = value.RequiresAlphaNumericOnly();
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition AlphaNumericOnly failed: value may only contain alphanumeric characters";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void AlphaNumericOnlyExtensions_RequiresAlphaNumericOnly_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "\t123\t";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresAlphaNumericOnly(messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement AlphaNumericOnly failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "!@#$%^&*()_+";
+      var act = () => _ = value.RequiresAlphaNumericOnly(exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition AlphaNumericOnly failed: value may only contain alphanumeric characters";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = StringData.DiaeresisCombiningCharacter;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresAlphaNumericOnly(messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement AlphaNumericOnly failed";
+
+      // Act/assert.
+      act.Should().Throw<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/NotEmptyOrWhiteSpaceExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEmptyOrWhiteSpaceExtensionsTests.cs
@@ -67,7 +67,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
+   public void NotEmptyOrWhiteSpaceExtensions_EnsuresNotEmptyOrWhiteSpace_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateIsUsed(String value)
    {
       // Arrange.
       var messageTemplate = "Requirement {RequirementName} failed";
@@ -129,13 +129,13 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowArgumentException_WhenValueIsEmptyOrWhiteSpace(String value)
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrow_WhenValueIsEmptyOrWhiteSpace(String value)
    {
       // Arrange.
       var act = () => _ = value.RequiresNotEmptyOrWhiteSpace();
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -147,7 +147,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var act = () => _ = value.RequiresNotEmptyOrWhiteSpace();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -167,7 +167,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Precondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -175,7 +175,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
    [Theory]
    [InlineData("")]
    [InlineData("\t")]
-   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndAllCustomMessageTemplateIsUsed(String value)
+   public void NotEmptyOrWhiteSpaceExtensions_RequiresNotEmptyOrWhiteSpace_ShouldThrowArgumentExceptionWithExpectedMessage_WhenValueIsEmptyOrWhiteSpaceAndCustomMessageTemplateIsUsed(String value)
    {
       // Arrange.
       var messageTemplate = "Requirement {RequirementName} failed";
@@ -184,7 +184,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }

--- a/DbC.Net.Tests.Unit/Utility/StringUtilitiesExtensions.cs
+++ b/DbC.Net.Tests.Unit/Utility/StringUtilitiesExtensions.cs
@@ -1,0 +1,51 @@
+﻿using DbC.Net.Utility;
+
+namespace DbC.Net.Tests.Unit.Utility;
+
+public class StringUtilitiesExtensions
+{
+   #region IsAlphaNumericOnly Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("123")]
+   [InlineData("asdf")]
+   [InlineData("QWERTY")]
+   [InlineData(StringData.UpperCaseDiphthongAE)]
+   [InlineData(StringData.LowerCaseAWithOverring)]
+   [InlineData("abc123XYZ")]
+   [InlineData("s\u00F8ster")]  // s + lower case slashed 'o' + ster - Danish for sister
+   public void StringUtilities_IsAlphaNumericOnly_ShouldReturnTrue_WhenValueContainsOnlyLetterOrDigitCharacters(String value)
+      => value.IsAlphaNumericOnly().Should().BeTrue();
+
+   [Fact]
+   public void StringUtilities_IsAlphaNumericOnly_ShouldReturnTrue_WhenValueIsNull()
+   {
+      // Arrange.
+      String value = null!;
+
+      // Act/assert.
+      value.IsAlphaNumericOnly().Should().BeTrue();
+   }
+
+   [Fact]
+   public void StringUtilities_IsAlphaNumericOnly_ShouldReturnTrue_WhenValueIsEmpty()
+   {
+      // Arrange.
+      var value = String.Empty;
+
+      // Act/assert.
+      value.IsAlphaNumericOnly().Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData("This is a test!")]
+   [InlineData("\t")]
+   [InlineData("\tASDF\t")]
+   [InlineData(StringData.LowerCaseAPlusDiaeresisCombiningCharacter)]
+   public void StringUtilities_IsAlphaNumericOnly_ShouldReturnTrue_WhenValueContainsNonLetterOrNonDigitCharacters(String value)
+      => value.IsAlphaNumericOnly().Should().BeFalse();
+
+   #endregion
+}

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -23,6 +23,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbC.Net.TestAndExampleResou
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{72254BA1-52A7-4B81-A595-76580B77647E}"
 	ProjectSection(SolutionItems) = preProject
+		Documentation\AlphaNumericOnly.md = Documentation\AlphaNumericOnly.md
 		Documentation\ApproximatelyEqual.md = Documentation\ApproximatelyEqual.md
 		Documentation\Between.md = Documentation\Between.md
 		Documentation\Equal.md = Documentation\Equal.md

--- a/DbC.Net/AlphaNumericOnlyExtensions.cs
+++ b/DbC.Net/AlphaNumericOnlyExtensions.cs
@@ -1,0 +1,117 @@
+﻿using DbC.Net.Utility;
+
+namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement String AlphaNumericOnly requirement.
+/// </summary>
+public static class AlphaNumericOnlyExtensions
+{
+   private const String _requirementName = RequirementNames.AlphaNumericOnly;
+
+   /// <summary>
+   ///   AlphaNumericOnly postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> contains only alphanumeric characters. A value
+   ///   that is <see langword="null"/> or <see cref="String.Empty"/> will pass
+   ///   the requirement.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may only contain alphanumeric characters".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> contains a
+   ///   non-letter or non-digit character. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String EnsuresAlphaNumericOnly(
+      this String value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!)
+   {
+      CheckAlphaNumericOnly(
+         value,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   /// <summary>
+   ///   AlphaNumericOnly precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> contains only alphanumeric characters. A value
+   ///   that is <see langword="null"/> or <see cref="String.Empty"/> will pass
+   ///   the requirement.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {ValueExpression} may only contain alphanumeric characters".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> contains a
+   ///   non-letter or non-digit character. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   public static String RequiresAlphaNumericOnly(
+      this String value,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!)
+   {
+      CheckAlphaNumericOnly(
+         value,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression);
+
+      return value;
+   }
+
+   private static void CheckAlphaNumericOnly(
+      String? value,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression)
+   {
+      if (!value!.IsAlphaNumericOnly())
+      {
+         messageTemplate ??= MessageTemplates.AlphaNumericOnlyTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -61,6 +61,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} may only contain alphanumeric characters.
+        /// </summary>
+        internal static string AlphaNumericOnlyTemplate {
+            get {
+                return ResourceManager.GetString("AlphaNumericOnlyTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}.
         /// </summary>
         internal static string ApproximatelyEqualTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AlphaNumericOnlyTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} may only contain alphanumeric characters</value>
+  </data>
   <data name="ApproximatelyEqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be within +/- {Epsilon} of {Target}</value>
   </data>

--- a/DbC.Net/NotEmptyOrWhiteSpaceExtensions.cs
+++ b/DbC.Net/NotEmptyOrWhiteSpaceExtensions.cs
@@ -101,7 +101,7 @@ public static class NotEmptyOrWhiteSpaceExtensions
       if (value is not null && String.IsNullOrWhiteSpace(value))
       {
          messageTemplate ??= MessageTemplates.NotEmptyOrWhiteSpaceTemplate;
-         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentNullExceptionFactory(requirementType);
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
          var data = ExceptionDataBuilder.Create()
             .WithRequirement(requirementType, _requirementName)
             .WithValue(value!, valueExpression)

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public static class RequirementNames
 {
+   public const String AlphaNumericOnly = nameof(AlphaNumericOnly);
    public const String ApproximatelyEqual = nameof(ApproximatelyEqual);
    public const String Between = nameof(Between);
    public const String Equal = nameof(Equal);

--- a/DbC.Net/Utility/StringUtilities.cs
+++ b/DbC.Net/Utility/StringUtilities.cs
@@ -1,0 +1,31 @@
+﻿namespace DbC.Net.Utility;
+
+public static class StringUtilities
+{
+   /// <summary>
+   ///   Check if the supplied <paramref name="str"/> contains only alphanumeric
+   ///   characters as defined by the <see cref="Char.IsLetterOrDigit(Char)"/>
+   ///   method.
+   /// </summary>
+   /// <param name="str">
+   ///   The <see cref="String"/> to check.
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if every character of <paramref name="str"/> is
+   ///   a alphanumeric; otherwise <see langword="false"/>.
+   /// </returns>
+   public static Boolean IsAlphaNumericOnly(this String str)
+   {
+      // Benchmarks showed that in this case foreach on the string is as 
+      // performant or better than indexed for loop or using a span.
+      foreach (var ch in str)
+      {
+         if (!Char.IsLetterOrDigit(ch))
+         {
+            return false;
+         }
+      }
+
+      return true;
+   }
+}

--- a/DbC.Net/Utility/StringUtilities.cs
+++ b/DbC.Net/Utility/StringUtilities.cs
@@ -5,7 +5,8 @@ public static class StringUtilities
    /// <summary>
    ///   Check if the supplied <paramref name="str"/> contains only alphanumeric
    ///   characters as defined by the <see cref="Char.IsLetterOrDigit(Char)"/>
-   ///   method.
+   ///   method. A value that is <see langword="null"/> or 
+   ///   <see cref="String.Empty"/> will return <see langword="true"/>.
    /// </summary>
    /// <param name="str">
    ///   The <see cref="String"/> to check.
@@ -16,6 +17,8 @@ public static class StringUtilities
    /// </returns>
    public static Boolean IsAlphaNumericOnly(this String str)
    {
+      str ??= String.Empty;
+
       // Benchmarks showed that in this case foreach on the string is as 
       // performant or better than indexed for loop or using a span.
       foreach (var ch in str)

--- a/Documentation/AlphaNumericOnly.md
+++ b/Documentation/AlphaNumericOnly.md
@@ -1,0 +1,53 @@
+### AlphaNumericOnly
+
+AlphaNumericOnly requires that the string value being checked contain only 
+alphanumeric characters (as defined by the Char.IsLetterOrDigit method). A null
+or empty string will fail the requirement.
+
+**Method signatures:**
+```C#
+String RequiresAlphaNumericOnly(this String value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
+
+String EnsuresAlphaNumericOnly(this String value, [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null])
+```
+
+The default message template for AlphaNumericOnly is "{RequirementType} {RequirementName} failed: {ValueExpression} may only contain alphanumeric characters".
+The default exception factory for RequiresAlphaNumericOnly is StandardExceptionFactories.ArgumentExceptionFactory 
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresAlphaNumericOnly.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value and ValueExpression.
+
+**Examples:**
+```C#
+var customMessageTemplate = "{ValueExpression} must contain only letters or digits";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = "This is a test!";
+
+// Precondition with default message template and default exception factory.
+value.RequiresAlphaNumericOnly();
+
+// Precondition with custom message template and default exception factory.
+value.RequiresAlphaNumericOnly(customMessageTemplate);
+
+// Precondition with default message template and custom exception factory.
+value.RequiresAlphaNumericOnly(exceptionFactory: customExceptionFactory);
+
+// Precondition with custom message template and custom exception factory.
+value.RequiresAlphaNumericOnly(customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default message template and default exception factory.
+value.EnsuresAlphaNumericOnly();
+
+// Postcondition with custom message template and default exception factory.
+value.EnsuresAlphaNumericOnly(customMessageTemplate);
+
+// Postcondition with default message template and custom exception factory.
+value.EnsuresAlphaNumericOnly(exceptionFactory: customExceptionFactory);
+
+// Postcondition with custom message template and custom exception factory.
+value.EnsuresAlphaNumericOnly(customMessageTemplate, customExceptionFactory);
+```

--- a/Documentation/AlphaNumericOnly.md
+++ b/Documentation/AlphaNumericOnly.md
@@ -2,7 +2,7 @@
 
 AlphaNumericOnly requires that the string value being checked contain only 
 alphanumeric characters (as defined by the Char.IsLetterOrDigit method). A null
-or empty string will fail the requirement.
+or empty string will pass the requirement.
 
 **Method signatures:**
 ```C#
@@ -24,7 +24,7 @@ RequirementName, Value and ValueExpression.
 var customMessageTemplate = "{ValueExpression} must contain only letters or digits";
 var customExceptionFactory = new CustomExceptionFactory();
 
-var value = "This is a test!";
+var value = "abc123";
 
 // Precondition with default message template and default exception factory.
 value.RequiresAlphaNumericOnly();

--- a/Documentation/NotEmptyOrWhiteSpace.md
+++ b/Documentation/NotEmptyOrWhiteSpace.md
@@ -14,7 +14,7 @@ String EnsuresNotEmptyOrWhiteSpace(this String value, [String? messageTemplate =
 ```
 
 The default message template for NotEmptyOrWhiteSpace is "{RequirementType} {RequirementName} failed: {ValueExpression} may not be String.Empty or all whitespace characters".
-The default exception factory for RequiresNotEmptyOrWhiteSpace is StandardExceptionFactories.ArgumentNullExceptionFactory 
+The default exception factory for RequiresNotEmptyOrWhiteSpace is StandardExceptionFactories.ArgumentExceptionFactory 
 and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
 EnsuresNotEmptyOrWhiteSpace.
 

--- a/Documentation/Stories/Backlog/S0049-Parsable.txt
+++ b/Documentation/Stories/Backlog/S0049-Parsable.txt
@@ -1,0 +1,17 @@
+As a developer who uses DbC.Net, I want to be able to require/ensure that a string value contains a value that can be parsed to type T where T implements the IParsable<TSelf> interface.
+
+If the string value can be parsed into type T, then the resulting value is returned via an output parameter.
+
+Requirements:
+
+  RequiresParsable<T> (precondition), default ArgumentException 
+  EnsuresParsable<T> (postcondition), default PostconditionFailedException
+
+DEFINITION OF DONE:
+
+1. Implement RequiresParsable<T>
+2. Implement EnsuresParsable<T>
+3. Unit tests for Requires/Ensures Parsable<T>
+4. Performance tests
+5. Readme updates
+6. Examples

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
     - [MinLength](/Documentation/MinLength.md)
     - [NotNullOrEmpty](/Documentation/NotNullOrEmpty.md)
     - [NotNullOrWhiteSpace](/Documentation/NotNullOrWhiteSpace.md)
+    - [AlphaNumericOnly](/Documentation/AlphaNumericOnly.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value contains only alphanumeric characters.

Requirements:

  RequiresAlphaNumericOnly (precondition), default ArgumentException 
  EnsuresAlphaNumericOnly (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresAlphaNumericOnly
2. Implement EnsuresAlphaNumericOnly
3. Unit tests for Requires/Ensures AlphaNumericOnly
4. Performance tests
5. Readme updates
6. Examples