### PR TITLE
S0024 starts with

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -37,6 +37,7 @@ Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical 
   - [AlphaNumericOnly Benchmarks](#alphanumericonly-benchmarks)
   - [Contains Benchmarks](#contains-benchmarks)
   - [DigitsOnly Benchmarks](#digitsonly-benchmarks)
+  - [StartsWith Benchmarks](#startswith-benchmarks)
 
 ### NotNull Benchmarks
 
@@ -609,3 +610,26 @@ parameter was omitted.
 | RequiresDigitsOnly | String (Length 100) |                  | X                 | 101.454 ns | 1.9839 ns | 2.4364 ns |         - |
 | RequiresDigitsOnly | String (Length 100) | X                | X                 | 100.172 ns | 0.5863 ns | 0.5197 ns |         - |
 
+### StartsWith Benchmarks
+
+X indicates that the optional parameter was supplied; blank indicates that the 
+parameter was omitted.
+
+| Method             | String Comparer   | Message Template | Exception Factory |      Mean |     Error |    StdDev | Allocated |
+|:------------------ |:------------------|:----------------:|:-----------------:|----------:|----------:|----------:|----------:|
+| RequiresStartsWith |                   |                  |                   |  4.278 ns | 0.0287 ns | 0.0240 ns |         - |
+| RequiresStartsWith |                   | X                |                   |  4.549 ns | 0.0811 ns | 0.0759 ns |         - |
+| RequiresStartsWith |                   |                  | X                 |  4.823 ns | 0.0591 ns | 0.0524 ns |         - |
+| RequiresStartsWith |                   | X                | X                 |  4.994 ns | 0.0447 ns | 0.0396 ns |         - |
+| RequiresStartsWith | Ordinal           |                  |                   |  4.547 ns | 0.0622 ns | 0.0582 ns |         - |
+| RequiresStartsWith | Ordinal           | X                |                   |  4.710 ns | 0.0538 ns | 0.0503 ns |         - |
+| RequiresStartsWith | Ordinal           |                  | X                 |  4.660 ns | 0.0623 ns | 0.0552 ns |         - |
+| RequiresStartsWith | Ordinal           | X                | X                 |  4.791 ns | 0.0244 ns | 0.0228 ns |         - |
+| RequiresStartsWith | OrdinalIgnoreCase |                  |                   |  6.118 ns | 0.0657 ns | 0.0615 ns |         - |
+| RequiresStartsWith | OrdinalIgnoreCase | X                |                   |  5.501 ns | 0.0618 ns | 0.0548 ns |         - |
+| RequiresStartsWith | OrdinalIgnoreCase |                  | X                 |  6.144 ns | 0.0674 ns | 0.0631 ns |         - |
+| RequiresStartsWith | OrdinalIgnoreCase | X                | X                 |  6.753 ns | 0.0648 ns | 0.0574 ns |         - |
+| RequiresStartsWith | CurrentCulture    |                  |                   | 29.521 ns | 0.1337 ns | 0.1250 ns |         - |
+| RequiresStartsWith | CurrentCulture    | X                |                   | 31.266 ns | 0.3283 ns | 0.3071 ns |         - |
+| RequiresStartsWith | CurrentCulture    |                  | X                 | 27.353 ns | 0.1298 ns | 0.1214 ns |         - |
+| RequiresStartsWith | CurrentCulture    | X                | X                 | 27.817 ns | 0.2212 ns | 0.2069 ns |         - |

--- a/DbC.Net.Examples/StartsWithExamples.cs
+++ b/DbC.Net.Examples/StartsWithExamples.cs
@@ -1,0 +1,66 @@
+﻿namespace DbC.Net.Examples;
+
+public sealed class StartsWithExamples
+{
+   public void Examples()
+   {
+      var customMessageTemplate = "{ValueExpression} must start with target substring";
+      var customExceptionFactory = new CustomExceptionFactory();
+
+      var value = "This is a test. This is only a test";
+      var target = "THIS";
+      var comparisionType = StringComparison.OrdinalIgnoreCase;
+
+
+      // Precondition with default comparisionType, default message template and default exception factory.
+      value.RequiresStartsWith(target);
+
+      // Precondition with default comparisionType, custom message template and default exception factory.
+      value.RequiresStartsWith(target, messageTemplate: customMessageTemplate);
+
+      // Precondition with default comparisionType, default message template and custom exception factory.
+      value.RequiresStartsWith(target, exceptionFactory: customExceptionFactory);
+
+      // Precondition with default comparisionType, custom message template and custom exception factory.
+      value.RequiresStartsWith(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+      // Precondition with comparisionType, default message template and default exception factory.
+      value.RequiresStartsWith(target, comparisionType);
+
+      // Precondition with comparisionType, custom message template and default exception factory.
+      value.RequiresStartsWith(target, comparisionType, customMessageTemplate);
+
+      // Precondition with comparisionType, default message template and custom exception factory.
+      value.RequiresStartsWith(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+      // Precondition with comparisionType, custom message template and custom exception factory.
+      value.RequiresStartsWith(target, comparisionType, customMessageTemplate, customExceptionFactory);
+
+
+      // Postcondition with default comparisionType, default message template and default exception factory.
+      value.EnsuresStartsWith(target);
+
+      // Postcondition with default comparisionType, custom message template and default exception factory.
+      value.EnsuresStartsWith(target, messageTemplate: customMessageTemplate);
+
+      // Postcondition with default comparisionType, default message template and custom exception factory.
+      value.EnsuresStartsWith(target, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with default comparisionType, custom message template and custom exception factory.
+      value.EnsuresStartsWith(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+      // Postcondition with comparisionType, default message template and default exception factory.
+      value.EnsuresStartsWith(target, comparisionType);
+
+      // Postcondition with comparisionType, custom message template and default exception factory.
+      value.EnsuresStartsWith(target, comparisionType, customMessageTemplate);
+
+      // Postcondition with comparisionType, default message template and custom exception factory.
+      value.EnsuresStartsWith(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+      // Postcondition with comparisionType, custom message template and custom exception factory.
+      value.EnsuresStartsWith(target, comparisionType, customMessageTemplate, customExceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Benchmarks/ContainsBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/ContainsBenchmarks.cs
@@ -110,5 +110,4 @@ public class ContainsBenchmarks
    {
       var result = _value.RequiresContains(_target, StringComparison.CurrentCulture, _messageTemplate, _exceptionFactory);
    }
-
 }

--- a/DbC.Net.Tests.Benchmarks/Program.cs
+++ b/DbC.Net.Tests.Benchmarks/Program.cs
@@ -19,4 +19,5 @@
 //BenchmarkRunner.Run<NotEmptyOrWhiteSpaceBenchmarks>();
 //BenchmarkRunner.Run<AlphaNumericOnlyBenchmarks>();
 //BenchmarkRunner.Run<ContainsBenchmarks>();
-BenchmarkRunner.Run<DigitsOnlyBenchmarks>();
+//BenchmarkRunner.Run<DigitsOnlyBenchmarks>();
+BenchmarkRunner.Run<StartsWithBenchmarks>();

--- a/DbC.Net.Tests.Benchmarks/StartsWithBenchmarks.cs
+++ b/DbC.Net.Tests.Benchmarks/StartsWithBenchmarks.cs
@@ -1,0 +1,113 @@
+﻿namespace DbC.Net.Tests.Benchmarks;
+
+[MemoryDiagnoser]
+public class StartsWithBenchmarks
+{
+   private const String _messageTemplate = "{ValueExpression} must start with target substring";
+   private static readonly IExceptionFactory _exceptionFactory = StandardExceptionFactories.InvalidOperationExceptionFactory;
+
+   private const String _value = "This is a test. This is only a test";
+   private const String _target = "This";
+
+   [Benchmark]
+   public void ThrowAway()
+   {
+      var result = _value.RequiresStartsWith(_target);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_P000()
+   {
+      var result = _value.RequiresStartsWith(_target);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_P010()
+   {
+      var result = _value.RequiresStartsWith(_target, messageTemplate: _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_P001()
+   {
+      var result = _value.RequiresStartsWith(_target, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_P011()
+   {
+      var result = _value.RequiresStartsWith(_target, messageTemplate: _messageTemplate, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_Ordinal_P100()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.Ordinal);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_Ordinal_P110()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.Ordinal, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_Ordinal_P101()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.Ordinal, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_Ordinal_P111()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.Ordinal, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_OrdinalIgnoreCase_P100()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.OrdinalIgnoreCase);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_OrdinalIgnoreCase_P110()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.OrdinalIgnoreCase, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_OrdinalIgnoreCase_P101()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.OrdinalIgnoreCase, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_OrdinalIgnoreCase_P111()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.OrdinalIgnoreCase, _messageTemplate, _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_CurrentCulture_P100()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.CurrentCulture);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_CurrentCulture_P110()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.CurrentCulture, _messageTemplate);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_CurrentCulture_P101()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.CurrentCulture, exceptionFactory: _exceptionFactory);
+   }
+
+   [Benchmark]
+   public void RequiresStartsWith_CurrentCulture_P111()
+   {
+      var result = _value.RequiresStartsWith(_target, StringComparison.CurrentCulture, _messageTemplate, _exceptionFactory);
+   }
+}

--- a/DbC.Net.Tests.Unit/StartsWithExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/StartsWithExtensionsTests.cs
@@ -1,0 +1,505 @@
+﻿namespace DbC.Net.Tests.Unit;
+
+public class StartsWithExtensionsTests
+{
+   private const Int32 _dataCount = 7;
+
+   #region RequiresStarts Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QW";
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldReturnOriginalValue_WhenRequirementIsPassedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QW";
+
+      // Act.
+      var result = value.RequiresStartsWith(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("IJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldReturnOriginalValue_WhenRequirementIsPassedAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.RequiresStartsWith(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var comparisonType = StringComparison.CurrentCulture;
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "IBCDEF";
+      var target = StringData.LowerCaseDotlessI;
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrow_WhenValueIsNotNullAndDoesNotStartWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [Theory]
+   [InlineData("!@#$%")]
+   [InlineData("")]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrow_WhenValueNullAndTargetIsNotNullAndComparisonIsDefault(String target)
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrow_WhenValueIsNotNullAndDoesNotStartWithTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrow_WhenValueIsNotNullAndDoesNotStartWithTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>();
+   }
+
+   [Theory]
+   [InlineData("not null string")]
+   [InlineData(null)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrowArgumentNullException_WhenTargetIsNullAndComparisonIsDefault(String value)
+   {
+      // Arrange.
+      String target = null!;
+      var act = () => _ = value.RequiresStartsWith(target);
+      var expectedMessage = Messages.TargetSubstringIsNull;
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentNullException>()
+         .WithParameterName(nameof(target))
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresStartsWith(target);
+
+      // Act/assert.
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.StartsWith);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(StringComparison.Ordinal);
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_RequiresStartsWith_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().ThrowExactly<ArgumentException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Precondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.StartsWith);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresStartsWith(target);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeIsSuppliedAndAllOtherDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.InvariantCulture;
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Precondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresStartsWith(target, messageTemplate: messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowArgumentExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType, messageTemplate);
+      var expectedParameterName = nameof(value);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentException>()
+         .WithParameterName(expectedParameterName)
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.RequiresStartsWith(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Precondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresStartsWith(target, messageTemplate: messageTemplate, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_RequiresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.RequiresStartsWith(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+}

--- a/DbC.Net.Tests.Unit/StartsWithExtensionsTests.cs
+++ b/DbC.Net.Tests.Unit/StartsWithExtensionsTests.cs
@@ -4,6 +4,497 @@ public class StartsWithExtensionsTests
 {
    private const Int32 _dataCount = 7;
 
+   #region EnsuresStarts Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QW";
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldReturnOriginalValue_WhenRequirementIsPassedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QW";
+
+      // Act.
+      var result = value.EnsuresStartsWith(target);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("IJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueIsNotEmptyAndTargetIsEmptyAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "asdf";
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueIsEmptyAndTargetIsEmptyAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = String.Empty;
+      var target = String.Empty;
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.CurrentCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.InvariantCulture)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "JKL", StringComparison.Ordinal)]
+   [InlineData("JKLMNOPQRSTUVWXYZ", "jkl", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldReturnOriginalValue_WhenRequirementIsPassedAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Act.
+      var result = value.EnsuresStartsWith(target, comparisonType);
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueEqualsTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "QWERTY";
+      var target = "QWERTY";
+      var comparisonType = StringComparison.CurrentCulture;
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldNotThrow_WhenValueStartsWithTargetAndComparisonIsSupplied()
+   {
+      // Arrange.
+      var value = "IBCDEF";
+      var target = StringData.LowerCaseDotlessI;
+      var comparisonType = StringComparison.CurrentCultureIgnoreCase;
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().NotThrow();
+   }
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrow_WhenValueIsNotNullAndDoesNotStartWithTargetAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [InlineData("!@#$%")]
+   [InlineData("")]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrow_WhenValueNullAndTargetIsNotNullAndComparisonIsDefault(String target)
+   {
+      // Arrange.
+      String value = null!;
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrow_WhenValueIsNotNullAndDoesNotStartWithTargetAndCurrentCultureIs_enUS(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   // Note: tr-TR culture considers "i" and upper case dotted "I" as equal when
+   // case is ignored. Same for "I" and lowercase dot-less "i".
+   [UseCulture(CultureData.TurkishTurkey)]
+   [Theory]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", StringData.LowerCaseDotlessI, StringComparison.CurrentCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.InvariantCulture)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "jkl", StringComparison.Ordinal)]
+   [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "adz", StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrow_WhenValueIsNotNullAndDoesNotStartWithTargetAndCurrentCultureIs_trTR(
+      String value,
+      String target,
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.EnglishUS)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_enUS(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrow_WhenValueIsNullAndTargetIsNotNullAndCurrentCultureIs_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      String value = null!;
+      var target = "QWERTY";
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>();
+   }
+
+   [Theory]
+   [InlineData("not null string")]
+   [InlineData(null)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrowArgumentNullException_WhenTargetIsNullAndComparisonIsDefault(String value)
+   {
+      // Arrange.
+      String target = null!;
+      var act = () => _ = value.EnsuresStartsWith(target);
+      var expectedMessage = Messages.TargetSubstringIsNull;
+
+      // Act/assert.
+      act.Should().ThrowExactly<ArgumentNullException>()
+         .WithParameterName(nameof(target))
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailedAndComparisonIsDefault()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresStartsWith(target);
+
+      // Act/assert.
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.StartsWith);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(StringComparison.Ordinal);
+   }
+
+   [UseCulture(CultureData.ThaiThailand)]
+   [Theory]
+   [InlineData(StringComparison.CurrentCulture)]
+   [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+   [InlineData(StringComparison.InvariantCulture)]
+   [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+   [InlineData(StringComparison.Ordinal)]
+   [InlineData(StringComparison.OrdinalIgnoreCase)]
+   public void StartsWithExtensions_EnsuresStartsWith_ShouldThrowWithExpectedDataDictionary_WhenRequirementIsFailed_thTH(
+      StringComparison comparisonType)
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+
+      // Act/assert.
+      var ex = act.Should().ThrowExactly<PostconditionFailedException>().Which;
+
+      ex.Data.Count.Should().Be(_dataCount);
+      ex.Data[DataNames.RequirementType].Should().Be(RequirementType.Postcondition);
+      ex.Data[DataNames.RequirementName].Should().Be(RequirementNames.StartsWith);
+      ex.Data[DataNames.Value].Should().Be(value);
+      ex.Data[DataNames.ValueExpression].Should().Be(nameof(value));
+      ex.Data[DataNames.Target].Should().Be(target);
+      ex.Data[DataNames.TargetExpression].Should().Be(nameof(target));
+      ex.Data[DataNames.StringComparison].Should().Be(comparisonType);
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndAllDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresStartsWith(target);
+      var expectedMessage = $"Postcondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeIsSuppliedAndAllOtherDefaultsAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.InvariantCulture;
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType);
+      var expectedMessage = $"Postcondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresStartsWith(target, messageTemplate: messageTemplate);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowPostconditionFailedExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.OrdinalIgnoreCase;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType, messageTemplate);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<PostconditionFailedException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomExceptionFactoryIsUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var act = () => _ = value.EnsuresStartsWith(target, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Postcondition StartsWith failed: {nameof(value)} must start with the substring \"{target}\"";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresStartsWith(target, messageTemplate: messageTemplate, exceptionFactory: TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   [Fact]
+   public void StartsWithExtension_EnsuresStartsWith_ShouldThrowCustomExceptionWithExpectedMessage_WhenRequirementIsFailedAndComparisonTypeAndCustomMessageTemplateAndCustomExceptionFactoryAreUsed()
+   {
+      // Arrange.
+      var value = "This is a test";
+      var target = "only";
+      var comparisonType = StringComparison.Ordinal;
+      var messageTemplate = "Requirement {RequirementName} failed";
+      var act = () => _ = value.EnsuresStartsWith(target, comparisonType, messageTemplate, TestExceptionFactories.CustomExceptionFactory);
+      var expectedMessage = $"Requirement StartsWith failed";
+
+      // Act/assert.
+      act.Should().ThrowExactly<CustomException>()
+         .WithMessage(expectedMessage + "*");
+   }
+
+   #endregion
+
    #region RequiresStarts Tests
    // ==========================================================================
    // ==========================================================================

--- a/DbC.Net.sln
+++ b/DbC.Net.sln
@@ -45,6 +45,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\NotNull.md = Documentation\NotNull.md
 		Documentation\NotNullOrEmpty.md = Documentation\NotNullOrEmpty.md
 		Documentation\NotNullOrWhiteSpace.md = Documentation\NotNullOrWhiteSpace.md
+		Documentation\StartsWith.md = Documentation\StartsWith.md
 	EndProjectSection
 EndProject
 Global

--- a/DbC.Net/BetweenExtensions.cs
+++ b/DbC.Net/BetweenExtensions.cs
@@ -177,7 +177,7 @@ public static class BetweenExtensions
    ///   The upper bound that <paramref name="value"/> should not exceed.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and the <paramref name="lowerBound"/> and
    ///   <paramref name="upperBound"/> strings are compared.
    /// </param>
@@ -403,7 +403,7 @@ public static class BetweenExtensions
    ///   The upper bound that <paramref name="value"/> should not exceed.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and the <paramref name="lowerBound"/> and
    ///   <paramref name="upperBound"/> strings are compared.
    /// </param>

--- a/DbC.Net/ContainsExtensions.cs
+++ b/DbC.Net/ContainsExtensions.cs
@@ -19,9 +19,9 @@ public static class ContainsExtensions
    ///   The target substring that <paramref name="value"/> should contain.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
-   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
-   ///   compared.
+   ///   Optional.  <see cref="StringComparison"/> enumeration value that 
+   ///   specifies how the <paramref name="value"/> and <paramref name="target"/> 
+   ///   strings are compared. Defaults to <see cref="StringComparison.Ordinal"/>.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.
@@ -82,9 +82,9 @@ public static class ContainsExtensions
    ///   The target substring that <paramref name="value"/> should contain.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
-   ///   <paramref name="value"/> and <paramref name="target"/> strings are 
-   ///   compared.
+   ///   Optional.  <see cref="StringComparison"/> enumeration value that 
+   ///   specifies how the <paramref name="value"/> and <paramref name="target"/> 
+   ///   strings are compared. Defaults to <see cref="StringComparison.Ordinal"/>.
    /// </param>
    /// <param name="messageTemplate">
    ///   Optional. The message template to use if an exception is thrown.

--- a/DbC.Net/EqualExtensions.cs
+++ b/DbC.Net/EqualExtensions.cs
@@ -134,7 +134,7 @@ public static class EqualExtensions
    ///   The target that <paramref name="value"/> should equal.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="target"/> strings are 
    ///   compared.
    /// </param>
@@ -307,7 +307,7 @@ public static class EqualExtensions
    ///   The target that <paramref name="value"/> should equal.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="target"/> strings are 
    ///   compared.
    /// </param>

--- a/DbC.Net/GreaterThanExtensions.cs
+++ b/DbC.Net/GreaterThanExtensions.cs
@@ -136,7 +136,7 @@ public static class GreaterThanExtensions
    ///   The lower bound that <paramref name="value"/> should be greater than.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="lowerBound"/> strings are 
    ///   compared.
    /// </param>
@@ -311,7 +311,7 @@ public static class GreaterThanExtensions
    ///   The lower bound that <paramref name="value"/> should be greater than.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="lowerBound"/> strings are 
    ///   compared.
    /// </param>

--- a/DbC.Net/GreaterThanOrEqualExtensions.cs
+++ b/DbC.Net/GreaterThanOrEqualExtensions.cs
@@ -140,7 +140,7 @@ public static class GreaterThanOrEqualToExtensions
    ///   equal to.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="lowerBound"/> strings are 
    ///   compared.
    /// </param>
@@ -319,7 +319,7 @@ public static class GreaterThanOrEqualToExtensions
    ///   equal to.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="lowerBound"/> strings are 
    ///   compared.
    /// </param>

--- a/DbC.Net/LessThanExtensions.cs
+++ b/DbC.Net/LessThanExtensions.cs
@@ -139,7 +139,7 @@ public static class LessThanExtensions
    ///   exceed.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="upperBound"/> strings are 
    ///   compared.
    /// </param>
@@ -317,7 +317,7 @@ public static class LessThanExtensions
    ///   exceed.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="upperBound"/> strings are 
    ///   compared.
    /// </param>

--- a/DbC.Net/LessThanOrEqualExtensions.cs
+++ b/DbC.Net/LessThanOrEqualExtensions.cs
@@ -137,7 +137,7 @@ public static class LessThanOrEqualExtensions
    ///   The upper bound that <paramref name="value"/> should not exceed.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="upperBound"/> strings are 
    ///   compared.
    /// </param>
@@ -313,7 +313,7 @@ public static class LessThanOrEqualExtensions
    ///   The upper bound that <paramref name="value"/> should not exceed.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="upperBound"/> strings are 
    ///   compared.
    /// </param>

--- a/DbC.Net/MessageTemplates.Designer.cs
+++ b/DbC.Net/MessageTemplates.Designer.cs
@@ -257,5 +257,14 @@ namespace DbC.Net {
                 return ResourceManager.GetString("NotNullTemplate", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {RequirementType} {RequirementName} failed: {ValueExpression} must start with the substring &quot;{Target}&quot;.
+        /// </summary>
+        internal static string StartsWithTemplate {
+            get {
+                return ResourceManager.GetString("StartsWithTemplate", resourceCulture);
+            }
+        }
     }
 }

--- a/DbC.Net/MessageTemplates.resx
+++ b/DbC.Net/MessageTemplates.resx
@@ -183,4 +183,7 @@
   <data name="NotNullTemplate" xml:space="preserve">
     <value>{RequirementType} {RequirementName} failed: {ValueExpression} may not be null</value>
   </data>
+  <data name="StartsWithTemplate" xml:space="preserve">
+    <value>{RequirementType} {RequirementName} failed: {ValueExpression} must start with the substring "{Target}"</value>
+  </data>
 </root>

--- a/DbC.Net/NotEqualExtensions.cs
+++ b/DbC.Net/NotEqualExtensions.cs
@@ -134,7 +134,7 @@ public static class NotEqualExtensions
    ///   The target that <paramref name="value"/> should not equal.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="target"/> strings are 
    ///   compared.
    /// </param>
@@ -307,7 +307,7 @@ public static class NotEqualExtensions
    ///   The target that <paramref name="value"/> should not equal.
    /// </param>
    /// <param name="comparisonType">
-   ///   <see cref="StringComparison"/> enumeration value that specified how the
+   ///   <see cref="StringComparison"/> enumeration value that specifies how the
    ///   <paramref name="value"/> and <paramref name="target"/> strings are 
    ///   compared.
    /// </param>

--- a/DbC.Net/RequirementNames.cs
+++ b/DbC.Net/RequirementNames.cs
@@ -27,4 +27,5 @@ public static class RequirementNames
    public const String NotNull = nameof(NotNull);
    public const String NotNullOrEmpty = nameof(NotNullOrEmpty);
    public const String NotNullOrWhiteSpace = nameof(NotNullOrWhiteSpace);
+   public const String StartsWith = nameof(StartsWith);
 }

--- a/DbC.Net/StartsWithExtensions.cs
+++ b/DbC.Net/StartsWithExtensions.cs
@@ -8,6 +8,69 @@ public static class StartsWithExtensions
    private const String _requirementName = RequirementNames.StartsWith;
 
    /// <summary>
+   ///   String StartsWith postcondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> starts with the  <paramref name="target"/> 
+   ///   substring and throw an exception if it does not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target substring that <paramref name="value"/> should start with.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   Optional.  <see cref="StringComparison"/> enumeration value that 
+   ///   specifies how the <paramref name="value"/> and <paramref name="target"/> 
+   ///   strings are compared. Defaults to <see cref="StringComparison.Ordinal"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must start with the substring "{Target}"".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.PostconditionFailedExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="target"/> is <see langword="null"/>.
+   /// </exception>
+   public static String EnsuresStartsWith(
+      this String value,
+      String target,
+      StringComparison comparisonType = StringComparison.Ordinal,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckStartsWith(
+         value,
+         target ?? throw new ArgumentNullException(nameof(target), Messages.TargetSubstringIsNull),
+         comparisonType,
+         RequirementType.Postcondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   /// <summary>
    ///   String StartsWith precondition. Confirm that the <see cref="String"/>
    ///   <paramref name="value"/> starts with the  <paramref name="target"/> 
    ///   substring and throw an exception if it does not.

--- a/DbC.Net/StartsWithExtensions.cs
+++ b/DbC.Net/StartsWithExtensions.cs
@@ -1,0 +1,97 @@
+﻿namespace DbC.Net;
+
+/// <summary>
+///   Extension methods that implement String StartsWith requirement.
+/// </summary>
+public static class StartsWithExtensions
+{
+   private const String _requirementName = RequirementNames.StartsWith;
+
+   /// <summary>
+   ///   String StartsWith precondition. Confirm that the <see cref="String"/>
+   ///   <paramref name="value"/> starts with the  <paramref name="target"/> 
+   ///   substring and throw an exception if it does not.
+   /// </summary>
+   /// <param name="value">
+   ///   The value to check.
+   /// </param>
+   /// <param name="target">
+   ///   The target substring that <paramref name="value"/> should start with.
+   /// </param>
+   /// <param name="comparisonType">
+   ///   Optional.  <see cref="StringComparison"/> enumeration value that 
+   ///   specifies how the <paramref name="value"/> and <paramref name="target"/> 
+   ///   strings are compared. Defaults to <see cref="StringComparison.Ordinal"/>.
+   /// </param>
+   /// <param name="messageTemplate">
+   ///   Optional. The message template to use if an exception is thrown.
+   ///   Defaults to "{RequirementType} {RequirementName} failed: {Value} must start with the substring "{Target}"".
+   /// </param>
+   /// <param name="exceptionFactory">
+   ///   Optional. The <see cref="IExceptionFactory"/> used to create the
+   ///   exception that is thrown if the <paramref name="value"/> is 
+   ///   <see langword="null"/>. Defaults to 
+   ///   <see cref="StandardExceptionFactories.ArgumentExceptionFactory"/>.
+   /// </param>
+   /// <param name="valueExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="value"/>. 
+   /// </param>
+   /// <param name="targetExpression">
+   ///   Optional. Defaults to the caller expression for
+   ///   <paramref name="target"/>. 
+   /// </param>
+   /// <returns>
+   ///   The tested <paramref name="value"/> is returned unaltered to support 
+   ///   chaining requirements.
+   /// </returns>
+   /// <exception cref="ArgumentNullException">
+   ///   <paramref name="target"/> is <see langword="null"/>.
+   /// </exception>
+   public static String RequiresStartsWith(
+      this String value,
+      String target,
+      StringComparison comparisonType = StringComparison.Ordinal,
+      String? messageTemplate = null,
+      IExceptionFactory? exceptionFactory = null,
+      [CallerArgumentExpression("value")] String valueExpression = null!,
+      [CallerArgumentExpression("target")] String targetExpression = null!)
+   {
+      CheckStartsWith(
+         value,
+         target ?? throw new ArgumentNullException(nameof(target), Messages.TargetSubstringIsNull),
+         comparisonType,
+         RequirementType.Precondition,
+         messageTemplate,
+         exceptionFactory,
+         valueExpression,
+         targetExpression);
+
+      return value;
+   }
+
+   private static void CheckStartsWith(
+      String value,
+      String target,
+      StringComparison comparisonType,
+      RequirementType requirementType,
+      String? messageTemplate,
+      IExceptionFactory? exceptionFactory,
+      String valueExpression,
+      String targetExpression)
+   {
+      if (value is null || !value.StartsWith(target, comparisonType))
+      {
+         messageTemplate ??= MessageTemplates.StartsWithTemplate;
+         exceptionFactory ??= StandardExceptionFactories.ResolveArgumentExceptionFactory(requirementType);
+         var data = ExceptionDataBuilder.Create()
+            .WithRequirement(requirementType, _requirementName)
+            .WithValue(value!, valueExpression)
+            .WithTarget(target, targetExpression)
+            .WithItem(DataNames.StringComparison, comparisonType)
+            .Build();
+
+         throw exceptionFactory.CreateException(data, messageTemplate);
+      }
+   }
+}

--- a/Documentation/Contains.md
+++ b/Documentation/Contains.md
@@ -29,4 +29,62 @@ is null.
 
 **Examples:**
 ```C#
+var customMessageTemplate = "{ValueExpression} must contain target substring";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = "This is a test. This is only a test";
+var target = "ONLY";
+var comparisionType = StringComparison.OrdinalIgnoreCase;
+
+
+// Precondition with default comparisionType, default message template and default exception factory.
+value.RequiresContains(target);
+
+// Precondition with default comparisionType, custom message template and default exception factory.
+value.RequiresContains(target, messageTemplate: customMessageTemplate);
+
+// Precondition with default comparisionType, default message template and custom exception factory.
+value.RequiresContains(target, exceptionFactory: customExceptionFactory);
+
+// Precondition with default comparisionType, custom message template and custom exception factory.
+value.RequiresContains(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+// Precondition with comparisionType, default message template and default exception factory.
+value.RequiresContains(target, comparisionType);
+
+// Precondition with comparisionType, custom message template and default exception factory.
+value.RequiresContains(target, comparisionType, customMessageTemplate);
+
+// Precondition with comparisionType, default message template and custom exception factory.
+value.RequiresContains(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+// Precondition with comparisionType, custom message template and custom exception factory.
+value.RequiresContains(target, comparisionType, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default comparisionType, default message template and default exception factory.
+value.EnsuresContains(target);
+
+// Postcondition with default comparisionType, custom message template and default exception factory.
+value.EnsuresContains(target, messageTemplate: customMessageTemplate);
+
+// Postcondition with default comparisionType, default message template and custom exception factory.
+value.EnsuresContains(target, exceptionFactory: customExceptionFactory);
+
+// Postcondition with default comparisionType, custom message template and custom exception factory.
+value.EnsuresContains(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+// Postcondition with comparisionType, default message template and default exception factory.
+value.EnsuresContains(target, comparisionType);
+
+// Postcondition with comparisionType, custom message template and default exception factory.
+value.EnsuresContains(target, comparisionType, customMessageTemplate);
+
+// Postcondition with comparisionType, default message template and custom exception factory.
+value.EnsuresContains(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+// Postcondition with comparisionType, custom message template and custom exception factory.
+value.EnsuresContains(target, comparisionType, customMessageTemplate, customExceptionFactory);
 ```

--- a/Documentation/StartsWith.md
+++ b/Documentation/StartsWith.md
@@ -29,4 +29,62 @@ is null.
 
 **Examples:**
 ```C#
+var customMessageTemplate = "{ValueExpression} must start with target substring";
+var customExceptionFactory = new CustomExceptionFactory();
+
+var value = "This is a test. This is only a test";
+var target = "THIS";
+var comparisionType = StringComparison.OrdinalIgnoreCase;
+
+
+// Precondition with default comparisionType, default message template and default exception factory.
+value.RequiresStartsWith(target);
+
+// Precondition with default comparisionType, custom message template and default exception factory.
+value.RequiresStartsWith(target, messageTemplate: customMessageTemplate);
+
+// Precondition with default comparisionType, default message template and custom exception factory.
+value.RequiresStartsWith(target, exceptionFactory: customExceptionFactory);
+
+// Precondition with default comparisionType, custom message template and custom exception factory.
+value.RequiresStartsWith(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+// Precondition with comparisionType, default message template and default exception factory.
+value.RequiresStartsWith(target, comparisionType);
+
+// Precondition with comparisionType, custom message template and default exception factory.
+value.RequiresStartsWith(target, comparisionType, customMessageTemplate);
+
+// Precondition with comparisionType, default message template and custom exception factory.
+value.RequiresStartsWith(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+// Precondition with comparisionType, custom message template and custom exception factory.
+value.RequiresStartsWith(target, comparisionType, customMessageTemplate, customExceptionFactory);
+
+
+// Postcondition with default comparisionType, default message template and default exception factory.
+value.EnsuresStartsWith(target);
+
+// Postcondition with default comparisionType, custom message template and default exception factory.
+value.EnsuresStartsWith(target, messageTemplate: customMessageTemplate);
+
+// Postcondition with default comparisionType, default message template and custom exception factory.
+value.EnsuresStartsWith(target, exceptionFactory: customExceptionFactory);
+
+// Postcondition with default comparisionType, custom message template and custom exception factory.
+value.EnsuresStartsWith(target, messageTemplate: customMessageTemplate, exceptionFactory: customExceptionFactory);
+
+
+// Postcondition with comparisionType, default message template and default exception factory.
+value.EnsuresStartsWith(target, comparisionType);
+
+// Postcondition with comparisionType, custom message template and default exception factory.
+value.EnsuresStartsWith(target, comparisionType, customMessageTemplate);
+
+// Postcondition with comparisionType, default message template and custom exception factory.
+value.EnsuresStartsWith(target, comparisionType, exceptionFactory: customExceptionFactory);
+
+// Postcondition with comparisionType, custom message template and custom exception factory.
+value.EnsuresStartsWith(target, comparisionType, customMessageTemplate, customExceptionFactory);
 ```

--- a/Documentation/StartsWith.md
+++ b/Documentation/StartsWith.md
@@ -1,0 +1,32 @@
+### StartsWith
+
+StartsWith requires that the string value being checked start with the target substring.
+StartsWith supports an optional StringComparison parameter that specifies how the 
+substring check is performed. By default the check is performed using an ordinal,
+case-sensitive comparison.
+
+StartsWith will always fail if the string value being checked is null.  An empty 
+target substring (String.Empty) will always pass the requirement (unless the
+string being checked is null).
+
+**Method signatures:**
+```C#
+String RequiresStartsWith(this String value, String target, [StringComparison comparisonType = StringComparison.Ordinal], [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+
+String EnsuresStartsWith(this String value, String target, [StringComparison comparisonType = StringComparison.Ordinal], [String? messageTemplate = null], [IExceptionFactory? exceptionFactory = null], [String? valueExpression = null], [String? targetExpression = null])
+```
+
+The default message template for StartsWith is "{RequirementType} {RequirementName} failed: {ValueExpression} must start with the substring "{Target}"".
+The default exception factory for RequiresStartsWith is StandardExceptionFactories.ArgumentExceptionFactory 
+and StandardExceptionFactories.PostconditionFailedExceptionFactory for 
+EnsuresStartsWith.
+
+The data dictionary for exceptions thrown will contain entries for RequirementType,
+RequirementName, Value, Target, StringComparison, ValueExpression and TargetExpression.
+
+Requires/EnsuresStartsWith will throw an ArgumentNullException if the target substring
+is null.
+
+**Examples:**
+```C#
+```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
     - [NotEmptyOrWhiteSpace](/Documentation/NotEmptyOrWhiteSpace.md)
     - [NotNullOrEmpty](/Documentation/NotNullOrEmpty.md)
     - [NotNullOrWhiteSpace](/Documentation/NotNullOrWhiteSpace.md)
+    - [StartsWith](/Documentation/StartsWith.md)
 
 - **[Release History/Release Notes](#release-historyrelease-notes)**
 


### PR DESCRIPTION
As a developer who uses DbC.Net, I want to be able to require/ensure that a string value starts with a target substring.

Requirements:

  RequiresStartsWith (precondition), default ArgumentException 
  EnsuresStartsWith (postcondition), default PostconditionFailedException
  Support supplying StringComparison value to perform the comparison

DEFINITION OF DONE:

1. Implement RequiresStartsWith
2. Implement EnsuresStartsWith
3. Unit tests for Requires/Ensures StartsWith
4. Performance tests
5. Readme updates
6. Examples