### PR TITLE
S0023 contains

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -35,6 +35,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [NotNullOrWhiteSpace Benchmarks](#notnullorwhitespace-benchmarks)
   - [NotEmptyOrWhiteSpace Benchmarks](#notemptyorwhitespace-benchmarks)
   - [AlphaNumericOnly Benchmarks](#alphanumericonly-benchmarks)
+  - [Contains Benchmarks](#contains-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -565,3 +566,27 @@ parameter was omitted.
 | RequiresAlphaNumericOnly | String (Length 100) | X                |                   | 140.831 ns | 1.7650 ns | 1.6510 ns |         - |
 | RequiresAlphaNumericOnly | String (Length 100) |                  | X                 | 138.831 ns | 0.8712 ns | 0.8149 ns |         - |
 | RequiresAlphaNumericOnly | String (Length 100) | X                | X                 | 140.733 ns | 0.7224 ns | 0.6757 ns |         - |
+
+### Contains Benchmarks
+
+X indicates that the optional parameter was supplied; blank indicates that the 
+parameter was omitted.
+
+| Method           | String Comparer   | Message Template | Exception Factory |     Mean |    Error |   StdDev | Allocated |
+|:---------------- |:------------------|:----------------:|:-----------------:|---------:|---------:|---------:|----------:|
+| RequiresContains |                   |                  |                   | 12.60 ns | 0.054 ns | 0.051 ns |         - |
+| RequiresContains |                   | X                |                   | 12.79 ns | 0.042 ns | 0.037 ns |         - |
+| RequiresContains |                   |                  | X                 | 14.35 ns | 0.087 ns | 0.077 ns |         - |
+| RequiresContains |                   | X                | X                 | 13.88 ns | 0.084 ns | 0.074 ns |         - |
+| RequiresContains | Ordinal           |                  |                   | 12.99 ns | 0.095 ns | 0.089 ns |         - |
+| RequiresContains | Ordinal           | X                |                   | 13.01 ns | 0.062 ns | 0.055 ns |         - |
+| RequiresContains | Ordinal           |                  | X                 | 14.10 ns | 0.077 ns | 0.068 ns |         - |
+| RequiresContains | Ordinal           | X                | X                 | 13.53 ns | 0.110 ns | 0.097 ns |         - |
+| RequiresContains | OrdinalIgnoreCase |                  |                   | 17.93 ns | 0.090 ns | 0.080 ns |         - |
+| RequiresContains | OrdinalIgnoreCase | X                |                   | 18.32 ns | 0.213 ns | 0.199 ns |         - |
+| RequiresContains | OrdinalIgnoreCase |                  | X                 | 18.72 ns | 0.351 ns | 0.391 ns |         - |
+| RequiresContains | OrdinalIgnoreCase | X                | X                 | 18.72 ns | 0.384 ns | 0.897 ns |         - |
+| RequiresContains | CurrentCulture    |                  |                   | 88.56 ns | 1.754 ns | 4.977 ns |         - |
+| RequiresContains | CurrentCulture    | X                |                   | 84.54 ns | 1.730 ns | 3.415 ns |         - |
+| RequiresContains | CurrentCulture    |                  | X                 | 84.51 ns | 1.713 ns | 3.688 ns |         - |
+| RequiresContains | CurrentCulture    | X                | X                 | 80.13 ns | 0.814 ns | 0.800 ns |         - |

--- a/DbC.Net.Examples/ContainsExamples.cs
+++ b/DbC.Net.Examples/ContainsExamples.cs
@@ -1,0 +1,66 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class ContainsExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must contain target substring";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = "This is a test. This is only a test";
+      var target = "ONLY";
+      var comparisionType = StringComparison.OrdinalIgnoreCase;
+
+
+      // Precondition with default comparisionType, default message template and default exception factory.
+      value.RequiresContains(target);
+
+      // Precondition with default comparisionType, custom message template and default exception factory.
+      value.RequiresContains(target, messageTemplate: customMessageTemplate);
+
+      // Precondition with default comparisionType, default message template and custom exception factory.
+      value.RequiresContains(target, exceptionFactory: customExceptionFactory);
+
+      // Precondition with default comparisionType, custom message template and custom exception factory.
+      value.RequiresContains(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+      // Precondition with comparisionType, default message template and default exception factory.
+      value.RequiresContains(target, comparisionType);
+
+      // Precondition with comparisionType, custom message template and default exception factory.
+      value.RequiresContains(target, comparisionType, customMessageTemplate);
+
+      // Precondition with comparisionType, default message template and custom exception factory.
+      value.RequiresContains(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+      // Precondition with comparisionType, custom message template and custom exception factory.
+      value.RequiresContains(target, comparisionType, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default comparisionType, default message template and default exception factory.
+      value.EnsuresContains(target);
+
+      // Postcondition with default comparisionType, custom message template and default exception factory.
+      value.EnsuresContains(target, messageTemplate: customMessageTemplate);
+
+      // Postcondition with default comparisionType, default message template and custom exception factory.
+      value.EnsuresContains(target, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with default comparisionType, custom message template and custom exception factory.
+      value.EnsuresContains(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+      // Postcondition with comparisionType, default message template and default exception factory.
+      value.EnsuresContains(target, comparisionType);
+
+      // Postcondition with comparisionType, custom message template and default exception factory.
+      value.EnsuresContains(target, comparisionType, customMessageTemplate);
+
+      // Postcondition with comparisionType, default message template and custom exception factory.
+      value.EnsuresContains(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with comparisionType, custom message template and custom exception factory.
+      value.EnsuresContains(target, comparisionType, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/ContainsBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/ContainsBenchmarks.cs
@@ -1,0 +1,114 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class ContainsBenchmarks
+{
+   private const String _messageTemplate = "{ValueExpression} must contain target substring";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   private const String _value = "This is a test. This is only a test";
+   private const String _target = "only";
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _value.RequiresContains(_target);
+   }
+
+   [Benchmark]
+   public void RequiresContains_P000()
+   {
+      var result = _value.RequiresContains(_target);
+   }
+
+   [Benchmark]
+   public void RequiresContains_P010()
+   {
+      var result = _value.RequiresContains(_target, messageTemplate: _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresContains_P001()
+   {
+      var result = _value.RequiresContains(_target, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_P011()
+   {
+      var result = _value.RequiresContains(_target, messageTemplate: _messageTemplate, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_Ordinal_P100()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.Ordinal);
+   }
+
+   [Benchmark]
+   public void RequiresContains_Ordinal_P110()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.Ordinal, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresContains_Ordinal_P101()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.Ordinal, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_Ordinal_P111()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.Ordinal, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_OrdinalIgnoreCase_P100()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.OrdinalIgnoreCase);
+   }
+
+   [Benchmark]
+   public void RequiresContains_OrdinalIgnoreCase_P110()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.OrdinalIgnoreCase, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresContains_OrdinalIgnoreCase_P101()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.OrdinalIgnoreCase, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_OrdinalIgnoreCase_P111()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.OrdinalIgnoreCase, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_CurrentCulture_P100()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.CurrentCulture);
+   }
+
+   [Benchmark]
+   public void RequiresContains_CurrentCulture_P110()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.CurrentCulture, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresContains_CurrentCulture_P101()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.CurrentCulture, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresContains_CurrentCulture_P111()
+   {
+      var result = _value.RequiresContains(_target, StringComparison.CurrentCulture, _messageTemplate, _exceptionFactory);
+   }
+
+}

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -17,4 +17,5 @@
 //BenchmarkRunner.Run<NotNullOrEmptyBenchmarks>();
 //BenchmarkRunner.Run<NotNullOrWhiteSpaceBenchmarks>();
 //BenchmarkRunner.Run<NotEmptyOrWhiteSpaceBenchmarks>();
-BenchmarkRunner.Run<AlphaNumericOnlyBenchmarks>();
+//BenchmarkRunner.Run<AlphaNumericOnlyBenchmarks>();
+BenchmarkRunner.Run<ContainsBenchmarks>();

--- a/DbC.Net.Tests.Unit/AlphaNumericOnlyExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/AlphaNumericOnlyExtensionsTests.cs
@@ -114,7 +114,7 @@ public class AlphaNumericOnlyExtensionsTests
       var expectedMessage = $"Postcondition AlphaNumericOnly failed: value may only contain alphanumeric characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -128,7 +128,7 @@ public class AlphaNumericOnlyExtensionsTests
       var expectedMessage = $"Requirement AlphaNumericOnly failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -248,7 +248,7 @@ public class AlphaNumericOnlyExtensionsTests
       var expectedMessage = $"Precondition AlphaNumericOnly failed: value may only contain alphanumeric characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -262,7 +262,7 @@ public class AlphaNumericOnlyExtensionsTests
       var expectedMessage = $"Requirement AlphaNumericOnly failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 

--- a/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ApproximatelyEqualExtensionsTests.cs
@@ -57,7 +57,7 @@ public class ApproximatelyEqualExtensionsTests
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -73,7 +73,7 @@ public class ApproximatelyEqualExtensionsTests
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -88,7 +88,7 @@ public class ApproximatelyEqualExtensionsTests
       var act = () => _ = value.EnsuresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -114,7 +114,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -132,7 +132,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -149,7 +149,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Postcondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -167,7 +167,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -226,7 +226,7 @@ public class ApproximatelyEqualExtensionsTests
       var act = () => _ =  value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -242,7 +242,7 @@ public class ApproximatelyEqualExtensionsTests
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -257,7 +257,7 @@ public class ApproximatelyEqualExtensionsTests
       var act = () => _ = value.RequiresApproximatelyEqual(target, epsilon, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -284,7 +284,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -304,7 +304,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -322,7 +322,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Precondition ApproximatelyEqual failed: {nameof(value)} must be within +/- {epsilon} of {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -340,7 +340,7 @@ public class ApproximatelyEqualExtensionsTests
       var expectedMessage = $"Requirement ApproximatelyEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
@@ -160,7 +160,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -175,7 +175,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -190,7 +190,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -204,7 +204,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -229,7 +229,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -246,7 +246,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -262,7 +262,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -278,7 +278,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -355,7 +355,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -372,7 +372,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -532,7 +532,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -547,7 +547,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -562,7 +562,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -576,7 +576,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -601,7 +601,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -618,7 +618,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -634,7 +634,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -651,7 +651,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -730,7 +730,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -747,7 +747,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1050,7 +1050,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
@@ -1072,7 +1072,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1093,7 +1093,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    // da-DK culture (Danish/Denmark) sorts Z, AE(diphthong), O(slashed), A(overring)
@@ -1115,7 +1115,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
    [Theory]
    [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCulture)]
@@ -1134,7 +1134,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -1148,7 +1148,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.EnsuresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -1174,7 +1174,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1191,7 +1191,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1207,7 +1207,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Postcondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1224,7 +1224,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1332,7 +1332,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1354,7 +1354,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1512,7 +1512,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -1527,7 +1527,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -1542,7 +1542,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -1556,7 +1556,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1582,7 +1582,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -1602,7 +1602,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -1620,7 +1620,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1636,7 +1636,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1713,7 +1713,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1730,7 +1730,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -1890,7 +1890,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -1905,7 +1905,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -1920,7 +1920,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -1934,7 +1934,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1960,7 +1960,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -1980,7 +1980,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -1998,7 +1998,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2015,7 +2015,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2094,7 +2094,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2111,7 +2111,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2414,7 +2414,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    // Azerbaijani Latin alphabet sorts H, X, I(dotless), I(dotted), J, ...
@@ -2436,7 +2436,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -2457,7 +2457,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    // da-DK culture (Danish/Denmark) sorts Z, AE(diphthong), O(slashed), A(overring)
@@ -2479,7 +2479,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
    [Theory]
    [InlineData(null, StringData.UpperCaseA, StringData.UpperCaseZ, StringComparison.CurrentCulture)]
@@ -2498,7 +2498,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -2512,7 +2512,7 @@ public class BetweenExtensionsTests
       var act = () => _ = value.RequiresBetween(lowerBound, upperBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -2539,7 +2539,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -2559,7 +2559,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -2577,7 +2577,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Precondition Between failed: {nameof(value)} must be between {lowerBound} and {upperBound} (inclusive)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2594,7 +2594,7 @@ public class BetweenExtensionsTests
       var expectedMessage = $"Requirement Between failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2702,7 +2702,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 
@@ -2724,7 +2724,7 @@ public class BetweenExtensionsTests
       var expectedMessage = Messages.BetweenBoundsNotNormalized;
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/BetweenExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace DbC.Net.Tests.Unit;
+﻿// Ignore Spelling: Latn sv
+
+namespace DbC.Net.Tests.Unit;
 
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters

--- a/DbC.Net.Tests.Unit/ContainsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ContainsExtensionsTests.cs
@@ -416,7 +416,7 @@ public class ContainsExtensionsTests
       var act = () => _ = value.EnsuresContains(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -445,7 +445,7 @@ public class ContainsExtensionsTests
       var act = () => _ = value.EnsuresContains(target, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -991,7 +991,7 @@ public class ContainsExtensionsTests
       var act = () => _ = value.RequiresContains(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1020,7 +1020,7 @@ public class ContainsExtensionsTests
       var act = () => _ = value.RequiresContains(target, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);

--- a/DbC.Net.Tests.Unit/ContainsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ContainsExtensionsTests.cs
@@ -1,0 +1,486 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class ContainsExtensionsTests
+{
+   private const Int32 _dataCount = 7;
+
+   #region RequiresContains Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueContainsTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "WE";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldReturnOriginalValue_WhenRequirementIsPassedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "WE";
+
+      // Act.
+      var result = value.RequiresContains(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueContainsTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueContainsTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Note: th-TH culture considers "a" and "a-" as equal.
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "A-", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "a-", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueContainsTargetAndCurrentCultureIs_thTH(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldReturnOriginalValue_WhenRequirementIsPassedAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresContains(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldThrow_WhenValueIsNotNullAndDoesNotContainTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [Theory]
+   [InlineData("!@#$%")]
+   [InlineData("")]
+   public void ContainsExtensions_RequiresContains_ShouldThrow_WhenValueNullAndTargetIsNotNullAndComparisonIsDefault(String target)
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldThrow_WhenValueIsNotNullAndDoesNotContainTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture("tr-TR")]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldThrow_WhenValueIsNotNullAndDoesNotContainTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [UseCulture("en-US")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [Theory]
+   [InlineData("not null string")]
+   [InlineData(null)]
+   public void ContainsExtensions_RequiresContains_ShouldThrowArgumentNullException_WhenTargetIsNullAndComparisonIsDefault(String value)
+   {
+      // Arrange.
+      String target = null!;
+      var act = () => _ = value.RequiresContains(target);
+      var expectedMessage = Messages.TargetSubstringIsNull;
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentNullException>()
+         .WithParameterName(nameof(target))
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Contains);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(StringComparison.Ordinal);
+   }
+
+   [UseCulture("th-TH")]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_RequiresContains_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Contains);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresContains(target);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeIsSuppliedAndAllOtherDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.InvariantCulture;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresContains(target, messageTemplate: messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresContains(target, comparisonType, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresContains(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.RequiresContains(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresContains(target, messageTemplate: messageTemplate, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_RequiresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresContains(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/ContainsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/ContainsExtensionsTests.cs
@@ -4,6 +4,581 @@ public class ContainsExtensionsTests
 {
    private const Int32 _dataCount = 7;
 
+   #region EnsuresContains Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueContainsTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "WE";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QW";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueEndsWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "TY";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueContainsMultipleTargetSubstringsAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "asdfQWERTYasdf";
+      var target = "sd";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldReturnOriginalValue_WhenRequirementIsPassedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "WE";
+
+      // Act.
+      var result = value.EnsuresContains(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueContainsTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueContainsTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Note: th-TH culture considers "a" and "a-" as equal.
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "A-", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "a-", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueContainsTargetAndCurrentCultureIs_thTH(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldReturnOriginalValue_WhenRequirementIsPassedAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresContains(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var comparisonType = StringComparison.CurrentCulture;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "ABCDEF";
+      var target = "A-";
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueEndsWithTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "TY";
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldNotThrow_WhenValueContainsMultipleTargetSubstringsAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "GHIJK12345GHIK";
+      var target = StringData.LowerCaseDotlessI;
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldThrow_WhenValueIsNotNullAndDoesNotContainTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [InlineData("!@#$%")]
+   [InlineData("")]
+   public void ContainsExtensions_EnsuresContains_ShouldThrow_WhenValueNullAndTargetIsNotNullAndComparisonIsDefault(String target)
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldThrow_WhenValueIsNotNullAndDoesNotContainTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldThrow_WhenValueIsNotNullAndDoesNotContainTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [InlineData("not null string")]
+   [InlineData(null)]
+   public void ContainsExtensions_EnsuresContains_ShouldThrowArgumentNullException_WhenTargetIsNullAndComparisonIsDefault(String value)
+   {
+      // Arrange.
+      String target = null!;
+      var act = () => _ = value.EnsuresContains(target);
+      var expectedMessage = Messages.TargetSubstringIsNull;
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentNullException>()
+         .WithParameterName(nameof(target))
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtensions_EnsuresContains_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresContains(target);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Contains);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(StringComparison.Ordinal);
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void ContainsExtensions_EnsuresContains_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.Contains);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresContains(target);
+      var expectedMessage = $"Postcondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeIsSuppliedAndAllOtherDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.InvariantCulture;
+      var act = () => _ = value.EnsuresContains(target, comparisonType);
+      var expectedMessage = $"Postcondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresContains(target, messageTemplate: messageTemplate);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresContains(target, comparisonType, messageTemplate);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresContains(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.EnsuresContains(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition Contains failed: {nameof(value)} must contain the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresContains(target, messageTemplate: messageTemplate, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void ContainsExtension_EnsuresContains_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresContains(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement Contains failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+
    #region RequiresContains Tests
    // ==========================================================================
    // ==========================================================================
@@ -45,6 +620,54 @@ public class ContainsExtensionsTests
    }
 
    [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QW";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueEndsWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "TY";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueContainsMultipleTargetSubstringsAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "asdfQWERTYasdf";
+      var target = "sd";
+      var act = () => _ = value.RequiresContains(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
    public void ContainsExtensions_RequiresContains_ShouldReturnOriginalValue_WhenRequirementIsPassedAndComparisonIsDefault()
    {
       // Arrange.
@@ -58,7 +681,7 @@ public class ContainsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
@@ -80,7 +703,7 @@ public class ContainsExtensionsTests
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
    // case is ignored. Same for "I" and lowercase dot-less "i".
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
@@ -101,7 +724,7 @@ public class ContainsExtensionsTests
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "A-", StringComparison.CurrentCulture)]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "a-", StringComparison.CurrentCultureIgnoreCase)]
@@ -121,7 +744,7 @@ public class ContainsExtensionsTests
       act.Should().NotThrow();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -141,7 +764,7 @@ public class ContainsExtensionsTests
       act.Should().NotThrow();
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -161,7 +784,7 @@ public class ContainsExtensionsTests
       act.Should().NotThrow();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
@@ -179,6 +802,61 @@ public class ContainsExtensionsTests
 
       // Assert.
       result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var comparisonType = StringComparison.CurrentCulture;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "ABCDEF";
+      var target = "A-";
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueEndsWithTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "TY";
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Fact]
+   public void ContainsExtensions_RequiresContains_ShouldNotThrow_WhenValueContainsMultipleTargetSubstringsAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "GHIJK12345GHIK";
+      var target = StringData.LowerCaseDotlessI;
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var act = () => _ = value.RequiresContains(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
    }
 
    [Fact]
@@ -206,7 +884,7 @@ public class ContainsExtensionsTests
       act.Should().ThrowExactly<ArgumentException>();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCulture)]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
@@ -228,7 +906,7 @@ public class ContainsExtensionsTests
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
    // case is ignored. Same for "I" and lowercase dot-less "i".
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
@@ -248,7 +926,7 @@ public class ContainsExtensionsTests
       act.Should().ThrowExactly<ArgumentException>();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -268,7 +946,7 @@ public class ContainsExtensionsTests
       act.Should().ThrowExactly<ArgumentException>();
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -325,7 +1003,7 @@ public class ContainsExtensionsTests
       ex.Data[DataNames.StringComparison].Should().Be(StringComparison.Ordinal);
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -324,7 +324,7 @@ public class EqualsExtensionsTests
    // ==========================================================================
    // ==========================================================================
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
@@ -346,7 +346,7 @@ public class EqualsExtensionsTests
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
    // case is ignored. Same for "I" and lowercase dot-less "i".
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -368,7 +368,7 @@ public class EqualsExtensionsTests
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -388,7 +388,7 @@ public class EqualsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -409,7 +409,7 @@ public class EqualsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -430,7 +430,7 @@ public class EqualsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -450,7 +450,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -470,7 +470,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -490,7 +490,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -509,7 +509,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -968,7 +968,7 @@ public class EqualsExtensionsTests
    // ==========================================================================
    // ==========================================================================
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
@@ -990,7 +990,7 @@ public class EqualsExtensionsTests
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
    // case is ignored. Same for "I" and lowercase dot-less "i".
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -1012,7 +1012,7 @@ public class EqualsExtensionsTests
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -1032,7 +1032,7 @@ public class EqualsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -1053,7 +1053,7 @@ public class EqualsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -1074,7 +1074,7 @@ public class EqualsExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -1094,7 +1094,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -1114,7 +1114,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -1134,7 +1134,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -1153,7 +1153,7 @@ public class EqualsExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]

--- a/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/EqualsExtensionsTests.cs
@@ -51,7 +51,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -64,7 +64,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -77,7 +77,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -90,7 +90,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -112,7 +112,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -128,7 +128,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -143,7 +143,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -158,7 +158,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -211,7 +211,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -225,7 +225,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -248,7 +248,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -265,7 +265,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -281,7 +281,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -298,7 +298,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -313,7 +313,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -447,7 +447,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -467,7 +467,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.ThaiThailand)]
@@ -487,7 +487,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -506,7 +506,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.ThaiThailand)]
@@ -525,7 +525,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -538,7 +538,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.EnsuresEqual(target, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -561,7 +561,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -577,7 +577,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -592,7 +592,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Postcondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -609,7 +609,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -659,7 +659,7 @@ public class EqualsExtensionsTests
       var act = () => _= value.RequiresEqual(target);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -672,7 +672,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -685,7 +685,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -698,7 +698,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -721,7 +721,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -739,7 +739,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -755,7 +755,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -770,7 +770,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -823,7 +823,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -837,7 +837,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -851,7 +851,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -865,7 +865,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -889,7 +889,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -908,7 +908,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -925,7 +925,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -942,7 +942,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -957,7 +957,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -1091,7 +1091,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -1111,7 +1111,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [UseCulture(CultureData.ThaiThailand)]
@@ -1131,7 +1131,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1150,7 +1150,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [UseCulture(CultureData.ThaiThailand)]
@@ -1169,7 +1169,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -1182,7 +1182,7 @@ public class EqualsExtensionsTests
       var act = () => _ = value.RequiresEqual(target, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1206,7 +1206,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -1224,7 +1224,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -1240,7 +1240,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Precondition Equal failed: {nameof(value)} must be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1257,7 +1257,7 @@ public class EqualsExtensionsTests
       var expectedMessage = $"Requirement Equal failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/Exceptions/ArgumentExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ArgumentExceptionFactoryTests.cs
@@ -52,7 +52,7 @@ public class ArgumentExceptionFactoryTests
         var act = () => _ = new ArgumentExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -65,7 +65,7 @@ public class ArgumentExceptionFactoryTests
         var act = () => _ = new ArgumentExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -88,7 +88,7 @@ public class ArgumentExceptionFactoryTests
         var act = () => _ = new ArgumentExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -210,7 +210,7 @@ public class ArgumentExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -225,7 +225,7 @@ public class ArgumentExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -239,7 +239,7 @@ public class ArgumentExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/ArgumentNullExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ArgumentNullExceptionFactoryTests.cs
@@ -49,7 +49,7 @@ public class ArgumentNullExceptionFactoryTests
         var act = () => _ = new ArgumentNullExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -62,7 +62,7 @@ public class ArgumentNullExceptionFactoryTests
         var act = () => _ = new ArgumentNullExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -85,7 +85,7 @@ public class ArgumentNullExceptionFactoryTests
         var act = () => _ = new ArgumentNullExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -201,7 +201,7 @@ public class ArgumentNullExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -216,7 +216,7 @@ public class ArgumentNullExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -230,7 +230,7 @@ public class ArgumentNullExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/ArgumentOutOfRangeExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ArgumentOutOfRangeExceptionFactoryTests.cs
@@ -52,7 +52,7 @@ public class ArgumentOutOfRangeExceptionFactoryTests
         var act = () => _ = new ArgumentOutOfRangeExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -65,7 +65,7 @@ public class ArgumentOutOfRangeExceptionFactoryTests
         var act = () => _ = new ArgumentOutOfRangeExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -88,7 +88,7 @@ public class ArgumentOutOfRangeExceptionFactoryTests
         var act = () => _ = new ArgumentOutOfRangeExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -240,7 +240,7 @@ public class ArgumentOutOfRangeExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -255,7 +255,7 @@ public class ArgumentOutOfRangeExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -269,7 +269,7 @@ public class ArgumentOutOfRangeExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/ExceptionDataBuilderTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ExceptionDataBuilderTests.cs
@@ -52,7 +52,7 @@ public class ExceptionDataBuilderTests
       var act = () => sut.Build();
 
       // Act/assert.
-      act.Should().Throw<InvalidOperationException>()
+      act.Should().ThrowExactly<InvalidOperationException>()
          .WithMessage(Messages.ExceptionDataAlreadyBuilt);
    }
 
@@ -122,7 +122,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithEpsilon(epsilon, epsilonExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(epsilonExpression));
    }
 
@@ -136,7 +136,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithEpsilon(epsilon, epsilonExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(epsilonExpression));
    }
 
@@ -188,7 +188,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithItem(name, value);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(name));
    }
 
@@ -202,7 +202,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithItem(name, value);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(name));
    }
 
@@ -275,7 +275,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithLowerBound(lowerBound, lowerBoundExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(lowerBoundExpression));
    }
 
@@ -289,7 +289,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithLowerBound(lowerBound, lowerBoundExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(lowerBoundExpression));
    }
 
@@ -342,7 +342,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithMaxLength(maxLength, maxLengthExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(maxLengthExpression));
    }
 
@@ -356,7 +356,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithMaxLength(maxLength, maxLengthExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(maxLengthExpression));
    }
 
@@ -409,7 +409,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithMinLength(minLength, minLengthExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(minLengthExpression));
    }
 
@@ -423,7 +423,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithMinLength(minLength, minLengthExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(minLengthExpression));
    }
 
@@ -476,7 +476,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithRequirement(requirementType, requirementName);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(nameof(requirementType));
       ex.ActualValue.Should().Be(requirementType);
       ex.Message.Should().StartWith(Messages.RequirementTypeIsNotDefined);
@@ -492,7 +492,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithRequirement(requirementType, requirementName);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(requirementName));
    }
 
@@ -506,7 +506,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithRequirement(requirementType, requirementName);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(requirementName));
    }
 
@@ -579,7 +579,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithTarget(target, targetExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(targetExpression));
    }
 
@@ -593,7 +593,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithTarget(target, targetExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(targetExpression));
    }
 
@@ -666,7 +666,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithUpperBound(upperBound, upperBoundExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(upperBoundExpression));
    }
 
@@ -680,7 +680,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithUpperBound(upperBound, upperBoundExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(upperBoundExpression));
    }
 
@@ -753,7 +753,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithValue(value, valueExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(nameof(valueExpression));
    }
 
@@ -767,7 +767,7 @@ public class ExceptionDataBuilderTests
       var act = () => _ = sut.WithValue(value, valueExpression);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(valueExpression));
    }
 

--- a/DbC.Net.Tests.Unit/Exceptions/ExceptionExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ExceptionExtensionsTests.cs
@@ -65,7 +65,7 @@ public class ExceptionExtensionsTests
         var act = () => _ = ex.PopulateExceptionData(_data);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(ex))
            .And.Message.Should().StartWith(Messages.ExceptionIsNull);
     }
@@ -79,7 +79,7 @@ public class ExceptionExtensionsTests
         var act = () => _ = ex.PopulateExceptionData(data);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/ExceptionFactoryBaseTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/ExceptionFactoryBaseTests.cs
@@ -65,7 +65,7 @@ public class ExceptionFactoryTests
         var act = () => _ = new ExampleExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -78,7 +78,7 @@ public class ExceptionFactoryTests
         var act = () => _ = new ExampleExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -101,7 +101,7 @@ public class ExceptionFactoryTests
         var act = () => _ = new ExampleExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -347,7 +347,7 @@ public class ExceptionFactoryTests
         var act = () => _ = sut.CreateMessage(messageTemplate, _data);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -361,7 +361,7 @@ public class ExceptionFactoryTests
         var act = () => _ = sut.CreateMessage(messageTemplate, _data);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -377,7 +377,7 @@ public class ExceptionFactoryTests
         var act = () => _ = sut.CreateMessage(messageTemplate, data);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -397,7 +397,7 @@ public class ExceptionFactoryTests
         var act = () => ExceptionFactoryBase.ValidateDataDictionary(data);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -506,7 +506,7 @@ public class ExceptionFactoryTests
         var act = () => ExceptionFactoryBase.ValidateMessageTemplate(messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -520,7 +520,7 @@ public class ExceptionFactoryTests
         var act = () => ExceptionFactoryBase.ValidateMessageTemplate(messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/FormatExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/FormatExceptionFactoryTests.cs
@@ -50,7 +50,7 @@ public class FormatExceptionFactoryTests
         var act = () => _ = new FormatExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -63,7 +63,7 @@ public class FormatExceptionFactoryTests
         var act = () => _ = new FormatExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -86,7 +86,7 @@ public class FormatExceptionFactoryTests
         var act = () => _ = new FormatExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -189,7 +189,7 @@ public class FormatExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -204,7 +204,7 @@ public class FormatExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -218,7 +218,7 @@ public class FormatExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/InvalidOperationExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/InvalidOperationExceptionFactoryTests.cs
@@ -51,7 +51,7 @@ public class InvalidOperationExceptionFactoryTests
         var act = () => _ = new InvalidOperationExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -64,7 +64,7 @@ public class InvalidOperationExceptionFactoryTests
         var act = () => _ = new InvalidOperationExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -87,7 +87,7 @@ public class InvalidOperationExceptionFactoryTests
         var act = () => _ = new InvalidOperationExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -192,7 +192,7 @@ public class InvalidOperationExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -207,7 +207,7 @@ public class InvalidOperationExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -221,7 +221,7 @@ public class InvalidOperationExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/NotSupportedExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/NotSupportedExceptionFactoryTests.cs
@@ -50,7 +50,7 @@ public class NotSupportedExceptionFactoryTests
         var act = () => _ = new NotSupportedExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -63,7 +63,7 @@ public class NotSupportedExceptionFactoryTests
         var act = () => _ = new NotSupportedExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -86,7 +86,7 @@ public class NotSupportedExceptionFactoryTests
         var act = () => _ = new NotSupportedExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -190,7 +190,7 @@ public class NotSupportedExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -205,7 +205,7 @@ public class NotSupportedExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -219,7 +219,7 @@ public class NotSupportedExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/Exceptions/PostconditionFailedExceptionFactoryTests.cs
+++ b/DbC.Net.Tests.Unit/Exceptions/PostconditionFailedExceptionFactoryTests.cs
@@ -50,7 +50,7 @@ public class PostconditionFailedExceptionFactoryTests
         var act = () => _ = new PostconditionFailedExceptionFactory(keys, _transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(keys))
            .And.Message.Should().StartWith(Messages.TransformKeysCollectonIsNull);
     }
@@ -63,7 +63,7 @@ public class PostconditionFailedExceptionFactoryTests
         var act = () => _ = new PostconditionFailedExceptionFactory(_keys, transform);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transform))
            .And.Message.Should().StartWith(Messages.ValueTransformIsNull);
     }
@@ -86,7 +86,7 @@ public class PostconditionFailedExceptionFactoryTests
         var act = () => _ = new PostconditionFailedExceptionFactory(transforms);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(transforms))
            .And.Message.Should().StartWith(Messages.TransformsDictionaryIsNull);
     }
@@ -189,7 +189,7 @@ public class PostconditionFailedExceptionFactoryTests
         var act = () => _ = sut.CreateException(data, _messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(data))
            .And.Message.Should().StartWith(Messages.DataDictionaryIsNull);
     }
@@ -204,7 +204,7 @@ public class PostconditionFailedExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentException>()
+        act.Should().ThrowExactly<ArgumentException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }
@@ -218,7 +218,7 @@ public class PostconditionFailedExceptionFactoryTests
         var act = () => _ = sut.CreateException(_data, messageTemplate);
 
         // Act/assert.
-        act.Should().Throw<ArgumentNullException>()
+        act.Should().ThrowExactly<ArgumentNullException>()
            .WithParameterName(nameof(messageTemplate))
            .And.Message.Should().StartWith(Messages.MessageTemplateIsEmpty);
     }

--- a/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanExtensionsTests.cs
@@ -55,7 +55,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -69,7 +69,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -83,7 +83,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -97,7 +97,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -110,7 +110,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -132,7 +132,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -148,7 +148,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>()
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -163,7 +163,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -178,7 +178,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -234,7 +234,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -249,7 +249,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -264,7 +264,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -279,7 +279,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -293,7 +293,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -316,7 +316,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().Be(expectedMessage);
    }
 
@@ -333,7 +333,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().Be(expectedMessage);
    }
 
@@ -349,7 +349,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -365,7 +365,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -380,7 +380,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -468,7 +468,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -488,7 +488,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -508,7 +508,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -528,7 +528,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -548,7 +548,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.DanishDenmark)]
@@ -568,7 +568,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -581,7 +581,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.EnsuresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -604,7 +604,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -620,7 +620,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -635,7 +635,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Postcondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -652,7 +652,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -705,7 +705,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -719,7 +719,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -733,7 +733,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -747,7 +747,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -760,7 +760,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -783,7 +783,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -802,7 +802,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -819,7 +819,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -834,7 +834,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -890,7 +890,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -905,7 +905,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -920,7 +920,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -935,7 +935,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -949,7 +949,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -973,7 +973,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -993,7 +993,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1011,7 +1011,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1027,7 +1027,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1042,7 +1042,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -1130,7 +1130,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -1150,7 +1150,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1170,7 +1170,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -1190,7 +1190,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1210,7 +1210,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.DanishDenmark)]
@@ -1230,7 +1230,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -1243,7 +1243,7 @@ public class GreaterThanExtensionsTests
       var act = () => _ = value.RequiresGreaterThan(lowerBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1267,7 +1267,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1286,7 +1286,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1303,7 +1303,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Precondition GreaterThan failed: {nameof(value)} must be greater than {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1320,7 +1320,7 @@ public class GreaterThanExtensionsTests
       var expectedMessage = $"Requirement GreaterThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualExtensionsTests.cs
@@ -87,7 +87,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -101,7 +101,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -114,7 +114,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -136,7 +136,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -152,7 +152,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -167,7 +167,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -182,7 +182,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -272,7 +272,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -287,7 +287,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -301,7 +301,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -324,7 +324,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -341,7 +341,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -357,7 +357,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -373,7 +373,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -388,7 +388,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -540,7 +540,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -560,7 +560,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -580,7 +580,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -593,7 +593,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -616,7 +616,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -632,7 +632,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -647,7 +647,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -664,7 +664,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -749,7 +749,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -763,7 +763,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -776,7 +776,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -799,7 +799,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -818,7 +818,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -835,7 +835,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -850,7 +850,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -940,7 +940,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -955,7 +955,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -969,7 +969,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -993,7 +993,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1013,7 +1013,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1031,7 +1031,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1047,7 +1047,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1062,7 +1062,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -1214,7 +1214,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1234,7 +1234,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -1254,7 +1254,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -1267,7 +1267,7 @@ public class GreaterThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqual(lowerBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1291,7 +1291,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1310,7 +1310,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1327,7 +1327,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqual failed: {nameof(value)} must be greater than or equal to {lowerBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1344,7 +1344,7 @@ public class GreaterThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanOrEqualToZeroExtensionsTests.cs
@@ -47,7 +47,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -88,7 +88,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanOrEqualToZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -106,7 +106,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -120,7 +120,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -133,7 +133,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -147,7 +147,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -193,7 +193,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -234,7 +234,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.RequiresGreaterThanOrEqualToZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -253,7 +253,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -270,7 +270,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -285,7 +285,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Precondition GreaterThanOrEqualToZero failed: {nameof(value)} must be greater than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -299,7 +299,7 @@ public class GreaterThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/GreaterThanZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/GreaterThanZeroExtensionsTests.cs
@@ -34,7 +34,7 @@ public class GreaterThanZeroExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanZero();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -47,7 +47,7 @@ public class GreaterThanZeroExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanZero();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -73,7 +73,7 @@ public class GreaterThanZeroExtensionsTests
       var act = () => _ = value.EnsuresGreaterThanZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -91,7 +91,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -105,7 +105,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -118,7 +118,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Postcondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -132,7 +132,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -165,7 +165,7 @@ public class GreaterThanZeroExtensionsTests
       var act = () => _ = value.RequiresGreaterThanZero();
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -178,7 +178,7 @@ public class GreaterThanZeroExtensionsTests
       var act = () => _ = value.RequiresGreaterThanZero();
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -204,7 +204,7 @@ public class GreaterThanZeroExtensionsTests
       var act = () => _ = value.RequiresGreaterThanZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -223,7 +223,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Precondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -240,7 +240,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -255,7 +255,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Precondition GreaterThanZero failed: {nameof(value)} must be greater than zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -269,7 +269,7 @@ public class GreaterThanZeroExtensionsTests
       var expectedMessage = $"Requirement GreaterThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/LessThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanExtensionsTests.cs
@@ -55,7 +55,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -69,7 +69,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -83,7 +83,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -97,7 +97,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -110,7 +110,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -132,7 +132,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Postcondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -148,7 +148,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -163,7 +163,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Postcondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -178,7 +178,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -234,7 +234,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -249,7 +249,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -264,7 +264,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -279,7 +279,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -293,7 +293,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -316,7 +316,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Postcondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -333,7 +333,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -349,7 +349,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Postcondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -365,7 +365,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -380,7 +380,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -468,7 +468,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -488,7 +488,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -508,7 +508,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -528,7 +528,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -548,7 +548,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.DanishDenmark)]
@@ -568,7 +568,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -581,7 +581,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.EnsuresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -604,7 +604,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Postcondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -620,7 +620,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -635,7 +635,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Postcondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -652,7 +652,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -705,7 +705,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -719,7 +719,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -733,7 +733,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -747,7 +747,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -760,7 +760,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -783,7 +783,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Precondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -802,7 +802,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -819,7 +819,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Precondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -834,7 +834,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -890,7 +890,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -905,7 +905,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -920,7 +920,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -935,7 +935,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -949,7 +949,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -973,7 +973,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Precondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -993,7 +993,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1011,7 +1011,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Precondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1027,7 +1027,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1042,7 +1042,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -1130,7 +1130,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -1150,7 +1150,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1170,7 +1170,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -1190,7 +1190,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1210,7 +1210,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.DanishDenmark)]
@@ -1230,7 +1230,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -1243,7 +1243,7 @@ public class LessThanExtensionsTests
       var act = () => _ = value.RequiresLessThan(upperBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1267,7 +1267,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Precondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1286,7 +1286,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1303,7 +1303,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Precondition LessThan failed: {nameof(value)} must be less than {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1320,7 +1320,7 @@ public class LessThanExtensionsTests
       var expectedMessage = $"Requirement LessThan failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/LessThanExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace DbC.Net.Tests.Unit;
+﻿// Ignore Spelling: sv
+
+namespace DbC.Net.Tests.Unit;
 
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters

--- a/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualExtensionsTests.cs
@@ -87,7 +87,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -101,7 +101,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -114,7 +114,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -136,7 +136,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -152,7 +152,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -167,7 +167,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -182,7 +182,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -272,7 +272,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -287,7 +287,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -301,7 +301,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -324,7 +324,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -341,7 +341,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -357,7 +357,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -373,7 +373,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -388,7 +388,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -540,7 +540,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -560,7 +560,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -580,7 +580,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -593,7 +593,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -616,7 +616,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -632,7 +632,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
       ex.Message.Should().StartWith(expectedMessage);
    }
 
@@ -647,7 +647,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -664,7 +664,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -749,7 +749,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -763,7 +763,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -776,7 +776,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -799,7 +799,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -818,7 +818,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -835,7 +835,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -850,7 +850,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -940,7 +940,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -955,7 +955,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -969,7 +969,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -993,7 +993,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1013,7 +1013,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1031,7 +1031,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1047,7 +1047,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1062,7 +1062,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -1214,7 +1214,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1234,7 +1234,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [UseCulture(CultureData.SwedishSweden)]
@@ -1254,7 +1254,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Fact]
@@ -1267,7 +1267,7 @@ public class LessThanOrEqualExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqual(upperBound, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1291,7 +1291,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1310,7 +1310,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
       ex.ParamName.Should().Be(expectedParameterName);
       ex.Message.Should().StartWith(expectedMessage);
       ex.ActualValue.Should().Be(value);
@@ -1327,7 +1327,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqual failed: {nameof(value)} must be less than or equal to {upperBound}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1344,7 +1344,7 @@ public class LessThanOrEqualExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/LessThanOrEqualToZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanOrEqualToZeroExtensionsTests.cs
@@ -47,7 +47,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqualToZero();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -88,7 +88,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.EnsuresLessThanOrEqualToZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -106,7 +106,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -120,7 +120,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -133,7 +133,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Postcondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -147,7 +147,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -193,7 +193,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqualToZero();
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -234,7 +234,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var act = () => _ = value.RequiresLessThanOrEqualToZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -253,7 +253,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -270,7 +270,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -285,7 +285,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Precondition LessThanOrEqualToZero failed: {nameof(value)} must be less than or equal to zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -299,7 +299,7 @@ public class LessThanOrEqualToZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanOrEqualToZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/LessThanZeroExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/LessThanZeroExtensionsTests.cs
@@ -34,7 +34,7 @@ public class LessThanZeroExtensionsTests
       var act = () => _ = value.EnsuresLessThanZero();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -47,7 +47,7 @@ public class LessThanZeroExtensionsTests
       var act = () => _ = value.EnsuresLessThanZero();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -73,7 +73,7 @@ public class LessThanZeroExtensionsTests
       var act = () => _ = value.EnsuresLessThanZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -91,7 +91,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Postcondition LessThanZero failed: {nameof(value)} must be less than zero";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -105,7 +105,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -118,7 +118,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Postcondition LessThanZero failed: {nameof(value)} must be less than zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -132,7 +132,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -165,7 +165,7 @@ public class LessThanZeroExtensionsTests
       var act = () => _ = value.RequiresLessThanZero();
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -178,7 +178,7 @@ public class LessThanZeroExtensionsTests
       var act = () => _ = value.RequiresLessThanZero();
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>();
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>();
    }
 
    [Theory]
@@ -204,7 +204,7 @@ public class LessThanZeroExtensionsTests
       var act = () => _ = value.RequiresLessThanZero();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentOutOfRangeException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentOutOfRangeException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -223,7 +223,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Precondition LessThanZero failed: {nameof(value)} must be less than zero";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -240,7 +240,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(value);
@@ -255,7 +255,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Precondition LessThanZero failed: {nameof(value)} must be less than zero";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -269,7 +269,7 @@ public class LessThanZeroExtensionsTests
       var expectedMessage = $"Requirement LessThanZero failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/MaxLengthExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/MaxLengthExtensionsTests.cs
@@ -90,7 +90,7 @@ public class MaxLengthExtensionsTests
       var act = () => _ = value.EnsuresMaxLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -174,7 +174,7 @@ public class MaxLengthExtensionsTests
       var act = () => _ = value.EnsuresMaxLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(maxLength))
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(maxLength);
@@ -189,7 +189,7 @@ public class MaxLengthExtensionsTests
       var act = () => _ = value.EnsuresMaxLength(maxLength);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -210,7 +210,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Postcondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -225,7 +225,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Requirement MaxLength failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -239,7 +239,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Postcondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -254,7 +254,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Requirement MaxLength failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -334,7 +334,7 @@ public class MaxLengthExtensionsTests
       var act = () => _ = value.RequiresMaxLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -418,7 +418,7 @@ public class MaxLengthExtensionsTests
       var act = () => _ = value.RequiresMaxLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(maxLength))
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(maxLength);
@@ -433,7 +433,7 @@ public class MaxLengthExtensionsTests
       var act = () => _ = value.RequiresMaxLength(maxLength);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -455,7 +455,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Precondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -472,7 +472,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Requirement MaxLength failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -487,7 +487,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Precondition MaxLength failed: {nameof(value)} must have a maximum length of {maxLength}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -502,7 +502,7 @@ public class MaxLengthExtensionsTests
       var expectedMessage = $"Requirement MaxLength failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/MinLengthExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/MinLengthExtensionsTests.cs
@@ -66,7 +66,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.EnsuresMinLength(minLength);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -78,7 +78,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.EnsuresMinLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -90,7 +90,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.EnsuresMinLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -146,7 +146,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.EnsuresMinLength(minLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(minLength))
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(minLength);
@@ -161,7 +161,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.EnsuresMinLength(minLength);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -182,7 +182,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Postcondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -197,7 +197,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Requirement MinLength failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage);
    }
 
@@ -211,7 +211,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Postcondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -226,7 +226,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Requirement MinLength failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -282,7 +282,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.RequiresMinLength(minLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -294,7 +294,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.RequiresMinLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -306,7 +306,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.RequiresMinLength(maxLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -362,7 +362,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.RequiresMinLength(minLength);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(minLength))
          .WithMessage(expectedMessage + "*")
          .And.ActualValue.Should().Be(minLength);
@@ -377,7 +377,7 @@ public class MinLengthExtensionsTests
       var act = () => _ = value.RequiresMinLength(minLength);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -399,7 +399,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Precondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -416,7 +416,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Requirement MinLength failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -431,7 +431,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Precondition MinLength failed: {nameof(value)} must have a minimum length of {minLength}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 
@@ -446,7 +446,7 @@ public class MinLengthExtensionsTests
       var expectedMessage = $"Requirement MinLength failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/NotDefaultExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotDefaultExtensionsTests.cs
@@ -42,7 +42,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.EnsuresNotDefault();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -53,7 +53,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.EnsuresNotDefault();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -64,7 +64,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.EnsuresNotDefault();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -75,7 +75,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.EnsuresNotDefault();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -92,7 +92,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.EnsuresNotDefault();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -109,7 +109,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.EnsuresNotDefault();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -127,7 +127,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Postcondition NotDefault failed: value may not be default(String)";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -141,7 +141,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Requirement NotDefault failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -154,7 +154,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Postcondition NotDefault failed: value may not be default(Single)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -168,7 +168,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Requirement NotDefault failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -212,7 +212,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.RequiresNotDefault();
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -223,7 +223,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.RequiresNotDefault();
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -234,7 +234,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.RequiresNotDefault();
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -245,7 +245,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.RequiresNotDefault();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -262,7 +262,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.RequiresNotDefault();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -279,7 +279,7 @@ public class NotDefaultExtensionsTests
       var act = () => _ = value.RequiresNotDefault();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -298,7 +298,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Precondition NotDefault failed: value may not be default(String)";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -314,7 +314,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Requirement NotDefault failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -328,7 +328,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Precondition NotDefault failed: value may not be default(Single)";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -342,7 +342,7 @@ public class NotDefaultExtensionsTests
       var expectedMessage = "Requirement NotDefault failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/NotEmptyOrWhiteSpaceExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEmptyOrWhiteSpaceExtensionsTests.cs
@@ -29,7 +29,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -41,7 +41,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var act = () => _ = value.EnsuresNotEmptyOrWhiteSpace();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -60,7 +60,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Postcondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -75,7 +75,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -89,7 +89,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Postcondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -104,7 +104,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -199,7 +199,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Precondition NotEmptyOrWhiteSpace failed: value may not be String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -214,7 +214,7 @@ public class NotEmptyOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotEmptyOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -343,7 +343,7 @@ public class NotEqualExtensionsTests
    // ==========================================================================
    // ==========================================================================
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -363,7 +363,7 @@ public class NotEqualExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -383,7 +383,7 @@ public class NotEqualExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -403,7 +403,7 @@ public class NotEqualExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
@@ -425,7 +425,7 @@ public class NotEqualExtensionsTests
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
    // case is ignored. Same for "I" and lowercase dot-less "i".
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -447,7 +447,7 @@ public class NotEqualExtensionsTests
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -467,7 +467,7 @@ public class NotEqualExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -486,7 +486,7 @@ public class NotEqualExtensionsTests
       act.Should().Throw<PostconditionFailedException>();
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -936,7 +936,7 @@ public class NotEqualExtensionsTests
    // ==========================================================================
    // ==========================================================================
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -956,7 +956,7 @@ public class NotEqualExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -976,7 +976,7 @@ public class NotEqualExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -996,7 +996,7 @@ public class NotEqualExtensionsTests
       result.Should().Be(value);
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseAE, StringData.UpperCaseAE, StringComparison.CurrentCultureIgnoreCase)]
@@ -1018,7 +1018,7 @@ public class NotEqualExtensionsTests
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
    // case is ignored. Same for "I" and lowercase dot-less "i".
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringData.LowerCaseAE, StringData.LowerCaseAE, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseI, StringData.UpperCaseDottedI, StringComparison.CurrentCultureIgnoreCase)]
@@ -1040,7 +1040,7 @@ public class NotEqualExtensionsTests
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
-   [UseCulture("th-TH")]
+   [UseCulture(CultureData.ThaiThailand)]
    [Theory]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCulture)]
    [InlineData(StringData.LowerCaseA, StringData.LowerCaseADash, StringComparison.CurrentCultureIgnoreCase)]
@@ -1060,7 +1060,7 @@ public class NotEqualExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [UseCulture("en-US")]
+   [UseCulture(CultureData.EnglishUS)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
@@ -1079,7 +1079,7 @@ public class NotEqualExtensionsTests
       act.Should().Throw<ArgumentException>();
    }
 
-   [UseCulture("tr-TR")]
+   [UseCulture(CultureData.TurkishTurkey)]
    [Theory]
    [InlineData(StringComparison.CurrentCulture)]
    [InlineData(StringComparison.CurrentCultureIgnoreCase)]

--- a/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotEqualExtensionsTests.cs
@@ -66,7 +66,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Theory]
@@ -79,7 +79,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -92,7 +92,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -114,7 +114,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -130,7 +130,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -145,7 +145,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -161,7 +161,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -230,7 +230,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -244,7 +244,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -267,7 +267,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -284,7 +284,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -300,7 +300,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -317,7 +317,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -332,7 +332,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -420,7 +420,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
@@ -443,7 +443,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
@@ -464,7 +464,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -483,7 +483,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -502,7 +502,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -515,7 +515,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.EnsuresNotEqual(target, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -538,7 +538,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -554,7 +554,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -569,7 +569,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Postcondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -586,7 +586,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -651,7 +651,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Theory]
@@ -664,7 +664,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -677,7 +677,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -700,7 +700,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -718,7 +718,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -734,7 +734,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -750,7 +750,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -819,7 +819,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -833,7 +833,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparer);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -857,7 +857,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -876,7 +876,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -893,7 +893,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -910,7 +910,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -925,7 +925,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparer);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(comparer))
          .And.Message.Should().StartWith(Messages.ComparerIsNull);
    }
@@ -1013,7 +1013,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
@@ -1036,7 +1036,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    // Note: th-TH culture considers "a" and "a-" as equal.
@@ -1057,7 +1057,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [UseCulture(CultureData.EnglishUS)]
@@ -1076,7 +1076,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [UseCulture(CultureData.TurkishTurkey)]
@@ -1095,7 +1095,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -1108,7 +1108,7 @@ public class NotEqualExtensionsTests
       var act = () => _ = value.RequiresNotEqual(target, comparisonType);
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_stringDataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -1132,7 +1132,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -1150,7 +1150,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -1166,7 +1166,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Precondition NotEqual failed: {nameof(value)} must not be equal to {target}";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -1183,7 +1183,7 @@ public class NotEqualExtensionsTests
       var expectedMessage = $"Requirement NotEqual failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/NotNullExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullExtensionsTests.cs
@@ -29,7 +29,7 @@ public class NotNullExtensionsTests
       var act = () => _ = value.EnsuresNotNull();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -40,7 +40,7 @@ public class NotNullExtensionsTests
       var act = () => _ = value.EnsuresNotNull();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -51,7 +51,7 @@ public class NotNullExtensionsTests
       var act = () => _ = value.EnsuresNotNull();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -68,7 +68,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Postcondition NotNull failed: value may not be null";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -82,7 +82,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Requirement NotNull failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -95,7 +95,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Postcondition NotNull failed: value may not be null";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -109,7 +109,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Requirement NotNull failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -140,7 +140,7 @@ public class NotNullExtensionsTests
       var act = () => _ = value.RequiresNotNull();
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>();
+      act.Should().ThrowExactly<ArgumentNullException>();
    }
 
    [Fact]
@@ -151,7 +151,7 @@ public class NotNullExtensionsTests
       var act = () => _ = value.RequiresNotNull();
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>();
+      act.Should().ThrowExactly<ArgumentNullException>();
    }
 
    [Fact]
@@ -162,7 +162,7 @@ public class NotNullExtensionsTests
       var act = () => _ = value.RequiresNotNull();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentNullException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentNullException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -180,7 +180,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Precondition NotNull failed: value may not be null";
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -196,7 +196,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Requirement NotNull failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(expectedParameterName)
          .And.Message.Should().StartWith(expectedMessage);
    }
@@ -210,7 +210,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Precondition NotNull failed: value may not be null";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 
@@ -224,7 +224,7 @@ public class NotNullExtensionsTests
       var expectedMessage = "Requirement NotNull failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .And.Message.Should().StartWith(expectedMessage);
    }
 

--- a/DbC.Net.Tests.Unit/NotNullOrEmptyExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullOrEmptyExtensionsTests.cs
@@ -38,7 +38,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrEmpty();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -49,7 +49,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrEmpty();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -73,7 +73,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrEmpty();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -90,7 +90,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrEmpty();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -108,7 +108,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -121,7 +121,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -135,7 +135,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -149,7 +149,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -162,7 +162,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -175,7 +175,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -189,7 +189,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -203,7 +203,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -243,7 +243,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.RequiresNotNullOrEmpty();
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>();
+      act.Should().ThrowExactly<ArgumentNullException>();
    }
 
    [Fact]
@@ -254,7 +254,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.RequiresNotNullOrEmpty();
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -278,7 +278,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.RequiresNotNullOrEmpty();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentNullException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentNullException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -295,7 +295,7 @@ public  class NotNullOrEmptyExtensionsTests
       var act = () => _ = value.RequiresNotNullOrEmpty();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -314,7 +314,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -329,7 +329,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -345,7 +345,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -361,7 +361,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -375,7 +375,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -388,7 +388,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Precondition NotNullOrEmpty failed: value may not be null or String.Empty";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -402,7 +402,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -416,7 +416,7 @@ public  class NotNullOrEmptyExtensionsTests
       var expectedMessage = $"Requirement NotNullOrEmpty failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 

--- a/DbC.Net.Tests.Unit/NotNullOrWhiteSpaceExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/NotNullOrWhiteSpaceExtensionsTests.cs
@@ -27,7 +27,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrWhiteSpace();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -38,7 +38,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrWhiteSpace();
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>();
+      act.Should().ThrowExactly<PostconditionFailedException>();
    }
 
    [Fact]
@@ -49,7 +49,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrWhiteSpace();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -67,7 +67,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.EnsuresNotNullOrWhiteSpace();
 
       // Act/assert.
-      var ex = act.Should().Throw<PostconditionFailedException>().Which;
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
@@ -85,7 +85,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -99,7 +99,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -113,7 +113,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -128,7 +128,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<PostconditionFailedException>()
+      act.Should().ThrowExactly<PostconditionFailedException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -141,7 +141,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -155,7 +155,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Postcondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -169,7 +169,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -184,7 +184,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -213,7 +213,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.RequiresNotNullOrWhiteSpace();
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>();
+      act.Should().ThrowExactly<ArgumentNullException>();
    }
 
    [Theory]
@@ -225,7 +225,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.RequiresNotNullOrWhiteSpace();
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>();
+      act.Should().ThrowExactly<ArgumentException>();
    }
 
    [Fact]
@@ -236,7 +236,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var act = () => _ = value.RequiresNotNullOrWhiteSpace();
 
       // Act/assert.
-      var ex = act.Should().Throw<ArgumentNullException>().Which;
+      var ex = act.Should().ThrowExactly<ArgumentNullException>().Which;
 
       ex.Data.Count.Should().Be(_dataCount);
       ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
@@ -255,7 +255,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Precondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -271,7 +271,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Precondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -287,7 +287,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -304,7 +304,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<ArgumentException>()
+      act.Should().ThrowExactly<ArgumentException>()
          .WithParameterName(expectedParameterName)
          .WithMessage(expectedMessage + "*");
    }
@@ -318,7 +318,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Precondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -332,7 +332,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Precondition NotNullOrWhiteSpace failed: value may not be null, String.Empty or all whitespace characters";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -346,7 +346,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 
@@ -361,7 +361,7 @@ public class NotNullOrWhiteSpaceExtensionsTests
       var expectedMessage = $"Requirement NotNullOrWhiteSpace failed";
 
       // Act/assert.
-      act.Should().Throw<CustomException>()
+      act.Should().ThrowExactly<CustomException>()
          .WithMessage(expectedMessage + "*");
    }
 

--- a/DbC.Net.Tests.Unit/TestData/StringData.cs
+++ b/DbC.Net.Tests.Unit/TestData/StringData.cs
@@ -1,4 +1,6 @@
-﻿namespace DbC.Net.Tests.Unit.TestData;
+﻿// Ignore Spelling: Overring Eszett Dotless
+
+namespace DbC.Net.Tests.Unit.TestData;
 
 public class StringData : ComparableValue<String>
 {

--- a/DbC.Net.Tests.Unit/Transforms/CharacterMaskDecoratorTests.cs
+++ b/DbC.Net.Tests.Unit/Transforms/CharacterMaskDecoratorTests.cs
@@ -39,7 +39,7 @@ public class CharacterMaskDecoratorTests
       var act = () => _ = new CharacterMaskDecorator(baseTransform, _maskCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(baseTransform))
          .And.Message.Should().StartWith(Messages.BaseTransformIsNull);
    }
@@ -52,7 +52,7 @@ public class CharacterMaskDecoratorTests
       var act = () => _ = new CharacterMaskDecorator(_baseTransform, maskCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(maskCharacter))
          .And.Message.Should().StartWith(Messages.MaskCharacterIsNull);
    }

--- a/DbC.Net.Tests.Unit/Transforms/ConstantTransformTests.cs
+++ b/DbC.Net.Tests.Unit/Transforms/ConstantTransformTests.cs
@@ -27,7 +27,7 @@ public class ConstantTransformTests
       var act = () => _ = new ConstantTransform(constantValue);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(constantValue))
          .And.Message.Should().StartWith(Messages.ConstantValueIsNull);
    }

--- a/DbC.Net.Tests.Unit/Transforms/DigitMaskDecoratorTests.cs
+++ b/DbC.Net.Tests.Unit/Transforms/DigitMaskDecoratorTests.cs
@@ -39,7 +39,7 @@ public class DigitMaskDecoratorTests
       var act = () => _ = new DigitMaskDecorator(baseTransform, _maskCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(baseTransform))
          .And.Message.Should().StartWith(Messages.BaseTransformIsNull);
    }
@@ -52,7 +52,7 @@ public class DigitMaskDecoratorTests
       var act = () => _ = new DigitMaskDecorator(_baseTransform, maskCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(maskCharacter))
          .And.Message.Should().StartWith(Messages.MaskCharacterIsNull);
    }

--- a/DbC.Net.Tests.Unit/Transforms/FixedLengthDecoratorTests.cs
+++ b/DbC.Net.Tests.Unit/Transforms/FixedLengthDecoratorTests.cs
@@ -42,7 +42,7 @@ public class FixedLengthDecoratorTests
       var act = () => _ = new FixedLengthDecorator(baseTransform, _length, _padCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentNullException>()
+      act.Should().ThrowExactly<ArgumentNullException>()
          .WithParameterName(nameof(baseTransform))
          .And.Message.Should().StartWith(Messages.BaseTransformIsNull);
    }
@@ -55,7 +55,7 @@ public class FixedLengthDecoratorTests
       var act = () => _ = new FixedLengthDecorator(_baseTransform, length, _padCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(length))
          .And.Message.Should().StartWith(Messages.LengthIsLessThanOne);
    }
@@ -68,7 +68,7 @@ public class FixedLengthDecoratorTests
       var act = () => _ = new FixedLengthDecorator(_baseTransform, _length, padCharacter);
 
       // Act/assert.
-      act.Should().Throw<ArgumentOutOfRangeException>()
+      act.Should().ThrowExactly<ArgumentOutOfRangeException>()
          .WithParameterName(nameof(padCharacter))
          .And.Message.Should().StartWith(Messages.PadCharacterIsNull);
    }

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\AlphaNumericOnly.md = Documentation\AlphaNumericOnly.md
 		Documentation\ApproximatelyEqual.md = Documentation\ApproximatelyEqual.md
 		Documentation\Between.md = Documentation\Between.md
+		Documentation\Contains.md = Documentation\Contains.md
 		Documentation\Equal.md = Documentation\Equal.md
 		Documentation\GreaterThan.md = Documentation\GreaterThan.md
 		Documentation\GreaterThanOrEqual.md = Documentation\GreaterThanOrEqual.md

--- a/DbC.Net/ContainsExtensions.cs
+++ b/DbC.Net/ContainsExtensions.cs
@@ -8,6 +8,69 @@ public static class ContainsExtensions
    private const String _requirementName = RequirementNames.Contains;
 
    /// <summary>
+   ///   String Contains postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> contains the  <paramref name="target"/> 
+   ///   substring and throw an exception if it does not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target substring that <paramref name="value"/> should contain.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must contain the substring "{Target}"".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="target"/> is <see langword="null"/>.
+   /// </exception>
+   public static String EnsuresContains(
+      this String value,
+      String target,
+      StringComparison comparisonType = StringComparison.Ordinal,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckContains(
+         value,
+         target ?? throw new ArgumentNullException(nameof(target), Messages.TargetSubstringIsNull),
+         comparisonType,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   String Contains precondition. Confirm that the <see cref="String"/>
    ///   <paramref name="value"/> contains the  <paramref name="target"/> 
    ///   substring and throw an exception if it does not.

--- a/DbC.Net/ContainsExtensions.cs
+++ b/DbC.Net/ContainsExtensions.cs
@@ -1,0 +1,97 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement String Contains requirement.
+/// </summary>
+public static class ContainsExtensions
+{
+   private const String _requirementName = RequirementNames.Contains;
+
+   /// <summary>
+   ///   String Contains precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> contains the  <paramref name="target"/> 
+   ///   substring and throw an exception if it does not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target substring that <paramref name="value"/> should contain.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
+   ///   compared.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must contain the substring "{Target}"".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="target"/> is <see langword="null"/>.
+   /// </exception>
+   public static String RequiresContains(
+      this String value,
+      String target,
+      StringComparison comparisonType = StringComparison.Ordinal,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckContains(
+         value,
+         target ?? throw new ArgumentNullException(nameof(target), Messages.TargetSubstringIsNull),
+         comparisonType,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   private static void CheckContains(
+      String value,
+      String target,
+      StringComparison comparisonType,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression)
+   {
+      if (value is null || !value.Contains(target, comparisonType))
+      {
+         messageTemplate ??= MessageTemplates.ContainsTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithTarget(target, targetExpression)
+            .WithItem(DataNames.StringComparison, comparisonType)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -88,6 +88,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must contain the substring &quot;{Target}&quot;.
+        /// </summary>
+        internal static string ContainsTemplate {
+            get {
+                return ResourceManager.GetString("ContainsTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}.
         /// </summary>
         internal static string EqualTemplate {

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -126,6 +126,9 @@
   <data name="BetweenTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be between {LowerBound} and {UpperBound} (inclusive)</value>
   </data>
+  <data name="ContainsTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must contain the substring "{Target}"</value>
+  </data>
   <data name="EqualTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} must be equal to {Target}</value>
   </data>

--- a/DbC.Net/Messages.Designer.cs
+++ b/DbC.Net/Messages.Designer.cs
@@ -196,6 +196,15 @@ namespace DbC.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Target substring is null.
+        /// </summary>
+        internal static string TargetSubstringIsNull {
+            get {
+                return ResourceManager.GetString("TargetSubstringIsNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Transform keys collection may not be null.
         /// </summary>
         internal static string TransformKeysCollectonIsNull {

--- a/DbC.Net/Messages.resx
+++ b/DbC.Net/Messages.resx
@@ -162,6 +162,9 @@
   <data name="SensitiveValuesListIsNull" xml:space="preserve">
     <value>List of sensitive value names may not be null</value>
   </data>
+  <data name="TargetSubstringIsNull" xml:space="preserve">
+    <value>Target substring is null</value>
+  </data>
   <data name="TransformKeysCollectonIsNull" xml:space="preserve">
     <value>Transform keys collection may not be null</value>
   </data>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -8,6 +8,7 @@ public static class RequirementNames
    public const String AlphaNumericOnly = nameof(AlphaNumericOnly);
    public const String ApproximatelyEqual = nameof(ApproximatelyEqual);
    public const String Between = nameof(Between);
+   public const String Contains = nameof(Contains);
    public const String Equal = nameof(Equal);
    public const String GreaterThan = nameof(GreaterThan);
    public const String GreaterThanOrEqual = nameof(GreaterThanOrEqual);

--- a/Documentation/Contains.md
+++ b/Documentation/Contains.md
@@ -1,0 +1,32 @@
+### Contains
+
+Contains requires that the string value being checked contain the target substring.
+Contains supports an optional StringComparison parameter that specifies how the 
+substring check is performed. By default the check is performed using an ordinal,
+case-sensitive comparison.
+
+Contains will always fail if the string value being checked is null.  An empty 
+target substring (String.Empty) will always pass the requirement (unless the
+string being checked is null).
+
+**Method signatures:**
+```C#
+String RequiresContains(this String value, String target, [StringComparison comparisonType = StringComparison.Ordinal], [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String EnsuresContains(this String value, String target, [StringComparison comparisonType = StringComparison.Ordinal], [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+```
+
+The default message template for Contains is "{RequirementType} {RequirementName} failed: {ValueExpression} must contain the substring "{Target}"".
+The default exception factory for RequiresContains is StandardExceptionFactories.ArgumentExceptionFactory 
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresContains.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, Target, StringComparison, ValueExpression and TargetExpression.
+
+Requires/EnsuresContains will throw an ArgumentNullException if the target substring
+is null.
+
+**Examples:**
+```C#
+```

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@
 
   - String Requirements
 
+    - [AlphaNumericOnly](/Documentation/AlphaNumericOnly.md)
+    - [Contains](/Documentation/Contains.md)
     - [MaxLength](/Documentation/MaxLength.md)
     - [MinLength](/Documentation/MinLength.md)
+    - [NotEmptyOrWhiteSpace](/Documentation/NotEmptyOrWhiteSpace.md)
     - [NotNullOrEmpty](/Documentation/NotNullOrEmpty.md)
     - [NotNullOrWhiteSpace](/Documentation/NotNullOrWhiteSpace.md)
-    - [AlphaNumericOnly](/Documentation/AlphaNumericOnly.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value contains a target substring.

Requirements:

  RequiresContains (precondition), default ArgumentException 
  EnsuresContains (postcondition), default PostconditionFailedException

DEFINITION OF DONE:

1. Implement RequiresContains
2. Implement EnsuresContains
3. Unit tests for Requires/Ensures Contains
4. Performance tests
5. Readme updates
6. Examples